### PR TITLE
Drop phaseId from the milestone ref so all three are {on, id}

### DIFF
--- a/packages/app/src/actions/tracker.ts
+++ b/packages/app/src/actions/tracker.ts
@@ -53,7 +53,7 @@ export function liveTrackerKeys(brewable: Brewable): Set<string> {
             if (item.id) keys.add(key({on: "equipment", id: item.id}));
         });
         phase.milestones.forEach(milestone => {
-            keys.add(key({on: "milestone", phaseId: phase.id, id: milestone.id}));
+            keys.add(key({on: "milestone", id: milestone.id}));
         });
     });
 

--- a/packages/app/src/model/brewable.ts
+++ b/packages/app/src/model/brewable.ts
@@ -16,7 +16,7 @@ export type MilestoneKind = "gravity";
 /**
  * A reading the brewer plans to take during a phase — *plan* config, not the
  * measurement. The value and date live in `batch.tracker`, keyed by
- * `{on:"milestone", phaseId, id}` (see `model/tracker.ts`). Because it's plan
+ * `{on:"milestone", id}` (see `model/tracker.ts`). Because it's plan
  * data it rides on the brewable, so a recipe can prescribe its own readings.
  */
 export interface Milestone {

--- a/packages/app/src/model/tracker.ts
+++ b/packages/app/src/model/tracker.ts
@@ -4,10 +4,22 @@ import Grain from "@/model/grain";
 import Hop from "@/model/hop";
 import Yeast from "@/model/yeast";
 
+/**
+ * What a tracker entry is attached to. All three kinds are `{on, id}` because all
+ * three point at a **stable per-instance uuid** — an assignment, a phase's
+ * equipment item, or a phase's milestone. None needs its parent phase in the key:
+ * the uuid is unique on its own, and encoding a *relationship* inside an
+ * *identity* would orphan the entry if the item ever moved between phases.
+ *
+ * (The milestone ref used to carry a `phaseId`, back when a milestone had no id
+ * of its own and was identified by phase + a fixed `when`/`kind` pair. Once
+ * milestones became user-added entries with uuids, that field stopped doing any
+ * work — this is the shape equipment always had.)
+ */
 export type Ref =
     | { on: "assignment"; id: string }
     | { on: "equipment"; id: string }
-    | { on: "milestone"; phaseId: string; id: string };
+    | { on: "milestone"; id: string };
 
 /**
  * The as-brewed counterpart of an assignment's `resource`, keyed by the **same
@@ -45,6 +57,6 @@ export const key = (ref: Ref): string => {
         case "equipment":
             return `equipment:${ref.id}`;
         case "milestone":
-            return `milestone:${ref.phaseId}:${ref.id}`;
+            return `milestone:${ref.id}`;
     }
 };

--- a/packages/app/src/screen/batch-schedule/gravity.tsx
+++ b/packages/app/src/screen/batch-schedule/gravity.tsx
@@ -19,10 +19,9 @@ const READING_UNIT_OPTIONS = [
     { name: "SG", value: UNITS.SPECIFIC_GRAVITY },
 ];
 
-const refOf = (phaseId: string, milestoneId: string): Ref => ({ on: "milestone", phaseId, id: milestoneId });
+const refOf = (milestoneId: string): Ref => ({ on: "milestone", id: milestoneId });
 
 type BatchScheduleGravityItemProps = {
-    phaseId: string;
     phaseIndex: number;
     row: number;
     milestone: Milestone;
@@ -32,7 +31,7 @@ type BatchScheduleGravityItemProps = {
     remove: RemoveFn;
 };
 
-function BatchScheduleGravityItem({ phaseId, phaseIndex, row, milestone, entry, onPatch, update, remove }: BatchScheduleGravityItemProps) {
+function BatchScheduleGravityItem({ phaseIndex, row, milestone, entry, onPatch, update, remove }: BatchScheduleGravityItemProps) {
     // reading unit defaults to the entry's own existing unit, like updateScalar's
     // prev.unit fallback — only a brand-new reading falls back to Plato
     const unit = entry?.reading?.unit ?? UNITS.PLATO;
@@ -42,16 +41,16 @@ function BatchScheduleGravityItem({ phaseId, phaseIndex, row, milestone, entry, 
 
     // the reading is a raw scalar while typing, formatted to its unit on blur —
     // mirrors the ingredient rows' updateScalar, but written to the tracker not a path
-    const onChangeReading = useCallback((next: string) => onPatch(refOf(phaseId, milestone.id), { reading: { value: next, unit } }), [onPatch, phaseId, milestone.id, unit]);
-    const onBlurReading = useCallback((next: string) => onPatch(refOf(phaseId, milestone.id), { reading: scalarFromNumberWithUnit(next, unit) }), [onPatch, phaseId, milestone.id, unit]);
+    const onChangeReading = useCallback((next: string) => onPatch(refOf(milestone.id), { reading: { value: next, unit } }), [onPatch, milestone.id, unit]);
+    const onBlurReading = useCallback((next: string) => onPatch(refOf(milestone.id), { reading: scalarFromNumberWithUnit(next, unit) }), [onPatch, milestone.id, unit]);
     // switching units reformats the existing numeric value under the new one, same
     // as updateScalar's lockUnit path — an empty reading just adopts the new unit
     const onChangeUnit = useCallback((next: string) => {
         const value = entry?.reading?.value;
-        onPatch(refOf(phaseId, milestone.id), { reading: value ? scalarFromNumberWithUnit(value, next as Unit, true) : { value: "", unit: next as Unit } });
-    }, [onPatch, phaseId, milestone.id, entry?.reading?.value]);
+        onPatch(refOf(milestone.id), { reading: value ? scalarFromNumberWithUnit(value, next as Unit, true) : { value: "", unit: next as Unit } });
+    }, [onPatch, milestone.id, entry?.reading?.value]);
     // exact date taken matters less than the reading, so it rides behind the expander
-    const onChangeDate = useCallback((next: string) => onPatch(refOf(phaseId, milestone.id), { date: next }), [onPatch, phaseId, milestone.id]);
+    const onChangeDate = useCallback((next: string) => onPatch(refOf(milestone.id), { date: next }), [onPatch, milestone.id]);
 
     return (
         <DataGridRow
@@ -91,7 +90,7 @@ export type BatchScheduleGravityProps = {
 
 /**
  * Editable gravity readings for a phase, one row per `phase.milestones[]`
- * entry, each keyed to a `{on:"milestone", phaseId, id}` entry in
+ * entry, each keyed to a `{on:"milestone", id}` entry in
  * `batch.tracker`. Its own DataGrid so the collapse rule scopes to these
  * rows, like Equipment. Renders on every phase tab, including an empty one —
  * the brewer adds the first reading from here.
@@ -107,11 +106,10 @@ export default function BatchScheduleGravity({ phase, phaseIndex, tracker, onPat
             {phase.milestones.map((milestone, row) => (
                 <Item
                     key={milestone.id}
-                    phaseId={phase.id}
                     phaseIndex={phaseIndex}
                     row={row}
                     milestone={milestone}
-                    entry={tracker[key(refOf(phase.id, milestone.id))]}
+                    entry={tracker[key(refOf(milestone.id))]}
                     onPatch={onPatch}
                     update={update}
                     remove={remove} />


### PR DESCRIPTION
## Summary

`equipment` and `milestone` live in exactly the same place — per-phase collections of uuid-bearing items on `BrewablePhase` — yet only one carried its parent phase in the tracker key:

```ts
| { on: "assignment"; id: string }
| { on: "equipment";  id: string }
| { on: "milestone"; phaseId: string; id: string }   // ← the odd one out
```

That asymmetry was a **leftover, not a design decision**. In epic #208 a milestone had no id of its own — it was identified by `phaseId` + a fixed `when`/`kind` pair, both effectively constants, so `phaseId` was the only discriminator (and why the old model couldn't express two ferment readings). Once #269 gave milestones real uuids, the field stopped doing any work. Equipment never went through that stage, so its ref was born in the right shape.

## Nothing depended on it

- **Uniqueness** — the milestone id is a `newId()` uuid; `milestone:<id>` is unique alone.
- **Pruning** — `liveTrackerKeys` already has `phase` in scope when it emits *both* kinds; it passed `phase.id` for milestones purely because the type demanded it, and never did for equipment.
- **Lookup** — callers build the ref from the milestone they're rendering.

It also carried a real (dormant) cost: encoding a *relationship* inside an *identity*. If a milestone ever moved between phases, its key would change and orphan its recorded reading — even though it's the same milestone.

```
milestone:<phaseId>:<id>   →   milestone:<id>
```

Also drops the now-dead `phaseId` prop threaded down into the gravity row, and records the history in a comment on `Ref` so the asymmetry doesn't get reintroduced.

## Verification

Node 22 — `tsc --noEmit` ✓, eslint ✓ (app/www/design/e2e), `vite build` ✓.

Browser, fresh purged store — both remaining ref kinds exercised, since the key format changed:

1. Added a gravity reading on Ferment (`1.014`) and ticked an equipment item.
2. Reloaded, then read IndexedDB:
   ```
   milestone:0c6aeded-1eb3-474f-ab81-7821976f0808   { reading: 1.014 °P }
   equipment:65ec4910-aeaf-4f11-b43c-a6cb65dcda1e   { completed: true }
   ```
   Flat milestone key, and both survived — which also proves `liveTrackerKeys` emits the *new* shape, since a mismatch there would have let `pruneTracker` delete the reading on save.
3. Reading renders back as `1.014`; the equipment box is still checked.

The e2e persistence suite (#277) covers both of these flows too, so `functional-test` is a second check on the same behaviour.

## Note

No migration — tracker entries stored under the old `milestone:<phaseId>:<id>` key won't be found and will be pruned on the next save. Pristine-store policy (`/?purge=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
