### PR TITLE
Rename Checklists tab to Shopping on Batch page

### DIFF
--- a/packages/app/src/routes/batch.$batchId.tsx
+++ b/packages/app/src/routes/batch.$batchId.tsx
@@ -22,7 +22,7 @@ function BatchPage() {
             <PanelSwitcherContent title="Planning">
                 <Planning batchId={batchId} onChange={onChange} />
             </PanelSwitcherContent>
-            <PanelSwitcherContent title="Checklists">
+            <PanelSwitcherContent title="Shopping">
                 <Shopping batchId={batchId} onChange={onChange} />
             </PanelSwitcherContent>
             <PanelSwitcherContent title="Schedule">


### PR DESCRIPTION
## Summary
Renames the "Checklists" panel tab to "Shopping" on the single Batch page. The tab already rendered the `<Shopping>` screen — only the label was stale.

Closes #20

## Verification
- `tsc --noEmit` — ✓
- `vite build` — ✓

Generated with [Claude Code](https://claude.ai/code)