### PR TITLE
Read overview/summary ingredients from the brewable (part of #190)

### DIFF
--- a/packages/app/src/component/organics/from-brewable.ts
+++ b/packages/app/src/component/organics/from-brewable.ts
@@ -1,0 +1,14 @@
+/** the minimal assignment shape this helper needs — satisfied by both the app `Assignment` and the loose `KbAssignment` (kb recipes ship an unnarrowed brewable) */
+type NamedResourceAssignment = { resourceType: string; resource: { name: string } };
+
+/**
+ * Display-only extraction of `{name}` lists per resource type, pulled from a
+ * brewable's `assignments`. Works for either an app `Brewable` or a `KbBrewable`
+ * (a kb recipe's own, unnarrowed), since both carry `{resourceType, resource:
+ * {name}}` — and `Organics` only ever renders the names.
+ */
+export function organicNames(assignments: NamedResourceAssignment[]): { hops: { name: string }[]; grains: { name: string }[]; yeasts: { name: string }[] } {
+    const namesOf = (resourceType: string) =>
+        assignments.filter(a => a.resourceType === resourceType).map(({ resource }) => ({ name: resource.name }));
+    return { hops: namesOf("hop"), grains: namesOf("grain"), yeasts: namesOf("yeast") };
+}

--- a/packages/app/src/screen/batch-summary/index.tsx
+++ b/packages/app/src/screen/batch-summary/index.tsx
@@ -1,5 +1,6 @@
 import {ScreenH2, ScreenH3, ScreenP} from "@brewdocs.beer/design";
 import Organics from "@/component/organics";
+import {organicNames} from "@/component/organics/from-brewable";
 import Screen from "@/component/screen";
 import Vitals from "@/component/vitals";
 import {useBatch} from "@/state/batches";
@@ -24,11 +25,7 @@ export default function BatchSummary({ batchId }: BatchSummaryProps) {
                 {/* Need to refactor this type */}
                 <Vitals className="-mt-2" vitals={[["Target", recipe.targets], ["Actuals", batch.actuals]]} />
                 <div className="divider">Organics</div>
-                <Organics
-                    className="-mt-2"
-                    hops={batch.hops ?? recipe.hops}
-                    grains={batch.grains ?? recipe.grains}
-                    yeasts={batch.yeasts ?? recipe.yeasts} />
+                <Organics className="-mt-2" {...organicNames(batch.brewable.assignments)} />
             </div>
         </Screen>
     );

--- a/packages/app/src/screen/recipe-overview/index.tsx
+++ b/packages/app/src/screen/recipe-overview/index.tsx
@@ -1,5 +1,6 @@
 import {ScreenP, ScreenH2} from "@brewdocs.beer/design";
 import Organics from "@/component/organics";
+import {organicNames} from "@/component/organics/from-brewable";
 import Screen from "@/component/screen";
 import {RecipeSource, useRecipeResource} from "@/state/recipeResource";
 
@@ -16,11 +17,7 @@ export default function RecipeOverview({ recipeId, source }: RecipeOverviewProps
                 <ScreenP className="pt-4">{`${recipe.description}`}</ScreenP>
             </div>
             <div className="divider">Ingredients</div>
-            <Organics
-                className="-mt-2"
-                hops={recipe.hops}
-                grains={recipe.grains}
-                yeasts={recipe.yeasts} />
+            <Organics className="-mt-2" {...organicNames(recipe.brewable.assignments)} />
         </Screen>
     );
 }


### PR DESCRIPTION
## Summary

First slice of #190 — move the **display readers** off the legacy ingredient arrays onto the brewable.

`RecipeOverview` and `BatchSummary` rendered ingredients from `recipe/batch.{hops,grains,yeasts}`. They now derive them from `…brewable.assignments` via a small helper, `organicNames`, that pulls `{name}` lists per resource type. The helper is intentionally loosely typed so it works for **both** the app `Brewable` (batches, user recipes) and a kb recipe's own `KbBrewable` (unnarrowed) — and `Organics` only ever renders names.

**Behaviour-preserving:** the legacy arrays are projected from the brewable by `_projectRecipeBrewable` / `_projectBatchBrewable`, so the same ingredient names render. This just removes two of the four legacy-array readers.

## Changes

- **new** `component/organics/from-brewable.ts` — `organicNames(assignments)` → `{hops, grains, yeasts}` name lists (loose shape, covers `Brewable` + `KbBrewable`).
- `screen/recipe-overview/index.tsx` — `<Organics {...organicNames(recipe.brewable.assignments)} />`.
- `screen/batch-summary/index.tsx` — same, off `batch.brewable.assignments`.

## What's still open on #190 (follow-ups)

- `_updateShopping` and `_updateSchedule` still read the legacy arrays. `_updateSchedule` is the hard one — it emits write-through `path:` refs (`hops[i].boil`, …) the schedule screen edits in place, so those must move to `brewable.assignments[i].resource.*` paths.
- ⚠️ Heads-up for the derivation slice: the shared `resourcesOf(assignments, type)` helper in `actions/_updateRecipe.ts` does **not** actually narrow its return (`(Grain|Hop|Yeast|Additive)[]` regardless of `T`; `_updateRecipe` gets away with it via `Object.assign`'s loose typing). Reusing it where the element type matters (e.g. `weighed` needs `weight`) fails to typecheck — either fix `resourcesOf` to narrow, or bucket via a discriminant `switch` on `resourceType`.
- Only once all four readers are off the legacy arrays can they (and the projections) be deleted — and the mash/boil arrays specifically are gated on #191.

## Verification

Node 22 prefix (`PATH="$HOME/.nvm/versions/node/v22.23.1/bin:$PATH"`):

- `tsc --noEmit` (app) ✓, `npm run lint -w packages/app` ✓ (0 errors).
- **Browser** ✓ — the kb recipe overview (`KbBrewable` path) and a batch's Summary (`Brewable` path) both render the same ingredients as before (Northern Brewer / German Pils, Crystal Malt 40L, Special Robust / Wyeast 2112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
