### PR TITLE
Move gravity readings onto the tracker as phase milestones (#211)

### DIFF
--- a/packages/app/src/actions/_updateSchedule.ts
+++ b/packages/app/src/actions/_updateSchedule.ts
@@ -89,25 +89,6 @@ function ferment(batch: Partial<Batch>): Derived[] {
     }));
 }
 
-/** each entry is a slot in `batch.hydrometer`, in the order the readings are taken */
-const READINGS: [index: number, phase: SchedulePhase][] = [
-    [0, "mash"],
-    [1, "boil"],
-    [2, "ferment"]
-];
-
-/** exact date taken matters less than the reading itself, so it rides behind the row's expander, same as the yeast pitch date */
-function gravity(batch: Partial<Batch>): Derived[] {
-    return READINGS
-        .filter(([i]) => (batch.hydrometer ?? [])[i])
-        .map(([i, phase]) => ({
-            name: batch.hydrometer![i].name,
-            tags: tags(phase, "gravity"),
-            path: `hydrometer[${i}].gravity`,
-            extra: [{ name: "Reading Taken", path: `hydrometer[${i}].date`, input: "date" as const }]
-        }));
-}
-
 /**
  * Rebuilds the flat brew schedule from the batch's ingredients and steps.
  *
@@ -124,7 +105,6 @@ export default function _updateSchedule(batch: Partial<Batch>): Partial<Batch> {
     const derived: Derived[] = [
         ...mash(batch),
         ...boil(batch),
-        ...gravity(batch),
         ...ferment(batch)
     ];
 

--- a/packages/app/src/actions/updateBatch.ts
+++ b/packages/app/src/actions/updateBatch.ts
@@ -7,12 +7,12 @@ import batchesStorage from "@/storage/batches";
 import {isEqual} from "@/utils/func";
 
 // shopping/schedule derive from `brewable.assignments` now, so a brewable edit
-// is the change signal (schedule also reads hydrometer). Comparing the whole
-// brewable slightly over-triggers on equipment/phase edits, but the derivations
+// is the change signal. Comparing the whole brewable slightly over-triggers on
+// equipment/phase edits, but the derivations
 // reuse their previous result by reference when nothing they own changed, so a
 // needless recompute stays cheap and doesn't dirty the batch.
 const shoppingTriggers: (keyof Batch)[] = ["brewable"];
-const scheduleTriggers: (keyof Batch)[] = ["brewable", "hydrometer"];
+const scheduleTriggers: (keyof Batch)[] = ["brewable"];
 
 export default async function updateBatch(id: string, batch: Batch) {
     const current = await batchesStorage.get(id);

--- a/packages/app/src/data/defaultBatch.ts
+++ b/packages/app/src/data/defaultBatch.ts
@@ -14,7 +14,7 @@ const defaultBatch  = {
     version: BATCH_MODEL_VERSION,
     phases,
     tracker: {},
-    // same placeholder the hydrometer dates use
+    // zero-date placeholder until the yeast is actually pitched
     pitchedDate: "0000-00-00",
     batchSize: {
         value: "5gal",
@@ -45,40 +45,6 @@ const defaultBatch  = {
         ibu: "0",
         srm: "0"
     },
-    hydrometer: [
-        {
-            date: "0000-00-00",
-            gravity: {
-                value: "0.00°P",
-                unit: UNITS.PLATO
-            },
-            name: "Before boil",
-        },
-        {
-            date: "0000-00-00",
-            gravity: {
-                value: "0.00°P",
-                unit: UNITS.PLATO
-            },
-            name: "After boil",
-        },
-        {
-            date: "0000-00-00",
-            gravity: {
-                value: "0.00°P",
-                unit: UNITS.PLATO
-            },
-            name: "After Ferment",
-        },
-        {
-            date: "0000-00-00",
-            gravity: {
-                value: "0.00°P",
-                unit: UNITS.PLATO
-            },
-            name: "After secondary",
-        }
-    ],
 };
 
 export default defaultBatch as Pick<Batch, keyof typeof defaultBatch>;

--- a/packages/app/src/model/batch.ts
+++ b/packages/app/src/model/batch.ts
@@ -1,6 +1,5 @@
 import {Entity, Scalar} from "@brewdocs.beer/core";
 import Brewable from "@/model/brewable";
-import Hydrometer from "@/model/hydrometer";
 import Measurements from "@/model/measurements";
 import {RecipeSource} from "@/model/recipe";
 import Statuses from "@/model/statuses";
@@ -24,7 +23,7 @@ export interface ShoppingItem {
 /** the brew-day stage a schedule item happens in */
 export type SchedulePhase = "mash"|"boil"|"ferment";
 /** what the item is — the shopping vocabulary plus readings */
-export type ScheduleKind = "grains"|"hops"|"yeasts"|"additives"|"gravity";
+export type ScheduleKind = "grains"|"hops"|"yeasts"|"additives";
 /** either facet; a Phase filters on these without caring which kind it is */
 export type ScheduleTag = SchedulePhase|ScheduleKind;
 
@@ -128,7 +127,6 @@ export default interface Batch extends Entity {
 
 
     actuals: Measurements;
-    hydrometer: Hydrometer[];
     shopping: ShoppingItem[];
     schedule: ScheduleItem[];
     /** configuration — how the derived schedule is sliced into tabs */

--- a/packages/app/src/model/hydrometer.ts
+++ b/packages/app/src/model/hydrometer.ts
@@ -1,7 +1,0 @@
-import {Scalar} from "@brewdocs.beer/core";
-
-export default interface Hydrometer {
-    name: string;
-    date: string;
-    gravity: Scalar;
-}

--- a/packages/app/src/screen/batch-schedule/gravity.tsx
+++ b/packages/app/src/screen/batch-schedule/gravity.tsx
@@ -1,0 +1,80 @@
+import {memo, useCallback} from "react";
+import {UNITS} from "@brewdocs.beer/core";
+import DataGrid from "@/component/data-grid";
+import DataGridHeaderRow from "@/component/data-grid/header-row";
+import DataGridInput from "@/component/data-grid/input";
+import DataGridLabel from "@/component/data-grid/label";
+import DataGridRow from "@/component/data-grid/row";
+import {key, Ref, TrackerEntry} from "@/model/tracker";
+import {scalarFromNumberWithUnit} from "@/utils/formatting";
+
+/** one gravity milestone slot — a post-reading on a mash or boil brewable phase */
+export type GravityReading = { phaseId: string; label: string };
+
+const refOf = (phaseId: string): Ref => ({ on: "milestone", phaseId, when: "post", kind: "gravity" });
+
+type BatchScheduleGravityItemProps = {
+    reading: GravityReading;
+    entry: TrackerEntry | undefined;
+    onPatch: (ref: Ref, patch: TrackerEntry) => void;
+};
+
+function BatchScheduleGravityItem({ reading: { phaseId, label }, entry, onPatch }: BatchScheduleGravityItemProps) {
+    // the reading is a raw scalar while typing, formatted to °P on blur — mirrors
+    // the ingredient rows' updateScalar, but written to the tracker not a path
+    const onChangeReading = useCallback((next: string) => onPatch(refOf(phaseId), { reading: { value: next, unit: UNITS.PLATO } }), [onPatch, phaseId]);
+    const onBlurReading = useCallback((next: string) => onPatch(refOf(phaseId), { reading: scalarFromNumberWithUnit(next, UNITS.PLATO) }), [onPatch, phaseId]);
+    // exact date taken matters less than the reading, so it rides behind the expander
+    const onChangeDate = useCallback((next: string) => onPatch(refOf(phaseId), { date: next }), [onPatch, phaseId]);
+
+    return (
+        <DataGridRow
+            zebra
+            label={`${label} reading`}
+            expandContent={(
+                <DataGrid>
+                    <DataGridRow zebra={false}>
+                        <DataGridLabel tiny cols={3}>Reading Taken</DataGridLabel>
+                        <DataGridInput cols={3} type="date" value={entry?.date ?? ""} onChange={onChangeDate} />
+                    </DataGridRow>
+                </DataGrid>
+            )}
+            reserveExpand
+        >
+            <DataGridLabel>{label}</DataGridLabel>
+            <DataGridInput colStart={3} value={entry?.reading?.value ?? ""} onChange={onChangeReading} onBlur={onBlurReading} />
+        </DataGridRow>
+    );
+}
+
+// props are primitives plus a stable onPatch, so editing one reading doesn't
+// re-render the rest — same reasoning as the equipment list
+const Item = memo(BatchScheduleGravityItem);
+
+export type BatchScheduleGravityProps = {
+    readings: GravityReading[];
+    tracker: Record<string, TrackerEntry>;
+    onPatch: (ref: Ref, patch: TrackerEntry) => void;
+};
+
+/**
+ * Post-phase gravity reads (one per mash/boil brewable phase), each keyed to a
+ * `{on:"milestone", phaseId, when:"post", kind:"gravity"}` entry in `batch.tracker`.
+ * Its own DataGrid so the collapse rule scopes to these rows, like Equipment.
+ */
+export default function BatchScheduleGravity({ readings, tracker, onPatch }: BatchScheduleGravityProps) {
+    if (!readings.length) return null;
+
+    return (
+        <DataGrid>
+            <DataGridHeaderRow collapsible>Gravity</DataGridHeaderRow>
+            {readings.map(reading => (
+                <Item
+                    key={reading.phaseId}
+                    reading={reading}
+                    entry={tracker[key(refOf(reading.phaseId))]}
+                    onPatch={onPatch} />
+            ))}
+        </DataGrid>
+    );
+}

--- a/packages/app/src/screen/batch-schedule/index.tsx
+++ b/packages/app/src/screen/batch-schedule/index.tsx
@@ -12,8 +12,9 @@ import Screen from "@/component/screen";
 import useJsonEdit from "@/hooks/useJsonEdit";
 import Batch, {Phase, phaseLabel, SchedulePhase, ScheduleKind} from "@/model/batch";
 import {statuses} from "@/model/statuses";
-import {key} from "@/model/tracker";
+import {key, Ref, TrackerEntry} from "@/model/tracker";
 import BatchScheduleEquipment from "@/screen/batch-schedule/equipment";
+import BatchScheduleGravity from "@/screen/batch-schedule/gravity";
 import ScheduleItemRow from "@/screen/batch-schedule/item-row";
 import {useBatch} from "@/state/batches";
 import {saveSession, useSession} from "@/state/session";
@@ -25,12 +26,11 @@ const KIND_LABELS: Record<ScheduleKind, string> = {
     grains: "Grains",
     hops: "Hops",
     yeasts: "Yeasts",
-    additives: "Additives",
-    gravity: "Gravity"
+    additives: "Additives"
 };
 
 /** within a phase, rows read in the order you'd actually work through them */
-const KIND_ORDER: ScheduleKind[] = ["grains", "hops", "additives", "yeasts", "gravity"];
+const KIND_ORDER: ScheduleKind[] = ["grains", "hops", "additives", "yeasts"];
 
 const SCHEDULE_PHASES: SchedulePhase[] = ["mash", "boil", "ferment"];
 
@@ -69,6 +69,14 @@ export default function BatchSchedule({ batchId, onChange }: BatchScheduleProps)
         onChange({ ...dataRef.current, tracker: putEntry(dataRef.current.tracker, ref, { completed: !completed }) });
     }, [onChange]);
 
+    // gravity/milestone edits are typed, so they route through useJsonEdit's
+    // debounced `update` (setting the whole `tracker` object at a top-level path,
+    // since a "milestone:..." key isn't dot-path addressable) rather than the
+    // immediate onChange the equipment toggle uses
+    const patchTracker = useCallback((ref: Ref, patch: TrackerEntry) => {
+        update("tracker", putEntry(dataRef.current.tracker, ref, patch));
+    }, [update]);
+
     const panels = useMemo(() => {
         // keep each item's index, so edit paths point at the real position in
         // batch.schedule no matter how the tabs and groups rearrange the display
@@ -98,7 +106,14 @@ export default function BatchSchedule({ batchId, onChange }: BatchScheduleProps)
                 ? data.brewable.schedule.phases.filter(p => p.type === type).flatMap(p => p.equipment)
                 : [];
 
-            return { phase, index, groups, equipment };
+            // one post-reading per mash/boil brewable phase (ferment gets none in v1)
+            const gravity = type === "mash" || type === "boil"
+                ? data.brewable.schedule.phases
+                    .filter(p => p.type === type)
+                    .map(p => ({ phaseId: p.id!, label: `Post-${type}` }))
+                : [];
+
+            return { phase, index, groups, equipment, gravity };
         });
     }, [data.schedule, data.phases, data.brewable]);
 
@@ -111,15 +126,15 @@ export default function BatchSchedule({ batchId, onChange }: BatchScheduleProps)
                 </DataGridRow>
             </DataGrid>
             <PanelSwitcher compact name="schedule" defaultTab={data.phases[0].name}>
-                {panels.map(({ phase, index, groups, equipment }) => (
+                {panels.map(({ phase, index, groups, equipment, gravity }) => (
                     <PanelSwitcherContent
                         key={phase.name}
                         title={phase.name}
                         label={phaseLabel(phase, index)}
                         // a phase with nothing in it renders as a disabled tab; say why,
                         // or it inherits the switcher's "Not implemented" tooltip
-                        titleAlt={groups.length || equipment.length ? "" : "Nothing scheduled in this step"}>
-                        {groups.length || equipment.length ? (
+                        titleAlt={groups.length || equipment.length || gravity.length ? "" : "Nothing scheduled in this step"}>
+                        {groups.length || equipment.length || gravity.length ? (
                             <div className="pt-2">
                                 {/* what to gather before the phase starts, ahead of the work itself */}
                                 <BatchScheduleEquipment
@@ -148,6 +163,11 @@ export default function BatchSchedule({ batchId, onChange }: BatchScheduleProps)
                                         ))}
                                     </DataGrid>
                                 ))}
+                                {/* readings come after the work — the wort's measured as the phase ends */}
+                                <BatchScheduleGravity
+                                    readings={gravity}
+                                    tracker={data.tracker}
+                                    onPatch={patchTracker} />
                             </div>
                         ) : null}
                     </PanelSwitcherContent>


### PR DESCRIPTION
Part of the **batch completion tracker** epic (#208). Deps #206/#209/#210 are all merged.

## Summary

Closes #211. Moves gravity readings off the fixed `batch.hydrometer[]` array onto tracker **phase milestones**, mirroring the #215 equipment cutover: gravity is pulled out of `_updateSchedule`/`batch.schedule` and rendered by a new live-derived, tracker-backed component.

- **Two reads: post-mash + post-boil** — one per mash/boil brewable phase (ferment gets none in v1). Each keys `{on:"milestone", phaseId, when:"post", kind:"gravity"}` → `tracker["milestone:<phaseId>:post:gravity"]` (`reading` + `date`).
- `batch.hydrometer` / the `Hydrometer` model / the `"gravity"` `ScheduleKind` / the `"hydrometer"` schedule trigger are all removed.

## Changes

- **new** `screen/batch-schedule/gravity.tsx` — `BatchScheduleGravity`, live off the brewable phases, reads/writes the tracker (reading formatted to °P on blur; date behind the row expander, mirroring the old UX).
- `screen/batch-schedule/index.tsx` — derives the gravity readings per mash/boil phase in the `panels` memo; renders `BatchScheduleGravity`; adds a `patchTracker` callback that routes edits through `useJsonEdit`'s debounced `update("tracker", putEntry(...))` (typed edits need debounce; a `milestone:` key isn't dot-path addressable, so the whole `tracker` object is set at a top-level path). Drops `"gravity"` from `KIND_LABELS`/`KIND_ORDER`.
- `actions/_updateSchedule.ts` — removed `gravity()` + `READINGS`.
- `model/batch.ts` — removed `hydrometer` field + `Hydrometer` import; dropped `"gravity"` from `ScheduleKind`.
- **deleted** `model/hydrometer.ts`.
- `data/defaultBatch.ts` — removed the `hydrometer` seed.
- `actions/updateBatch.ts` — dropped `"hydrometer"` from `scheduleTriggers`.

## Verification

Node 22. `tsc --noEmit` ✓, `npm run lint -w packages/app` ✓ (0 errors), `vite build` ✓.

**Browser** (purge → fresh Anchor Steam batch, IndexedDB inspected):
- Mash tab shows **Post-mash**, Boil shows **Post-boil**, Ferment shows **no gravity**.
- Entered a Post-boil reading → persisted `tracker["milestone:<boilId>:post:gravity"].reading = "12.5°P"` (formatted on blur), **no `batch.hydrometer`**, and it reads back **12.5°P after a full reload**.
- The "Reading Taken" date sits behind the row expander. Ingredient rows + equipment checkoff unaffected.

<details><summary><b>Handoff</b></summary>

**Done:** gravity fully on tracker milestones; `hydrometer` + `Hydrometer` + `"gravity"` ScheduleKind + hydrometer trigger removed.

**Decisions/gotchas:**
- Gravity is its own component (like equipment), **not** a `ScheduleItem`/`item-row` row — so `item-row.tsx` is untouched (leaves it clean for #212's ingredient cutover, which *does* touch it).
- **Tracker text writes**: use `update("tracker", putEntry(dataRef.current.tracker, ref, patch))` — debounced via useJsonEdit, no staleness (setState is immediate so `dataRef.current` is fresh). The equipment *toggle* (#215) uses immediate `onChange` instead; both are fine.
- No `completed` checkbox on gravity (a reading is self-evidencing); `TrackerEntry.completed` just goes unused for milestones.
- **Column system**: `DataGridInput` `colStart` only maps to cols 4–6 (`VALUE_COL_STARTS`), so the reading sits in the value column and the date rides the expander — don't try to place a second input in the left columns.

**Still open (other children):** ingredient `completed`/`actual`/pitch (#212), eager-prune wiring + `BATCH_MODEL_VERSION` bump (#213 — an orphan gravity entry from a removed phase isn't pruned until then).

**Files:** `gravity.tsx` (new component) · `index.tsx` (derive + render + `patchTracker`) · `_updateSchedule.ts` (drop gravity()) · `model/batch.ts` (drop hydrometer + ScheduleKind gravity) · `model/hydrometer.ts` (deleted) · `defaultBatch.ts` (drop seed) · `updateBatch.ts` (drop trigger).

**Verify:** purge → fresh batch → Schedule → Boil, enter a Post-boil reading, reload, confirm it persists; Ferment has no gravity.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
