### PR TITLE
Remove the dead readonly field from schedule items

### DIFF
--- a/packages/app/src/actions/_updateSchedule.ts
+++ b/packages/app/src/actions/_updateSchedule.ts
@@ -17,7 +17,6 @@ const sameDerived = (a: Derived|ScheduleItem, b: Derived|ScheduleItem) =>
     a.name === b.name
     && a.path === b.path
     && a.note === b.note
-    && a.readonly === b.readonly
     && isEqual(a.tags, b.tags)
     && isEqual(a.amount, b.amount)
     && isEqual(a.extra, b.extra);

--- a/packages/app/src/model/batch.ts
+++ b/packages/app/src/model/batch.ts
@@ -64,7 +64,6 @@ export interface ScheduleDetail {
     path: string;
     /** a date is a plain string at the path and skips unit formatting */
     input?: "date";
-    readonly?: boolean;
 }
 
 export interface ScheduleItem {
@@ -95,8 +94,6 @@ export interface ScheduleItem {
      * be clobbered on the next recalculation.
      */
     path: string;
-    /** derived — when set, the `path` value is shown read-only. No producer sets it currently (it backed the removed mash-step temp); kept as a general capability. */
-    readonly?: boolean;
     /** derived — secondary fields, revealed only when the row is expanded */
     extra?: ScheduleDetail[];
     /** user-owned — preserved across recalculation */

--- a/packages/app/src/screen/batch-schedule/item-row.tsx
+++ b/packages/app/src/screen/batch-schedule/item-row.tsx
@@ -30,10 +30,9 @@ function BatchScheduleItemDetail({ detail, value, update, updateScalar }: BatchS
             ) : (
                 <DataGridInput
                     colStart={3}
-                    readonly={detail.readonly}
                     value={value}
-                    onChange={detail.readonly ? undefined : onChangeValue}
-                    onBlur={detail.readonly ? undefined : onBlurValue}
+                    onChange={onChangeValue}
+                    onBlur={onBlurValue}
                 />
             )}
         </DataGridRow>
@@ -120,10 +119,9 @@ function BatchScheduleItemRow({ row, item, value, extraValues, toggle, update, u
             {item.path ? (
                 <DataGridInput
                     colStart={3}
-                    readonly={item.readonly}
                     value={value}
-                    onChange={item.readonly ? undefined : onChangeValue}
-                    onBlur={item.readonly ? undefined : onBlurValue}
+                    onChange={onChangeValue}
+                    onBlur={onBlurValue}
                 />
             ) : null}
         </DataGridRow>


### PR DESCRIPTION
## Summary

Closes #200. Removes the dead `readonly` field from schedule items.

`ScheduleItem.readonly` and `ScheduleDetail.readonly` had **no producer** — the only thing that ever set `readonly: true` was `_updateSchedule`'s mash-step temp row, removed in #194. This drops the fields and the now-always-false branches that guarded them.

## Changes

- `model/batch.ts` — remove `readonly?: boolean` from `ScheduleItem` and `ScheduleDetail`.
- `screen/batch-schedule/item-row.tsx` — drop the `readonly` prop and the `… ? undefined : onChange/onBlur` ternaries from both the item and detail inputs (unconditionally editable now).
- `actions/_updateSchedule.ts` — drop the `a.readonly === b.readonly` comparison from `sameDerived` (tsc caught this one — the field is gone).

`DataGridInput`'s own `readonly` prop is left intact; these rows just stop passing it.

## Behavior

None changed — the removed conditions were always false (`item.readonly`/`detail.readonly` were never set), so each ternary already resolved to its editable branch.

## Verification

Node 22 prefix. `tsc --noEmit` ✓ (caught the `sameDerived` reference), `npm run lint -w packages/app` ✓ (0 errors), `vite build` ✓.

**Browser** — Schedule → Boil renders normally (equipment, hops w/ boil times, additives, gravity); edited a hop boil 60 → 40min and confirmed it persisted; stored schedule items carry no `readonly` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
