### PR TITLE
Add additives from the Ingredients panel

### DIFF
--- a/packages/app/src/screen/brewable-edit/ingredients/catalog-defaults.ts
+++ b/packages/app/src/screen/brewable-edit/ingredients/catalog-defaults.ts
@@ -1,5 +1,6 @@
 import {UNITS} from "@brewdocs.beer/core";
 import {KbGrain, KbHop, KbYeast} from "@brewdocs.beer/kb";
+import Additive from "@/model/additive";
 import {PhaseType, ResourceType} from "@/model/brewable";
 import Grain from "@/model/grain";
 import Hop from "@/model/hop";
@@ -65,5 +66,16 @@ export function kbYeastToRecipeYeast(kbYeast: KbYeast): Yeast {
             unit: UNITS.FAHRENHEIT
         },
         starter: false
+    };
+}
+
+/** Default boil time for a freeform additive — there's no kb catalog for additives, so the name is typed rather than picked. */
+export function defaultAdditive(name: string): Additive {
+    return {
+        name,
+        boil: {
+            value: "15min",
+            unit: UNITS.MINUTES
+        },
     };
 }

--- a/packages/app/src/screen/brewable-edit/ingredients/phase-add-row.tsx
+++ b/packages/app/src/screen/brewable-edit/ingredients/phase-add-row.tsx
@@ -1,4 +1,5 @@
-import {useCallback, useState} from "react";
+import {useCallback, useMemo, useState} from "react";
+import {InputText} from "@brewdocs.beer/design";
 import {KbGrain, KbHop, KbYeast} from "@brewdocs.beer/kb";
 import DataGridAddButton from "@/component/data-grid/add-button";
 import DataGridLabel from "@/component/data-grid/label";
@@ -6,13 +7,18 @@ import DataGridRow from "@/component/data-grid/row";
 import DataGridSelect from "@/component/data-grid/select";
 import {AddFn} from "@/hooks/useJsonEdit";
 import {Assignment, PhaseType} from "@/model/brewable";
-import {kbGrainToRecipeGrain, kbHopToRecipeHop, kbYeastToRecipeYeast} from "@/screen/brewable-edit/ingredients/catalog-defaults";
+import {defaultAdditive, kbGrainToRecipeGrain, kbHopToRecipeHop, kbYeastToRecipeYeast} from "@/screen/brewable-edit/ingredients/catalog-defaults";
+
+/** dropdown value for the freeform-additive choice — no colon, so it never collides with a `"<type>:<name>"` catalog value */
+const ADDITIVE_VALUE = "additive";
+const ADDITIVE_OPTION = { value: ADDITIVE_VALUE, name: "Additive…" };
 
 /**
  * The per-phase ingredient add-row: a single "resource" dropdown, since the
  * phase is fixed by the section this row sits in and the resource *type* is
- * carried in the option value (`"<type>:<name>"`) rather than picked. Additives
- * have no kb catalog, so they aren't offered here — only grains/hops/yeasts.
+ * carried in the option value (`"<type>:<name>"`) rather than picked. Grains,
+ * hops and yeasts come from the kb catalog; picking "Additive…" instead reveals
+ * a text field, since additives are freeform (no catalog).
  */
 export type RecipeEditPhaseAddRowProps = {
     phaseType: PhaseType;
@@ -24,8 +30,8 @@ export type RecipeEditPhaseAddRowProps = {
     kbYeastsIndex: Map<string, KbYeast>;
 };
 
-/** decodes a `"<resourceType>:<name>"` option value into a full Assignment; each case builds a single discriminated-union member so `resource` stays typed with no cast */
-function buildAssignment(
+/** decodes a `"<resourceType>:<name>"` catalog value into a full Assignment; each case builds a single discriminated-union member so `resource` stays typed with no cast */
+function buildCatalogAssignment(
     phaseType: PhaseType,
     encoded: string,
     kbGrainsIndex: Map<string, KbGrain>,
@@ -55,26 +61,46 @@ function buildAssignment(
 
 export default function RecipeEditPhaseAddRow({ phaseType, add, resourceOptions, kbGrainsIndex, kbHopsIndex, kbYeastsIndex }: RecipeEditPhaseAddRowProps) {
     const [value, setValue] = useState<string | null>(null);
+    const [additiveName, setAdditiveName] = useState("");
+
+    const options = useMemo(() => [...resourceOptions, ADDITIVE_OPTION], [resourceOptions]);
+    const isAdditive = value === ADDITIVE_VALUE;
 
     const addAssignment = useCallback(() => {
-        if (!value) return;
-        const assignment = buildAssignment(phaseType, value, kbGrainsIndex, kbHopsIndex, kbYeastsIndex);
-        if (!assignment) return;
-        add("assignments", assignment);
+        if (isAdditive) {
+            const name = additiveName.trim();
+            if (!name) return;
+            add("assignments", { phaseType, resourceType: "additive", slug: name, resource: defaultAdditive(name) });
+        } else {
+            if (!value) return;
+            const assignment = buildCatalogAssignment(phaseType, value, kbGrainsIndex, kbHopsIndex, kbYeastsIndex);
+            if (!assignment) return;
+            add("assignments", assignment);
+        }
         setValue(null);
-    }, [add, phaseType, value, kbGrainsIndex, kbHopsIndex, kbYeastsIndex]);
+        setAdditiveName("");
+    }, [add, phaseType, value, isAdditive, additiveName, kbGrainsIndex, kbHopsIndex, kbYeastsIndex]);
 
     return (
         <DataGridRow zebra reserveExpand>
             <DataGridAddButton onClick={addAssignment} />
-            <DataGridLabel className="ml-6" cols={4}>
+            <DataGridLabel className="ml-6" cols={isAdditive ? 2 : 4}>
                 <DataGridSelect
                     allowNull
-                    data={resourceOptions}
+                    data={options}
                     value={value}
                     onChange={setValue}
                 />
             </DataGridLabel>
+            {isAdditive && (
+                <InputText
+                    className="col-start-3 col-span-3"
+                    primary
+                    value={additiveName}
+                    onChange={setAdditiveName}
+                    placeholder="Additive name"
+                />
+            )}
         </DataGridRow>
     );
 }


### PR DESCRIPTION
## Summary

Lets you add a freeform **additive** to a phase from the Ingredients panel — the follow-up deferred during the single-dropdown design.

The per-phase add-row's resource dropdown (grains/hops/yeasts, from the KB catalog) now also offers an **"Additive…"** entry. Picking it reveals a text field for the name (additives have no catalog), and adding builds an additive assignment in the section's phase via `defaultAdditive(name)`. `defaultAdditive` is restored to `catalog-defaults.ts` — it had been dropped as dead code in the BrewableEdit refactor (PR #161).

Closes #162. Part of the brewable pilot (epic #140).

## Changes

- `screen/brewable-edit/ingredients/phase-add-row.tsx` — append an `"Additive…"` option (bare `additive` value, no colon so it never collides with `"<type>:<name>"` catalog values); when selected, render an `InputText` for the name and shrink the select; `addAssignment` branches to build the additive from the typed name.
- `screen/brewable-edit/ingredients/catalog-defaults.ts` — restore `defaultAdditive(name)` + the `Additive` import.

## Verification

Node 22 prefix (`PATH="$HOME/.nvm/versions/node/v22.23.1/bin:$PATH"`):

- `npm run lint -w packages/app` ✓ — 0 errors (1 pre-existing `react-refresh` warning).
- `tsc --noEmit` (app) ✓.
- `vite build` (app) ✓.
- **Browser** ✓ — on a cloned recipe, picked "Additive…" in the Mash add-row → the name field appeared → typed "Gypsum" → **+** added it under a Mash **Additives** subsection and reset the row. Reloaded the page and Gypsum persisted; the row's remove control removes it.

## Constraints

- ⚠️ Targets **`brewable`**, not `mainline` (epic #140).
- ⚠️ Verify only runs on PRs into `mainline`, so no automatic checks appear here — the checks above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
