### PR TITLE
Fix: cannot edit kb recipe (stale cache breaks the Edit clone)

### DIFF
--- a/packages/app/src/state/kbRecipes.ts
+++ b/packages/app/src/state/kbRecipes.ts
@@ -6,13 +6,27 @@ import {isOnline} from "@/utils/connectivity";
 import {FilterFn} from "@/utils/func";
 
 const kbRecipesQueryKey = () => ["kb", "recipes"];
+
+/**
+ * The local kb cache is unversioned, so a cache written before `brewable` was
+ * added to the recipe shape (KB model v2) is stale — the app can no longer
+ * narrow it, and the "Edit" clone crashes on `kbRecipe.brewable`. Treat a
+ * cached recipe missing `brewable` as stale so we re-hydrate from HTTP instead
+ * of serving (and copying) a shape we can't read.
+ */
+const isStaleCache = (recipes: KbRecipe[]): boolean => recipes.some((recipe) => !recipe.brewable);
+
 export const fetchKbRecipes = async (): Promise<KbRecipe[]> => {
     const cached = await kbStorage.getResource("recipes");
-    if (cached) {
+    if (cached && !isStaleCache(cached)) {
         return cached;
     }
 
     if (!isOnline()) {
+        // best effort offline — no fresher source than what we already have
+        if (cached) {
+            return cached;
+        }
         throw new Error("Recipe data isn't downloaded yet, and you're offline.");
     }
 


### PR DESCRIPTION
## Summary

Fixes #177 — confirming the Edit modal on a kb recipe did nothing.

**Root cause.** The local kb cache is unversioned. A browser that cached kb recipes *before* `brewable` was added to the recipe shape (KB model v2, PR #172) holds `KbRecipe`s with **no `brewable` field**. The "Edit" clone flow (`createRecipe(kbRecipe)` → `kbRecipeToRecipe`, #169) now narrows `kbRecipe.brewable` via `kbBrewableToBrewable`, which does `kbBrewable.schedule.phases…` and throws `TypeError: Cannot read properties of undefined (reading 'schedule')`. `createRecipe` rejects, so the modal's `.then(navigate)` never runs — the modal closes and nothing happens.

Confirmed live: captured that exact TypeError in the console on Confirm.

**Fix.** In `fetchKbRecipes` (`state/kbRecipes.ts`), treat a cached recipe missing `brewable` as **stale** and re-hydrate from HTTP (the served/dist data carries the brewable) instead of serving — and copying — a shape the app can no longer narrow. This heals the class of bug rather than just guarding the crash: the re-imported recipe has its full brewable, so the clone gets its ingredients/equipment too. Offline stays best-effort (return the cache if present, else the existing "not downloaded" error).

## Changes

- `packages/app/src/state/kbRecipes.ts` — add an `isStaleCache` check (a cached recipe with no `brewable`) to `fetchKbRecipes`; re-hydrate from HTTP when stale (or absent) and online.

## Verification

Node 22 prefix (`PATH="$HOME/.nvm/versions/node/v22.23.1/bin:$PATH"`):

- `npm run lint -w packages/app` ✓ — 0 errors (1 pre-existing `react-refresh` warning).
- `tsc --noEmit` (app) ✓.
- `vite build` (app) ✓.
- **Browser** ✓ — reproduced the crash with a stale cache (the exact `undefined.schedule` TypeError), applied the fix, and confirmed: on next load the kb cache re-hydrates (IndexedDB `kb#recipes` now carries `brewable`), and **Edit → Confirm creates the user recipe and navigates to `/recipe/<id>/edit`**, with the Ingredients panel fully populated (Mash grains, Boil hops + additives, Ferment yeast). Also verified a purged/fresh cache works end to end.

## Note

The one remaining corner — a cache that predates `brewable` **and** the user is offline — still can't be re-hydrated, so it returns the stale cache best-effort (Edit would still fail there until online/purge). That's consistent with the documented "unversioned kb cache → throw-until-purge" POC behavior and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
