### PR TITLE
Researcher: every sub-issue must be independently mergeable

### DIFF
--- a/.claude/commands/plan-feature-light.md
+++ b/.claude/commands/plan-feature-light.md
@@ -116,6 +116,15 @@ and the *Your task* block.
 > screens/rows, split it further. Size is the hard constraint; the number of sub-issues is
 > soft — prefer more small issues over one that balloons.
 >
+> ⚠️ **Every sub-issue must be independently mergeable — its PR has to pass the gate alone.**
+> The gate is repo-wide (`npm test -ws` + `tsc --noEmit` + `vite build`), so a sub-issue that
+> leaves the tree not compiling can *never* go green and its worker will burn its whole turn
+> budget trying. **Never** write "it's fine if this doesn't compile yet" or "the next
+> sub-issue fixes the type errors". A rename/signature change and its call sites are **one**
+> sub-issue. If a split would break the build, fold the consumers in, or make the step
+> **additive** (new shape alongside old, old deleted later) — and keep it
+> behaviour-preserving, so old consumers' data isn't silently dropped.
+>
 > Write each sub-issue self-contained, using the headings from
 > `.github/ISSUE_TEMPLATE/claude-task.yml` (Summary / Where the code lives / What to change /
 > Patterns to follow / Out of scope / Acceptance criteria / CLAUDE.md Updates). Put verified,

--- a/.claude/commands/plan-feature.md
+++ b/.claude/commands/plan-feature.md
@@ -49,6 +49,18 @@ turn cap having made almost no edits.
 - Precise paths in *Where the code lives* directly cut exploration cost — the more exact,
   the fewer files the worker reads to orient.
 
+⚠️ **Every sub-issue must be independently mergeable — its PR has to pass the gate alone.**
+The gate is repo-wide (`npm test -ws` + `tsc --noEmit` + `vite build`), so a sub-issue that
+leaves the tree not compiling can *never* go green, and its worker will burn the whole turn
+budget trying. **Never** write "it's fine if this doesn't compile yet" or "the next sub-issue
+fixes the type errors" — that's an unsatisfiable task, not a scoping decision. A
+rename/signature change and its call sites are **one** sub-issue, not two. If a split would
+break the build, either fold the consumers in, or make the step **additive** (new shape
+alongside old, both working, old one deleted in a later sub-issue — mark the transitional
+code in-file with the issue that removes it). An additive step must also be
+**behaviour-preserving**: if old consumers still write data the new code ignores, keep the
+old path live until they migrate rather than shipping silent data loss.
+
 **Write every sub-issue self-contained.** There is no runtime parent lookup — a worker
 picks up one labeled issue and sees only that issue. Restating shared constraints in
 each child is correct here; a child that says "see the parent for context" will be

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -152,6 +152,23 @@ jobs:
               whole directory tree). If one would span a directory of screens/rows, split
               it further. Size is the hard constraint; the number of sub-issues is soft —
               prefer more small issues over one that balloons.
+            - ⚠️ **Every sub-issue must be independently mergeable — its PR has to pass the
+              gate on its own.** The gate is repo-wide (`npm test -ws` + `tsc --noEmit` +
+              `vite build`), so a sub-issue that leaves the tree not compiling can *never*
+              go green and its Implementor will burn its whole turn budget trying. **Never**
+              write "it's fine if this doesn't compile yet", "the next sub-issue fixes the
+              type errors", or "expected errors in <other file> belong to sub-issue N" —
+              that is an unsatisfiable task, not a scoping decision. This has already cost
+              a full run.
+              A rename/signature change and its call sites are **one** sub-issue, not two.
+              When a split would break the build, pick one:
+                - put the definition and all its consumers in the same sub-issue; or
+                - make the step **additive** — add the new shape alongside the old, keep
+                  both working, and delete the old one in a later sub-issue (mark the
+                  transitional code in-file with the issue that removes it).
+              ⚠️ An additive step must also be **behaviour-preserving**: if the old
+              consumers still write data the new code no longer accounts for, say so and
+              keep the old path live until they migrate — don't ship silent data loss.
             - Create each as its own GitHub issue (`gh issue create`), **unlabeled**, and
               self-contained (a worker sees only that one issue), using the headings from
               `.github/ISSUE_TEMPLATE/claude-task.yml`: Summary / Where the code lives /


### PR DESCRIPTION
## Summary

Epic #249's decomposition produced sub-issues that **cannot pass the gate on their own**, which is what burned the Implementor's turn budget on #271.

- **#266** — its *Out of scope* forbade touching `screen/batch-schedule/*`, while its own change deleted a symbol `gravity.tsx` imports. Its acceptance criteria called the resulting type errors "expected".
- **#267** — goes further, in writing: *"It's fine if `gravity.tsx`'s new prop signature doesn't yet compile against `index.tsx`'s current call site."*

The gate is **repo-wide** (`npm test -ws` + `tsc --noEmit` + `vite build`), so a PR that knowingly leaves the tree broken can *never* go green. That's an unsatisfiable task, and the Implementor has no way to tell the difference between "my change is wrong" and "this issue can't be completed" — so it retries until the turn cap.

## The rule added

To the **Researcher** prompt in `claude-roles.yaml`, and to both `plan-feature` skills (same activity, same failure mode):

- Every sub-issue must be **independently mergeable** — its PR passes the gate alone.
- Never write *"it's fine if this doesn't compile yet"* / *"the next sub-issue fixes the type errors"*.
- A **rename/signature change and its call sites are one sub-issue**, not two.
- If a split would break the build: fold the consumers in, **or** make the step **additive** (new shape alongside old, both working, old deleted in a later sub-issue — transitional code marked in-file with the issue that removes it).
- ⚠️ An additive step must also be **behaviour-preserving**: if old consumers still write data the new code no longer accounts for, keep the old path live until they migrate — don't ship silent data loss. (Exactly the trap #271 hit: restoring the deleted constant compiled, but would have pruned every gravity reading on save.)

## Verification

Docs / prompt-only — no code paths. `claude-roles.yaml` re-parsed as valid YAML; jobs (`manager`/`researcher`/`implementor`) and all four triggers intact; asserted the researcher job's prompt now carries the rule. Not in the Verify gate (`.github/` + `.claude/`).

## Follow-up (separate, doing next)

The rule prevents recurrence but doesn't fix the two issues already written that way — **#267 and #268 are a mutually-dependent pair** (`gravity.tsx`'s prop shape and `index.tsx`'s call site must change together). They need folding into one sub-issue before the next Implementor picks up #267 and hits the same wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
