### PR TITLE
Let Claude invoke the four skills, not just the maintainer

### DIFF
--- a/.claude/skills/file-bug/SKILL.md
+++ b/.claude/skills/file-bug/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: file-bug
 description: Research a bug the maintainer describes, verify what is actually wrong, and file one GitHub issue ready for an Implementor.
-# these all create issues, write code or open PRs — the maintainer decides when
-disable-model-invocation: true
 ---
 
 Research a bug the maintainer describes, **verify what's actually wrong**, and file **one**

--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: implement-feature
 description: Take a single well-scoped task end to end: research it, file a tracking issue, cut a branch, implement, and open a PR.
-# these all create issues, write code or open PRs — the maintainer decides when
-disable-model-invocation: true
 ---
 
 Take a single, well-scoped task end to end: research it, file a tracking issue with a short

--- a/.claude/skills/plan-feature-light/SKILL.md
+++ b/.claude/skills/plan-feature-light/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: plan-feature-light
 description: Sketch a feature's proposal and research path, and file it as one GitHub issue for a Researcher agent to decompose in-repo.
-# these all create issues, write code or open PRs — the maintainer decides when
-disable-model-invocation: true
 ---
 
 Sketch a feature's big-picture proposal and — the part that matters most — a **research

--- a/.claude/skills/plan-feature/SKILL.md
+++ b/.claude/skills/plan-feature/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: plan-feature
 description: Decompose a feature into an epic issue plus independently-implementable sub-issues, and create them on GitHub, linked and unlabeled.
-# these all create issues, write code or open PRs — the maintainer decides when
-disable-model-invocation: true
 ---
 
 Decompose a feature into a parent (epic) issue and independently-implementable


### PR DESCRIPTION
## Summary

Removes `disable-model-invocation: true` from all four skills.

I added it in #390 on the reasoning that workflows creating issues or opening PRs shouldn't start on their own. That was the wrong call for how these are actually used — **all four exist for me to follow**, and you ask for them in plain English rather than by typing the slash command.

## Why it mattered more than it looked

The flag does two things, and I only weighed the first:

| | You invoke | Claude invokes | Description in context |
|---|---|---|---|
| with the flag | ✅ | ❌ | ❌ |
| without (this PR) | ✅ | ✅ | ✅ |

The second column is the visible one; the **third** is what bit. With the flag set, the skill's description is dropped from context entirely — so it may as well not exist unless invoked by name.

The practical effect: *"file a bug for the marker lag"* would get improvised work instead of the checklist the skill exists to enforce. That's exactly the failure `/file-bug` was written to prevent — #365 was filed on a cause I hadn't reproduced, and #367 turned out to be the real one.

## Verification

Only the flag and its explanatory comment are removed — asserted exactly two lines dropped per file, and that all four **bodies are byte-identical** to `HEAD`. Descriptions unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
