### PR TITLE
Instruct: no code comments unless explicitly requested

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -284,6 +284,12 @@ jobs:
             pull request against `mainline` yourself — do not stop at pushing a branch and
             returning a PR link.
 
+            ⚠️ **Write no code comments.** See CLAUDE.md's _Code style_. Not explanatory
+            blocks, not `⚠️` notes, not JSDoc — none, unless the issue or a reviewer asks
+            for one. Put the *why* in the PR description or a `CLAUDE.md`, where it's
+            discoverable and maintained. Comment-heavy diffs are a recurring failure mode
+            here: the volume buries what matters and goes stale as soon as the code moves.
+
             Not every trigger is a code change. Some ask only for a written answer — post
             it as a comment and stop; do not invent a code change or open a PR just to
             satisfy the workflow. The task text (issue body, review, comment) is the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,12 @@ Guidance for human contributors **and** for the `@claude` GitHub integration.
 - **Merge.** Squash only. **The maintainer merges** — contributors and the `@claude` bot open PRs, never merge them. No auto-merge.
 - Protect `mainline` to require the **Verify** check green before merge.
 
+### Code style
+- ⚠️ **Don't write code comments.** Add one only when the maintainer explicitly asks for it in that task. This covers explanatory blocks, `⚠️` notes, JSDoc, and "why it's like this" asides — the default is **none**.
+- Say it in the code instead: a precise name, a smaller function, an explicit type. If a reader would still need the *why*, it belongs in a `CLAUDE.md` — that's where this repo keeps its gotchas, and unlike an inline comment it's discoverable from outside the file and actually gets maintained.
+- Deleting a stale or redundant comment is always fine and needs no permission. Adding one does.
+- ⚠️ This applies to the `@claude` roles too. Comment-heavy output is a recurring failure mode: the volume buries the few things that matter and goes stale the moment the code moves.
+
 ### Definition of done
 - The gate is `npm test` (eslint, errors-only) **and** `tsc --noEmit` **and** `vite build` clean, plus manual browser checks for any UI change. A green lint + typecheck + build is the floor for every change.
 - ⚠️ Don't hand-edit generated files (`routeTree.gen.ts`); don't add `lodash` or `../` parent-relative intra-app imports (both lint-enforced — use `@/`).


### PR DESCRIPTION
## Summary

Comment volume had become clutter — mostly explanatory noise that buries the few notes that matter and goes stale the moment the code moves. A lot of it is mine.

**New `### Code style` section in the root `CLAUDE.md`:**

- **No code comments by default.** Only when the maintainer explicitly asks in that task. Covers explanatory blocks, `⚠️` notes, JSDoc, and "why it's like this" asides.
- **Say it in the code instead** — a precise name, a smaller function, an explicit type.
- **If the *why* still needs saying, it goes in a `CLAUDE.md`** — which is where this repo already keeps its gotchas, and unlike an inline comment it's discoverable from outside the file and actually gets maintained.
- **Deleting** a stale comment stays free; **adding** one needs asking.

**Also restated in the Implementor prompt** (`claude-roles.yaml`). That prompt enumerates specific Contributing items rather than pointing at the section generally, so the rule would otherwise be easy to miss — and comment-heavy diffs are a recurring failure mode for the roles specifically.

## Verification

Docs / prompt only, no code paths. `claude-roles.yaml` re-parsed as valid YAML with all three jobs and four triggers intact, and the implementor prompt asserted to carry the rule.

## Note

This doesn't strip the comments already in the tree — that's a separate, much larger diff and would bury any real change it rode along with. Happy to do a dedicated cleanup pass if you want one; my suggestion would be to let them fall away as files get touched, so the churn stays attached to work that's already being reviewed.

There's one category worth a deliberate decision rather than silent loss: the handful of `⚠️` comments that encode hard-won gotchas (`putEntry` merging `resource` a level deeper or data is lost; `AddFn` taking `unknown` so a missing field only fails at runtime). Those exist because they've each already cost a debugging session. They're mostly duplicated in `packages/app/CLAUDE.md` — if you want, I can verify the duplication is complete and then drop the inline copies, so the knowledge survives in the place this rule points to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
