### PR TITLE
Cache npm in the functional-test workflow

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e -w packages/e2e


### PR DESCRIPTION
## Summary

`functional-test.yaml`'s `setup-node` had no `cache: npm`, unlike the one in `claude-roles.yaml`, so `npm ci` re-downloaded the whole dependency tree on every run — about **7s of a ~56s job**.

One line, no new failure modes.

## Why not the Playwright browsers too

That step is the bigger cost (**21s**), but caching it is worth less than it looks here:

- `--with-deps` also installs **system libraries via apt**, which live system-wide and never land in `~/.cache/ms-playwright`. A cache hit still has to run `playwright install-deps`, so only part of the 21s is recoverable.
- More decisively: this workflow triggers **only on `pull_request`**, never on push to `mainline`. Actions caches are branch-scoped — a run can read its own ref, the base branch, or the default branch — so with nothing ever running on `mainline`, **no shareable cache is ever written**. Every PR's first run would miss; only repeat runs on the same PR would hit.

Getting a real hit rate would mean adding a push-to-`mainline` or scheduled job purely to warm the cache. More machinery than the seconds justify, so it's left out.

## Verification

YAML re-parses; the `setup-node` step reads `{"node-version":"${{ env.NODE_VERSION }}","cache":"npm"}`. Effect shows up in this PR's own `functional-test` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
