### PR TITLE
Always cut a feature branch per epic in the plan-feature skills

### DIFF
--- a/.claude/commands/plan-feature-light.md
+++ b/.claude/commands/plan-feature-light.md
@@ -61,7 +61,22 @@ turn into a sized breakdown — no more.
 - **Proposal** — the high-level shape (§3).
 - **Constraints** — standing + feature-specific.
 - **Research path** — the reading list + questions (§2). *This is the heart of the issue.*
+- **Integration branch** — the epic's feature branch (cut below) and the branch-per-epic flow.
 - **Your task** — the block below, addressed to the assignee agent.
+
+**Then cut the epic's feature branch — always.** This issue *is* the epic (the agent's sub-issues
+link to it as native sub-issues), so it gets one integration branch that all that work targets, not
+`mainline` — the feature lands together and merges as a single PR. Capture the issue number, then:
+
+```
+git checkout mainline && git pull --ff-only
+git checkout -b <issue#>-<kebab-summary>
+git push -u origin <issue#>-<kebab-summary>
+```
+
+The branch is empty (off `mainline`) until the first sub-issue PR merges in. After cutting it,
+`gh issue edit` the issue to fill the concrete branch name into its **Integration branch** section
+and the *Your task* block.
 
 ### The "Your task" block (include in the issue, addressed to the GitHub agent)
 
@@ -83,6 +98,16 @@ turn into a sized breakdown — no more.
 > repo, i.e. `$GITHUB_REPOSITORY`). If that API is unavailable, fall back to a
 > `Part of #<this-issue-number>` line in each body.
 >
+> **Target the epic's feature branch.** A branch `<issue#>-<kebab-summary>` has been cut off
+> `mainline` for this epic (its name is in the *Integration branch* section above). Every sub-issue
+> you create must carry a **Base branch** note telling its worker to *branch off that branch and open
+> the PR against it, not `mainline`; rebase onto it once the prerequisite sub-issue has landed there.*
+> Land the prerequisite sub-issue into the branch first.
+>
+> ⚠️ When your index comment or any issue body references sub-issues by number, use their **real
+> issue numbers** (assigned after creation), never ordinals like #1…#7 — GitHub auto-links `#N` to
+> whatever issue/PR already holds that number, so low ordinals silently point at unrelated old PRs.
+>
 > Then post ONE comment on *this* issue listing the sub-issues (with links) in prerequisite
 > order, marking which are parallel vs blocked — a single index to review.
 >
@@ -100,10 +125,11 @@ turn into a sized breakdown — no more.
 
 ## 5. Close with a one-liner for the maintainer
 
-After creating it, post the issue link in your response and remind the maintainer: review /
-iterate, then apply the **`claude` label** to trigger the research + decomposition — the
-label tier gets the full turn budget, while an `@claude` comment runs on the smaller poke
-budget and can time out on real research. The agent will then **create the sub-issues
+After creating it, post the issue link **and the epic's feature-branch name** in your response
+and remind the maintainer: review / iterate, then apply the **`claude` label** to trigger the
+research + decomposition — the label tier gets the full turn budget, while an `@claude` comment
+runs on the smaller poke budget and can time out on real research. The agent's sub-issues will
+target the feature branch, not `mainline`. The agent will then **create the sub-issues
 (unlabeled), link them as native sub-issues of the parent**, and post an index comment; the
 maintainer reviews and applies the `claude` label to whichever ones to start.
 
@@ -112,5 +138,7 @@ maintainer reviews and applies the `claude` label to whichever ones to start.
 - Light grounding only — never produce the final per-file decomposition yourself; that's the
   assignee agent's job.
 - Never implement and never apply a label. Create **only** the single research issue
-  (unlabeled) — never the sub-issues; those are the agent's job.
-- Stop once the research-path issue is created and its link posted.
+  (unlabeled) — never the sub-issues; those are the agent's job. Cutting the epic's **empty**
+  feature branch off `mainline` is the one expected exception — it's not code; write nothing onto it.
+- Stop once the research-path issue is created, its feature branch is cut, and its link + branch
+  name are posted.

--- a/.claude/commands/plan-feature.md
+++ b/.claude/commands/plan-feature.md
@@ -23,7 +23,8 @@ is `mainline`. See CLAUDE.md for architecture and conventions.
 
 The overall goal and why, the shared constraints, and a short codebase map of where the
 relevant code lives. This is the review artifact — it's what the maintainer reads to
-decide whether the decomposition is right.
+decide whether the decomposition is right. Include an **Integration branch** section naming
+the epic's feature branch and the branch-per-epic flow (see §4).
 
 ## 3. Decompose into sub-issues sized for a bounded-turn worker
 
@@ -56,13 +57,26 @@ implemented without that context.
 Order them so prerequisites come first, and say plainly which are independent (safe to
 start in parallel) and which are blocked on an earlier child.
 
-## 4. Create the issues
+## 4. Create the issues and the epic's feature branch
 
-Create the **epic first**, then each sub-issue, then link them:
+Create the **epic first**, cut its feature branch, then each sub-issue, then link them:
 
 1. **Epic** — `gh issue create --title "<epic title>" --body "<parent body from §2>"` (no
    labels). Capture its number from the returned URL.
-2. **Sub-issues** — one `gh issue create` per child (no labels), body built from the
+2. **Cut the epic's feature branch — always.** Every epic gets one integration branch; sub-issue
+   work targets it, not `mainline`, so the whole feature lands together and merges to `mainline`
+   as a single PR. From the epic number:
+   ```
+   git checkout mainline && git pull --ff-only
+   git checkout -b <epic#>-<kebab-summary>
+   git push -u origin <epic#>-<kebab-summary>
+   ```
+   Cut from current `mainline`; it stays empty until the first sub-issue PR merges in. Then give the
+   **epic body** an **Integration branch** section: name the branch, say each sub-issue branches off
+   it and PRs **into** it, land the prerequisite child first, and note that if the `@claude` action
+   opens a sub-issue PR against `mainline` by default, the maintainer retargets the PR's base to the
+   epic branch (GitHub → the PR → Edit → base dropdown).
+3. **Sub-issues** — one `gh issue create` per child (no labels), body built from the
    `.github/ISSUE_TEMPLATE/claude-task.yml` headings:
    - **Summary** — what needs to happen and why
    - **Where the code lives** — specific, verified paths
@@ -71,7 +85,11 @@ Create the **epic first**, then each sub-issue, then link them:
    - **Out of scope** — what not to touch; prevents over-engineering
    - **Acceptance criteria** — a short checklist
    - **CLAUDE.md Updates (Optional)** — anything that will need updating in CLAUDE.md
-3. **Link each sub-issue as a native GitHub sub-issue of the epic** so they show in its
+
+   ⚠️ Every child body must also carry a **Base branch** note: *branch off `<epic#>-<kebab-summary>`
+   and open your PR against it, not `mainline`; rebase onto it once the prerequisite child has landed
+   there.* A worker sees only its own issue, so this can't be left implicit.
+4. **Link each sub-issue as a native GitHub sub-issue of the epic** so they show in its
    Sub-issues list — a `Part of #N` text line is *not* sufficient. The REST API wants the
    child's integer database `id`, **not** its issue number:
    - `gh api repos/{owner}/{repo}/issues/<child-number> --jq .id` → the child's id
@@ -79,6 +97,10 @@ Create the **epic first**, then each sub-issue, then link them:
 
    `gh api` fills `{owner}/{repo}` from the current repo. If the sub-issues API is
    unavailable, fall back to a `Part of #<epic-number>` line in each child body.
+
+⚠️ When the epic body lists its children, reference them by their **real issue numbers** (e.g.
+`#231`), added after the children exist — never as ordinals like "#1…#7". GitHub auto-links `#N` to
+whatever issue/PR already holds that number, so low ordinals silently point at ancient PRs.
 
 Carry these standing constraints into every sub-issue's Out of scope:
 
@@ -113,9 +135,10 @@ cadence is already wired for every run.
 
 ## 5. Close with a plan of attack
 
-After creating them, post the summary in your response: the epic link, then each
-sub-issue's title + link, which are independent vs. blocked and on what, and the order to
-apply the `claude` label. The issues are **unlabeled drafts** — the maintainer reviews and
+After creating them, post the summary in your response: the epic link, the epic's **feature
+branch** name (and the reminder that sub-issue PRs target it, retargeting off `mainline` if
+needed), then each sub-issue's title + link, which are independent vs. blocked and on what, and
+the order to apply the `claude` label. The issues are **unlabeled drafts** — the maintainer reviews and
 iterates, then **starts a sub-issue by applying the `claude` label** (the full feature-work
 turn budget; an `@claude` comment runs on the smaller poke budget and can time out on real
 implementation work).
@@ -124,5 +147,6 @@ implementation work).
 
 - Create the issues **unlabeled**. Never apply the `claude` label — the maintainer's
   label-apply is both the review gate and the trigger.
-- Never implement any of it — issues only, no code, no PR.
-- Stop once the issues are created, linked, and summarized.
+- Never implement any of it — issues only, no code, no PR. Cutting the epic's **empty** feature
+  branch off `mainline` (step 4.2) is the one expected exception — it's not code; write nothing onto it.
+- Stop once the issues are created, linked, the feature branch is cut, and everything is summarized.


### PR DESCRIPTION
## Summary

Bakes the **branch-per-epic** practice into both planning slash-commands so every decomposition targets a shared integration branch instead of `mainline` directly — the workflow we just used for the Playwright e2e epic (#225 → `225-playwright-e2e-suite`).

### `.claude/commands/plan-feature.md`
- New **step 4.2 — "Cut the epic's feature branch — always"**: after creating the epic, `git checkout -b <epic#>-<kebab-summary>` off `mainline` and push it.
- The **epic body** gains an **Integration branch** section: sub-issues branch off it and PR *into* it, land the prerequisite child first, and the maintainer retargets a PR's base if the `@claude` action opens against `mainline` by default.
- Every **child body** must carry a **Base branch** note (a worker sees only its own issue, so it can't be implicit).
- Plan-of-attack summary now reports the branch name; **Boundaries** note the empty-branch cut is the one allowed exception to "issues only, no code, no PR".

### `.claude/commands/plan-feature-light.md`
- After creating the research issue (which *is* the epic), **cut the same feature branch** and `gh issue edit` its name into the body.
- The **"Your task"** block instructs the assignee agent that every sub-issue it creates must target that branch; **Boundaries**/close updated to match.

### Both
- ⚠️ Added a guard to reference children by their **real issue numbers, never `#1…#7` ordinals** — GitHub auto-links `#N` to whatever issue/PR already holds that number, so low ordinals silently point at unrelated old PRs (exactly what happened when the epic's `#6`/`#7` linked to 2018 PRs "feat: webapp" / "task: Remove DAL").

## Verification

Docs/command-prompt only — no code paths, no build impact. Reviewed both rendered files; the branch step, Integration/Base-branch sections, `#N` caveat, and Boundaries updates are consistent across the two commands. Not wired into the Verify gate (it's `.claude/` tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
