### PR TITLE
Make the compact tab bar scroll horizontally instead of wrapping

### DIFF
--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -138,6 +138,7 @@ useKbX() → IndexedDB hit? return it
 - ⚠️ Some DaisyUI behaviors are compound selectors keyed to **literal class names** (e.g. `.collapse`'s arrow needs the literal `collapse-arrow`) — applying them only via responsive variants (`max-lg:collapse-arrow`) silently breaks them.
 - ⚠️ Don't add a `tabIndex` to a `.collapse` element — it force-opens via `:focus-within` in v5.
 **Gotchas.** Tailwind utilities override DaisyUI component styles (cascade layers), so `checked:bg-primary` etc. on components is the intended customization mechanism.
+- ⚠️ `.no-scrollbar` (unlayered, bottom of `styles.css`) hides a scrollbar without hiding the overflow — Tailwind ships no utility for it. It exists for the **compact** PanelSwitcher tab bar, which is a single scrolling row: a visible horizontal scrollbar inside a 40px bar costs more than it explains. ⚠️ DaisyUI's `.tabs` is `flex-wrap: wrap`, so that bar *wrapped* rather than overflowing until `flex-nowrap` was added — measured at 390px, it went to two rows and 72px at five phases. The scroll only works with all three together (`flex-nowrap` + `overflow-x-auto` + `.no-scrollbar`), and PanelSwitcher's effect centring the active tab is what keeps a scrolled-away tab reachable.
 **Example.** The unlayered `--radius-selector` override at the bottom of `styles.css`. `packages/www/src/styles/global.css` is the minimal working example of the shared-tokens stack; `packages/app/src/styles.css` is the maximal one (adds its own app-only tokens on top).
 
 ## kb serving during dev/build

--- a/packages/app/src/component/panel-switcher/index.tsx
+++ b/packages/app/src/component/panel-switcher/index.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import {Children, isValidElement, PropsWithChildren, ReactElement, Suspense} from "react";
+import {Children, isValidElement, PropsWithChildren, ReactElement, Suspense, useEffect, useRef} from "react";
 import {PropsWithClass} from "@brewdocs.beer/core";
 import {PanelSwitcherContentProps} from "@/component/panel-switcher/content";
 import usePanelSwitcher from "@/component/panel-switcher/usePanelSwitcher";
@@ -21,6 +21,15 @@ export type PanelSwitcherProps = PropsWithChildren & Partial<PropsWithClass> & {
  */
 export default function PanelSwitcher({ name, defaultTab, children, className, compact = false }: PanelSwitcherProps) {
     const [active, change, pending] = usePanelSwitcher(name, defaultTab);
+    const tablistRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const list = tablistRef.current;
+        const tab = list?.querySelector<HTMLElement>("[aria-selected=\"true\"]");
+        if (!list || !tab) return;
+
+        list.scrollTo({ left: Math.max(0, tab.offsetLeft - (list.clientWidth - tab.clientWidth) / 2), behavior: "smooth" });
+    }, [active]);
 
     const panels = Children.toArray(children)
         .filter((child): child is ReactElement<PanelSwitcherContentProps> => isValidElement(child));
@@ -36,9 +45,10 @@ export default function PanelSwitcher({ name, defaultTab, children, className, c
     // fit when actions need room on the same row
     const tablist = (
         <div
+            ref={tablistRef}
             role="tablist"
             className={compact
-                ? "tabs tabs-box tabs-sm w-auto"
+                ? "tabs tabs-box tabs-sm w-auto flex-nowrap overflow-x-auto no-scrollbar snap-x snap-proximity"
                 : classNames("tabs tabs-box", actions ? "w-full" : "mx-2 w-auto")}>
             {panels.map(({ props: { title, label, titleAlt, children: content } }) => (
                 <button
@@ -50,7 +60,7 @@ export default function PanelSwitcher({ name, defaultTab, children, className, c
                     title={titleAlt || (!content ? "Not implemented" : "")}
                     onClick={() => change(title)}
                     className={classNames(
-                        compact ? "tab whitespace-nowrap" : "tab whitespace-nowrap lg:px-3 px-2.5",
+                        compact ? "tab whitespace-nowrap snap-start" : "tab whitespace-nowrap lg:px-3 px-2.5",
                         // daisyui v5 styles the active tab neutral and fades inactive tab
                         // text; restore the v4 primary look and full-strength text
                         // (disabled tabs stay dim)

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -18,3 +18,12 @@
 .dg-collapsed ~ * {
     display: none;
 }
+
+.no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+    display: none;
+}

--- a/packages/e2e/tests/batch-edit.spec.ts
+++ b/packages/e2e/tests/batch-edit.spec.ts
@@ -345,3 +345,36 @@ test("completing a phase puts a marker on the brew timer's live timeline", async
     await expect(markers).toHaveCount(1);
     await expect(page.getByRole("button", {name: /^1\. Mash at /})).toBeVisible();
 });
+
+/**
+ * DaisyUI's `.tabs` is `flex-wrap: wrap`, so before `flex-nowrap` the compact bar
+ * silently grew a second row at five phases (72px at a 390px viewport) instead of
+ * overflowing. Height is the assertion because that is the actual cost — and a
+ * scrolling bar is only an improvement if a scrolled-away tab still comes back,
+ * hence the second half.
+ */
+test("the phase tab bar stays one row on a phone and keeps every tab reachable", async ({page}) => {
+    await page.setViewportSize({width: 390, height: 844});
+    await brewBatchFromKbRecipe(page, "E2E Tab Scroll Batch");
+
+    for (let i = 0; i < 4; i++) {
+        await page.getByRole("tab", {name: "Planning", exact: true}).click();
+        await page.getByRole("tab", {name: "Phases", exact: true}).click();
+        await page.getByLabel("Phase type to add").selectOption("boil");
+        await page.getByRole("button", {name: "Add phase"}).click();
+        await settleSave(page);
+    }
+
+    await page.getByRole("tab", {name: "Brewing", exact: true}).click();
+
+    const bar = page.locator('[role="tablist"]').last();
+    await expect(bar).toHaveCount(1);
+    expect(await bar.evaluate(el => el.getBoundingClientRect().height)).toBeLessThan(56);
+    expect(await bar.evaluate(el => el.scrollWidth > el.clientWidth)).toBe(true);
+
+    // the last tab starts outside the scroll window; selecting it must bring it back
+    const notes = page.getByRole("tab", {name: "Notes", exact: true});
+    await notes.click();
+    await expect(notes).toHaveAttribute("aria-selected", "true");
+    await expect(notes).toBeInViewport();
+});


### PR DESCRIPTION
## Summary

Closes #392

The compact PanelSwitcher tab bar (phase sub-tabs on **Brewing**, and Ingredients/Equipment/Phases on **Planning**) is now a single horizontally-scrolling row instead of a wrapping one.

⚠️ **The premise turned out to be different from expected**, so it's worth stating: DaisyUI's `.tabs` is `flex-wrap: wrap`, so the bar **never overflowed** — it wrapped. Measured at a 390px viewport before the change:

| phases | tabs | rows | bar height | overflows? |
|---|---|---|---|---|
| 3 (default) | 5 | 1 | 40px | no |
| 4 | 6 | 1 | 40px | no |
| **5** | **7** | **2** | **72px** | no |
| 7 | 9 | 2 | 72px | no |

Nothing was clipped or unreachable. The real cost is **vertical space on the screen used most during a brew day**, and it grows as phases are added — carbonation and conditioning are opt-in phases now, so five is a realistic configuration rather than a stress test.

## What changed

- **`panel-switcher/index.tsx`** — the compact tablist gets `flex-nowrap overflow-x-auto no-scrollbar snap-x snap-proximity`, and each compact tab `snap-start`.
- **`styles.css`** — a `.no-scrollbar` utility. A visible horizontal scrollbar inside a 40px bar costs more than it explains, and Tailwind ships no utility for it. All three parts are needed together; drop any one and it either wraps again or shows a scrollbar.
- **PanelSwitcher centres the active tab whenever `active` changes.** Without this, a scrolling bar is *worse* than a wrapping one: the active tab is restored from the query string on load, and completing a phase advances the current phase — either can leave the selection off-screen with nothing to indicate it.

The **non-compact** bar is untouched: its actions overlay is absolutely positioned against the tablist, and its four top-level tabs don't wrap.

## Verification

- `npm test --ws` (eslint) ✓ — 0 errors, 6 pre-existing `design` warnings
- `tsc --noEmit` ✓
- `vite build` ✓
- Playwright **48/48**, including a new test in `batch-edit.spec.ts`

Same measurement after the change, at 390px with 7 phases:

```
{"tabs":9,"rows":1,"height":40,"clientW":358,"scrollW":492,"scrollable":true}
selecting the last tab: scrollLeft 4 -> 134, tab in viewport
```

The new test asserts **height** rather than row count, because height is the actual cost — and asserts a scrolled-away tab returns when selected, since a scroller that loses the selection is a regression, not a fix.

## Note on screenshots

I captured the after-state at 390px but can't attach an image through `gh`; it's been sent to the maintainer directly. The measurement table above is the substantive before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
