### PR TITLE
Fix app build: remove dangling search-everywhere import in knowledge.tsx

### DIFF
--- a/packages/app/src/routes/knowledge.tsx
+++ b/packages/app/src/routes/knowledge.tsx
@@ -1,8 +1,5 @@
 import {createFileRoute} from "@tanstack/react-router";
 import {Crumb, useBreadcrumbs} from "@/component/breadcrumbs/context";
-import Batch from "@/model/batch";
-import SearchEverywhere from "@/screen/search-everywhere";
-import {FEATURES_SEARCH_EVERYWHERE} from "@/utils/env";
 
 // module const so the array is stable across renders (see useBreadcrumbs)
 const BREADCRUMBS: Crumb[] = [{ label: "Knowledge" }];
@@ -13,16 +10,6 @@ export const Route = createFileRoute("/knowledge")({
 
 function KnowledgePage() {
     useBreadcrumbs(BREADCRUMBS);
-
-    const batches = [] as Batch[];
-
-    if (!batches) {
-        return null;
-    }
-
-    if (FEATURES_SEARCH_EVERYWHERE) {
-        return <SearchEverywhere batches={batches} />;
-    }
 
     return <p>Page not implemented</p>;
 }


### PR DESCRIPTION
## Summary

Fixes a broken `mainline` build. `tsc --noEmit` (inside `npm run build -ws`) was failing:

```
src/routes/knowledge.tsx(4,30): error TS2307:
Cannot find module '@/screen/search-everywhere'
```

`f6cc90e "remove unused component"` deleted `packages/app/src/screen/search-everywhere/` but left `routes/knowledge.tsx` importing and using it (behind the off-by-default `FEATURES_SEARCH_EVERYWHERE` flag). That commit was **pushed directly to mainline**, and Verify only runs on `pull_request` — so it never ran on the break, and mainline has been build-red since 2026-07-27. It surfaced on the next PR's Verify ([run #144](https://github.com/matt-whitaker/brewdocs.beer/actions/runs/30578599431)), whose diff was unrelated (workflow YAML only).

**The fix:** the page renders `"Page not implemented"` and the flag is off, so `SearchEverywhere` was already unreachable dead code. Remove the dangling import and the flag branch (plus the now-unused `Batch`/`batches` scaffolding it fed), collapsing `KnowledgePage` to the stub. **No behavior change** — one file touched.

## Verification

Node 22, run locally (this is exactly what Verify runs):
- `tsc --noEmit` (app) ✓ — the previously-failing check now passes.
- `npm test -w packages/app` (eslint) ✓.
- `npm run build -w packages/app` ✓.
- `grep search-everywhere` across the repo → no references remain.

## Follow-ups (out of scope here, flagged not fixed)

- **Orphaned flag:** `FEATURES_SEARCH_EVERYWHERE` (`utils/env.ts`, `vite-env.d.ts`, and a mention in CLAUDE.md's app _Env_) now has no consumer. Harmless; removable in a separate cleanup.
- **Process gap:** Verify runs on PRs only, so **direct pushes to `mainline` bypass the gate** — which is how this landed. Worth branch protection that requires PRs + a green Verify if the gate is meant to hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
