### PR TITLE
Add Writer and Security roles, retire Owner for scripted hooks

### DIFF
--- a/.github/agent-bin/close-merged-work.sh
+++ b/.github/agent-bin/close-merged-work.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+issues=$(gh pr view "$PR" --repo "$REPO" --json closingIssuesReferences \
+  --jq '.closingIssuesReferences[].number')
+
+# ⚠️ GitHub only acts on closing keywords when a PR targets the DEFAULT
+# branch. Every sub-issue PR goes into an epic branch instead, so its
+# "Closes #N" is inert and closingIssuesReferences comes back empty — the
+# intent is in the body, GitHub just never linked it. Parse it ourselves.
+if [ -z "$issues" ]; then
+  issues=$(gh pr view "$PR" --repo "$REPO" --json body --jq \
+    '[.body // "" | scan("(?i)(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#([0-9]+)")[]] | unique | .[]')
+  if [ -n "$issues" ]; then
+    echo "No linked issues (non-default base); parsed from the body:" $issues
+  fi
+fi
+
+if [ -z "$issues" ]; then
+  echo "PR #$PR closes no issue — nothing to do."
+  exit 0
+fi
+
+for issue in $issues; do
+  if [ "$(gh issue view "$issue" --repo "$REPO" --json state --jq '.state')" = "OPEN" ]; then
+    gh issue close "$issue" --repo "$REPO" --comment "Completed by #${PR}."
+    echo "Issue #$issue -> closed"
+  fi
+done
+
+if [ -z "${PROJECTS_TOKEN:-}" ]; then
+  echo "::warning::PROJECTS_TOKEN is not set — issues closed, but not moved on the board. Add a classic PAT with the 'project' AND 'read:org' scopes (fine-grained tokens cannot reach user-owned Projects v2)."
+  exit 0
+fi
+
+export GH_TOKEN="$PROJECTS_TOKEN"
+
+# ⚠️ Preflight, so a token problem warns instead of failing a merged PR.
+# `gh project` needs **read:org on top of project**, even for a user-owned
+# project — that is a second gate, separate from the owner-type probe that
+# `--owner "@me"` handles, and its raw error ("missing required scopes
+# [read:org read:discussion]") never mentions which secret is at fault.
+if ! gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --jq '.id' >/dev/null 2>&1; then
+  echo "::warning::PROJECTS_TOKEN cannot reach project $PROJECT_NUMBER — issues were closed, but the board was not updated. \`gh project\` requires the 'read:org' scope in addition to 'project', even for a user-owned project."
+  exit 0
+fi
+
+project_id=$(gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --jq '.id')
+status_field=$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json \
+  --jq '.fields[] | select(.name == "Status")')
+field_id=$(echo "$status_field" | jq -r '.id')
+done_id=$(echo "$status_field" | jq -r '(.options // [])[] | select(.name == "Done") | .id')
+
+if [ -z "$done_id" ] || [ "$done_id" = "null" ]; then
+  echo "::warning::Project $PROJECT_NUMBER has no Status option named 'Done' — skipping the board update."
+  exit 0
+fi
+
+items=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500)
+
+for issue in $issues; do
+  item_id=$(echo "$items" | jq -r --argjson n "$issue" \
+    'first(.items[] | select(.content.type == "Issue" and .content.number == $n) | .id) // empty')
+  if [ -z "$item_id" ]; then
+    echo "::warning::Issue #$issue is not on project $PROJECT_NUMBER — skipping."
+    continue
+  fi
+  gh project item-edit --id "$item_id" --project-id "$project_id" \
+    --field-id "$field_id" --single-select-option-id "$done_id"
+  echo "Issue #$issue -> Done"
+done

--- a/.github/agent-bin/file-sub-issues.sh
+++ b/.github/agent-bin/file-sub-issues.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest=$(gh api "repos/$REPO/issues/$ISSUE/comments" --paginate \
+  --jq '[.[] | select(.body | contains("owner-manifest")) | .body] | last // empty')
+
+if [ -z "$manifest" ]; then
+  echo "No owner-manifest on #$ISSUE — nothing to file."
+  exit 0
+fi
+
+# one line on purpose: a python heredoc indented inside this YAML block would
+# arrive with its leading spaces intact and die on IndentationError
+payload=$(printf '%s' "$manifest" | python3 -c 'import sys,re; m=re.search(r"owner-manifest\s*(\{.*?\})\s*-->", sys.stdin.read(), re.S); print(m.group(1) if m else "")')
+
+if [ -z "$payload" ]; then
+  echo "::warning::#$ISSUE has an owner-manifest marker whose JSON could not be parsed — leaving it alone."
+  exit 0
+fi
+
+epic=$(printf '%s' "$payload" | jq -r '.epic')
+children=$(printf '%s' "$payload" | jq -r '(.children // [])[]')
+
+if [ -z "$children" ]; then
+  echo "Manifest on #$ISSUE lists no children — nothing to file."
+  exit 0
+fi
+
+milestone=$(gh issue view "$epic" --repo "$REPO" --json milestone --jq '.milestone.title // empty')
+existing=" $(gh api "repos/$REPO/issues/$epic/sub_issues" --jq '[.[].number] | join(" ")' 2>/dev/null || true) "
+
+for child in $children; do
+  if [ "${existing#* $child }" != "$existing" ]; then
+    echo "#$child already a sub-issue of #$epic"
+  else
+    # ⚠️ this API wants the child's integer REST id, not its issue number
+    cid=$(gh api "repos/$REPO/issues/$child" --jq .id)
+    if gh api --method POST "repos/$REPO/issues/$epic/sub_issues" -F sub_issue_id="$cid" >/dev/null 2>&1; then
+      echo "#$child -> sub-issue of #$epic"
+    else
+      echo "::warning::could not parent #$child to #$epic"
+    fi
+  fi
+
+  if [ -n "$milestone" ]; then
+    if gh issue edit "$child" --repo "$REPO" --milestone "$milestone" >/dev/null 2>&1; then
+      echo "#$child -> milestone $milestone"
+    else
+      echo "::warning::could not set milestone '$milestone' on #$child"
+    fi
+  fi
+done

--- a/.github/agent-bin/stamp-role-label.sh
+++ b/.github/agent-bin/stamp-role-label.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Pre-hook for every role. Stamps @claude/<role> on the issue or PR that triggered
+# the run, so the labels read as "these agents have been here".
+#
+# Deterministic on purpose: this used to be an instruction in each prompt, which
+# cost a model turn and could simply be skipped. A label the maintainer clears as
+# a check-off is worth nothing if a run can forget to apply it.
+set -euo pipefail
+
+: "${ROLE:?ROLE is required}"
+: "${REPO:?REPO is required}"
+
+if [ -z "${NUMBER:-}" ]; then
+    echo "No issue or PR number on this event — nothing to stamp."
+    exit 0
+fi
+
+# the /labels endpoint serves pull requests too; a repeat add is a no-op
+if gh api "repos/$REPO/issues/$NUMBER/labels" -f "labels[]=@claude/$ROLE" >/dev/null 2>&1; then
+    echo "#$NUMBER -> @claude/$ROLE"
+else
+    echo "::warning::could not stamp @claude/$ROLE on #$NUMBER — does the label exist in this repo?"
+fi

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -1,34 +1,34 @@
 name: Claude
-# The history entry names the role that actually ran. Read off the triggering comment,
-# since that is what routes now.
-run-name: "Claude · ${{ github.event_name == 'pull_request' && 'Owner · merge' || contains(github.event.comment.body || github.event.review.body, '@claude/manager') && 'Manager' || contains(github.event.comment.body || github.event.review.body, '@claude/researcher') && 'Researcher' || contains(github.event.comment.body || github.event.review.body, '@claude/tester') && 'Tester' || contains(github.event.comment.body || github.event.review.body, '@claude/implementor') && 'Implementor' || 'Owner' }} #${{ github.event.issue.number || github.event.pull_request.number }}"
+run-name: "Claude · ${{ github.event_name == 'pull_request' && 'merge hooks' || contains(github.event.comment.body || github.event.review.body, '@claude/manager') && 'Manager' || contains(github.event.comment.body || github.event.review.body, '@claude/researcher') && 'Researcher' || contains(github.event.comment.body || github.event.review.body, '@claude/tester') && 'Tester' || contains(github.event.comment.body || github.event.review.body, '@claude/writer') && 'Writer' || 'Implementor' }} #${{ github.event.issue.number || github.event.pull_request.number }}"
 
-# FIVE ROLES, ONE WORKFLOW. Manager / Researcher / Implementor / Tester / Owner are jobs
+# SIX ROLES, ONE WORKFLOW. Manager / Researcher / Implementor / Tester / Writer are jobs
 # here rather than separate files to keep the Actions history readable: the role is picked
 # by a job-level `if:`, so it is one run per comment with the unselected roles skipping
-# inside it.
+# inside it. Security is the sixth and runs on merge, not on a comment.
 #
-# ⚠️ THE HANDLE IN THE COMMENT ROUTES. Not labels — labels no longer trigger or route
-# anything at all. You start a role by naming it:
+# ⚠️ THE HANDLE IN THE COMMENT ROUTES. Not labels.
 #
 #   "@claude/manager ..."      -> Manager      (issues only — it shapes an epic)
 #   "@claude/researcher ..."   -> Researcher   (issues only — it decomposes an epic)
 #   "@claude/implementor ..."  -> Implementor  (issue or PR)
 #   "@claude/tester ..."       -> Tester       (issue or PR)
-#   "@claude/owner ..."        -> Owner        (issue or PR)
+#   "@claude/writer ..."       -> Writer       (issue or PR)
 #
-# ⚠️ A BARE "@claude" DOES NOTHING. It is not a fallback to any role — that is deliberate,
-# so a half-typed handle can never start the wrong agent. Name the role you want.
+# ⚠️ A BARE "@claude" DOES NOTHING, deliberately, so a half-typed handle cannot start the
+# wrong agent. Labels trigger nothing either — `on.issues` is not subscribed.
 #
-# ⚠️ LABELS ARE NOW A RECORD, NOT A ROUTE. Each role stamps its own `@claude/<role>` label
-# on the issue or PR as it starts, so the labels read as "these agents have run here". The
-# maintainer clears them as a check-off; only the Owner ever removes one, and only on
-# request.
+# ⚠️ BACKLOG WORK IS SCRIPTED, NOT PROMPTED. Every role carries hard-coded hooks around
+# its model step, in `.github/agent-bin/`:
 #
-# The Owner is the exception to one-role-per-event: it also runs AFTER whichever role a
-# comment started (via `needs` + `always()`), and after a merged PR. It is the backlog
-# agent — links, parents, milestones, board. It is not a blanket trigger: if no role ran
-# and nothing merged, the Owner does not run either.
+#   pre   every role   stamp-role-label.sh    stamps @claude/<role> on the issue or PR
+#   post  researcher   file-sub-issues.sh     parents + milestones from the epic's manifest
+#   merge (no role)    close-merged-work.sh   closes the PR's issues, files them on the board
+#
+# These used to be prompt instructions, and a model could skip them — the label trail is
+# worthless if a run can forget to stamp it. They cost no turns and cannot be forgotten.
+# `close-merged-work.sh` is also the only place PROJECTS_TOKEN appears: it is a long-lived
+# classic PAT covering every project the maintainer owns, and secret masking covers logs
+# only, so it stays out of any environment a prompt can read.
 on:
   issue_comment:
     types: [created]
@@ -77,6 +77,13 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       # No `npm ci`: the Manager reads code to shape the epic, it doesn't build.
+      - name: Stamp the role label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLE: manager
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: .github/agent-bin/stamp-role-label.sh
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -142,15 +149,6 @@ jobs:
             and Implementor's job once the maintainer hands off by relabelling the issue
             `@claude/researcher` and commenting.
 
-            **Stamp your label first.** Before anything else, add your own role label to
-            the issue or PR that triggered you:
-
-                gh api repos/$GITHUB_REPOSITORY/issues/<number>/labels -f "labels[]=@claude/manager"
-
-            That endpoint works for pull requests too. Labels no longer route anything —
-            they are a record of which roles have run, which the maintainer clears as a
-            check-off. Add **only your own**, never another role's, and never remove one:
-            pruning is the Owner's job.
 
             Operational notes: dependencies are NOT installed and you don't need them —
             don't run `npm ci`/`npm install` or the build. Run one command per Bash call
@@ -187,6 +185,13 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       # No `npm ci`: the Researcher reads code and files issues, it doesn't build.
+      - name: Stamp the role label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLE: researcher
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: .github/agent-bin/stamp-role-label.sh
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -263,12 +268,12 @@ jobs:
               ⚠️ **Name the epic number in that line, every time.** The Implementor opens the
               epic's integration PR the first time it finds one missing, and it needs the
               number to write `Closes #<epic>`. It only ever sees the sub-issue.
-            - ⚠️ **Don't link, parent, or milestone anything — that is the Owner's job.**
+            - ⚠️ **Don't link, parent, or milestone anything — a script does it.**
               You create the issues and nothing else about the backlog: no `sub_issues` API
-              calls, no `--milestone`, no project edits. The **Owner** runs straight after
-              you and does all of it, and it works from your index comment (below), so that
-              comment is the handoff, not a summary. Doing it yourself duplicates work and
-              causes the two of you to fight over the same fields.
+              calls, no `--milestone`, no project edits. A post-hook runs the moment you
+              finish and does all of it from the manifest you leave (below), so that
+              manifest is the handoff, not a decoration. Doing it yourself duplicates work
+              and makes the two of you fight over the same fields.
             - Don't give any sub-issue the job of opening the epic's integration PR. The
               Implementor now opens it on the **first** run that finds it missing, so it
               exists from the start of the epic and the maintainer can watch the feature
@@ -285,7 +290,7 @@ jobs:
                   {"epic": 246, "children": [346, 347]}
                   -->
 
-              An HTML comment, so it is invisible in the rendered issue. The Owner files the
+              An HTML comment, so it is invisible in the rendered issue. The post-hook files the
               sub-issues from **this**, not from your prose — a script reads it, with no
               model involved, which is why it has to be exact. Keep the human-readable list
               above it as well; that is what the maintainer reads.
@@ -315,15 +320,6 @@ jobs:
             them **unlabeled**; a role label is a record of a role having *run*, so it never
             belongs on an issue you just created.
 
-            **Stamp your label first.** Before anything else, add your own role label to
-            the issue or PR that triggered you:
-
-                gh api repos/$GITHUB_REPOSITORY/issues/<number>/labels -f "labels[]=@claude/researcher"
-
-            That endpoint works for pull requests too. Labels no longer route anything —
-            they are a record of which roles have run, which the maintainer clears as a
-            check-off. Add **only your own**, never another role's, and never remove one:
-            pruning is the Owner's job.
 
             Operational notes: dependencies are NOT installed and you don't need them —
             don't run `npm ci`/`install` or the build. Run one command per Bash call
@@ -333,6 +329,14 @@ jobs:
             --model sonnet
             --allowedTools "Read,Edit,Write,Bash(gh:*),Bash(git:*)"
             --max-turns 80
+
+      - name: File the epic's sub-issues
+        if: always() && github.event_name == 'issue_comment' && !github.event.issue.pull_request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: .github/agent-bin/file-sub-issues.sh
 
   # ── Implementor ────────────────────────────────────────────────────────────────
   # The main engineer. Executes issues and handles follow-up engineering (bug fixes,
@@ -369,6 +373,13 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - run: npm ci
+      - name: Stamp the role label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLE: implementor
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: .github/agent-bin/stamp-role-label.sh
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -534,6 +545,16 @@ jobs:
             If your change needs no test, say that and why — an explicit "no test needed"
             is a useful answer, a silent omission isn't.
 
+            End the Handoff with a **Docs notes** section as well, for the **Writer**. You no
+            longer edit `CLAUDE.md`; you say what it should record and why:
+
+            - The invariant a future reader would otherwise break, and what breaks.
+            - Anything that surprised you or cost you time — a gotcha nobody wrote down is
+              one everybody rediscovers.
+            - Which `CLAUDE.md` it belongs in, if you know.
+            - "Nothing to document" is a valid answer. Say it rather than leaving the
+              section off.
+
             A denied tool call is settled. The permission layer is policy, not a syntax
             problem, so rewording or re-quoting the same operation will be denied
             identically — you are spending turns to learn nothing. Note what you couldn't
@@ -566,13 +587,14 @@ jobs:
             epic**. That one line is the whole of your backlog obligation, and it matters
             more than it looks: GitHub only acts on closing keywords when a PR targets the
             **default** branch, and yours targets the epic's integration branch, so GitHub
-            ignores it entirely. The **Owner** parses it out of your body to close the
+            ignores it entirely. The merge hook parses it out of your body to close the
             issue, link it, and file it on the board. Get the number wrong and the work is
             filed against the wrong issue.
 
             ⚠️ **Do no other backlog management.** Don't comment on the issue, don't set a
-            milestone, don't touch parents, sub-issues or the project board — the Owner runs
-            straight after you and owns all of it. Your deliverable is code and a PR.
+            milestone, don't touch parents, sub-issues or the project board — scripted hooks
+            own all of it. ⚠️ **Don't edit any `CLAUDE.md` either** — documentation belongs to
+            the **Writer**. Your deliverable is code and a PR.
 
             Keep your task checklist to at most 3-5 coarse, outcome-level items ("Add the
             version field to the models", not one line per file). Group related edits under
@@ -582,15 +604,6 @@ jobs:
 
             Never merge the PR. The maintainer merges.
 
-            **Stamp your label first.** Before anything else, add your own role label to
-            the issue or PR that triggered you:
-
-                gh api repos/$GITHUB_REPOSITORY/issues/<number>/labels -f "labels[]=@claude/implementor"
-
-            That endpoint works for pull requests too. Labels no longer route anything —
-            they are a record of which roles have run, which the maintainer clears as a
-            check-off. Add **only your own**, never another role's, and never remove one:
-            pruning is the Owner's job.
           # Allowlist by *family*, not per-subcommand. Deliberately NOT bare `Bash`: this
           # runner carries GH_TOKEN and the Claude OAuth token in env, and arbitrary shell
           # could exfiltrate them. Only write-access actors can trigger a run (see the `if:`
@@ -634,6 +647,13 @@ jobs:
       # Browser install as a workflow step, not a Claude turn. Without it the Tester can
       # write specs but never run them, and an unrun test is worse than no test.
       - run: npx playwright install --with-deps chromium
+      - name: Stamp the role label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLE: tester
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: .github/agent-bin/stamp-role-label.sh
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -719,321 +739,213 @@ jobs:
             turn to narrate back.
 
             Never merge a PR. Leave anything you create unlabeled, and do no backlog
-            management — no linking, milestones or project edits; the Owner owns that.
+            management — no linking, milestones or project edits; scripted hooks own that.
+            ⚠️ **Don't edit any `CLAUDE.md`** — documentation belongs to the **Writer**.
 
-            **Stamp your label first.** Before anything else, add your own role label to
-            the issue or PR that triggered you:
-
-                gh api repos/$GITHUB_REPOSITORY/issues/<number>/labels -f "labels[]=@claude/tester"
-
-            That endpoint works for pull requests too. Labels no longer route anything —
-            they are a record of which roles have run, which the maintainer clears as a
-            check-off. Add **only your own**, never another role's, and never remove one:
-            pruning is the Owner's job.
           claude_args: |
             --model sonnet
             --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
             --max-turns 80
 
-  # ── Owner ──────────────────────────────────────────────────────────────────────
-  # The backlog agent. Two ways in:
-  #   • summoned directly with "@claude/owner ..." to do backlog work you ask for
-  #   • automatically AFTER whichever role a comment started (needs + always()), and
-  #     after a merged PR — so every run leaves the backlog tidy without being asked
-  # It is not a blanket trigger: no role ran and no merge happened means no Owner.
+  # ── Writer ─────────────────────────────────────────────────────────────────────
+  # The tech writer. Owns documentation: every CLAUDE.md, the agent instruction files
+  # under .claude/skills, and anything else whose job is to explain rather than run.
   #
-  # ⚠️ It runs LAST on purpose. The whole point is to file work that already exists —
-  # link the PR the Implementor just opened, parent the sub-issues the Researcher just
-  # created. Running alongside them would race work that isn't there yet.
-  #
-  # ⚠️ The deterministic part stays a SCRIPT, not a model turn. "Parse the closing
-  # keyword, close the issue, set one field" is fully determined, and it is what the
-  # merged-PR path depends on — so it runs as its own step before Claude starts, and
-  # Claude handles only the judgment work (parenting, milestones, reconciling, pruning).
-  owner:
-    needs: [manager, researcher, implementor, tester]
+  # ⚠️ Split out because CLAUDE.md was the single biggest source of merge conflicts —
+  # every role edited it, so two branches touching the same package collided on prose
+  # neither of them was really working on. Implementor and Tester now report what needs
+  # documenting in their handoff and change no docs themselves.
+  writer:
     if: |
-      always()
-      && github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]'
-      && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude/owner')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude/owner')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/owner')) ||
-        needs.manager.result != 'skipped' ||
-        needs.researcher.result != 'skipped' ||
-        needs.implementor.result != 'skipped' ||
-        needs.tester.result != 'skipped' ||
-        (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+      github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude/writer')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude/writer')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/writer'))
       )
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      issues: write
+      contents: write
       pull-requests: write
+      issues: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - name: File the epic's sub-issues (deterministic)
-        # The automatic pass runs NO model. Parenting and milestoning are fully determined
-        # once you know (epic, children), and the Researcher now states both in a manifest
-        # rather than leaving them to be recovered from prose. This is why the quiet
-        # majority of Owner passes cost seconds instead of minutes.
-        if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
+        with:
+          fetch-depth: 0
+      - name: Stamp the role label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLE: writer
           REPO: ${{ github.repository }}
-          ISSUE: ${{ github.event.issue.number }}
-        run: |
-          set -euo pipefail
-
-          manifest=$(gh api "repos/$REPO/issues/$ISSUE/comments" --paginate \
-            --jq '[.[] | select(.body | contains("owner-manifest")) | .body] | last // empty')
-
-          if [ -z "$manifest" ]; then
-            echo "No owner-manifest on #$ISSUE — nothing to file."
-            exit 0
-          fi
-
-          # one line on purpose: a python heredoc indented inside this YAML block would
-          # arrive with its leading spaces intact and die on IndentationError
-          payload=$(printf '%s' "$manifest" | python3 -c 'import sys,re; m=re.search(r"owner-manifest\s*(\{.*?\})\s*-->", sys.stdin.read(), re.S); print(m.group(1) if m else "")')
-
-          if [ -z "$payload" ]; then
-            echo "::warning::#$ISSUE has an owner-manifest marker whose JSON could not be parsed — leaving it alone."
-            exit 0
-          fi
-
-          epic=$(printf '%s' "$payload" | jq -r '.epic')
-          children=$(printf '%s' "$payload" | jq -r '(.children // [])[]')
-
-          if [ -z "$children" ]; then
-            echo "Manifest on #$ISSUE lists no children — nothing to file."
-            exit 0
-          fi
-
-          milestone=$(gh issue view "$epic" --repo "$REPO" --json milestone --jq '.milestone.title // empty')
-          existing=" $(gh api "repos/$REPO/issues/$epic/sub_issues" --jq '[.[].number] | join(" ")' 2>/dev/null || true) "
-
-          for child in $children; do
-            if [ "${existing#* $child }" != "$existing" ]; then
-              echo "#$child already a sub-issue of #$epic"
-            else
-              # ⚠️ this API wants the child's integer REST id, not its issue number
-              cid=$(gh api "repos/$REPO/issues/$child" --jq .id)
-              if gh api --method POST "repos/$REPO/issues/$epic/sub_issues" -F sub_issue_id="$cid" >/dev/null 2>&1; then
-                echo "#$child -> sub-issue of #$epic"
-              else
-                echo "::warning::could not parent #$child to #$epic"
-              fi
-            fi
-
-            if [ -n "$milestone" ]; then
-              if gh issue edit "$child" --repo "$REPO" --milestone "$milestone" >/dev/null 2>&1; then
-                echo "#$child -> milestone $milestone"
-              else
-                echo "::warning::could not set milestone '$milestone' on #$child"
-              fi
-            fi
-          done
-
-      - name: File merged work (deterministic)
-        if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
-        env:
-          # Two tokens on purpose. The built-in GITHUB_TOKEN reads the PR and closes
-          # issues; PROJECTS_TOKEN is a classic PAT that exists only because it can
-          # reach user-owned Projects v2. Keeping them separate means that PAT needs
-          # the `project` scope and nothing else — no `repo`, no write on this repo.
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-          # `@me`, not the literal login: `gh project` otherwise probes whether the
-          # owner is a user or an org, which needs `read:org` that a project-only PAT
-          # lacks, and fails with a bare "unknown owner type".
-          PROJECT_OWNER: "@me"
-          PROJECT_NUMBER: "4"
-        run: |
-          set -euo pipefail
-
-          issues=$(gh pr view "$PR" --repo "$REPO" --json closingIssuesReferences \
-            --jq '.closingIssuesReferences[].number')
-
-          # ⚠️ GitHub only acts on closing keywords when a PR targets the DEFAULT
-          # branch. Every sub-issue PR goes into an epic branch instead, so its
-          # "Closes #N" is inert and closingIssuesReferences comes back empty — the
-          # intent is in the body, GitHub just never linked it. Parse it ourselves.
-          if [ -z "$issues" ]; then
-            issues=$(gh pr view "$PR" --repo "$REPO" --json body --jq \
-              '[.body // "" | scan("(?i)(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#([0-9]+)")[]] | unique | .[]')
-            if [ -n "$issues" ]; then
-              echo "No linked issues (non-default base); parsed from the body:" $issues
-            fi
-          fi
-
-          if [ -z "$issues" ]; then
-            echo "PR #$PR closes no issue — nothing to do."
-            exit 0
-          fi
-
-          for issue in $issues; do
-            if [ "$(gh issue view "$issue" --repo "$REPO" --json state --jq '.state')" = "OPEN" ]; then
-              gh issue close "$issue" --repo "$REPO" --comment "Completed by #${PR}."
-              echo "Issue #$issue -> closed"
-            fi
-          done
-
-          if [ -z "${PROJECTS_TOKEN:-}" ]; then
-            echo "::warning::PROJECTS_TOKEN is not set — issues closed, but not moved on the board. Add a classic PAT with the 'project' AND 'read:org' scopes (fine-grained tokens cannot reach user-owned Projects v2)."
-            exit 0
-          fi
-
-          export GH_TOKEN="$PROJECTS_TOKEN"
-
-          # ⚠️ Preflight, so a token problem warns instead of failing a merged PR.
-          # `gh project` needs **read:org on top of project**, even for a user-owned
-          # project — that is a second gate, separate from the owner-type probe that
-          # `--owner "@me"` handles, and its raw error ("missing required scopes
-          # [read:org read:discussion]") never mentions which secret is at fault.
-          if ! gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --jq '.id' >/dev/null 2>&1; then
-            echo "::warning::PROJECTS_TOKEN cannot reach project $PROJECT_NUMBER — issues were closed, but the board was not updated. \`gh project\` requires the 'read:org' scope in addition to 'project', even for a user-owned project."
-            exit 0
-          fi
-
-          project_id=$(gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --jq '.id')
-          status_field=$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json \
-            --jq '.fields[] | select(.name == "Status")')
-          field_id=$(echo "$status_field" | jq -r '.id')
-          done_id=$(echo "$status_field" | jq -r '(.options // [])[] | select(.name == "Done") | .id')
-
-          if [ -z "$done_id" ] || [ "$done_id" = "null" ]; then
-            echo "::warning::Project $PROJECT_NUMBER has no Status option named 'Done' — skipping the board update."
-            exit 0
-          fi
-
-          items=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500)
-
-          for issue in $issues; do
-            item_id=$(echo "$items" | jq -r --argjson n "$issue" \
-              'first(.items[] | select(.content.type == "Issue" and .content.number == $n) | .id) // empty')
-            if [ -z "$item_id" ]; then
-              echo "::warning::Issue #$issue is not on project $PROJECT_NUMBER — skipping."
-              continue
-            fi
-            gh project item-edit --id "$item_id" --project-id "$project_id" \
-              --field-id "$field_id" --single-select-option-id "$done_id"
-            echo "Issue #$issue -> Done"
-          done
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: .github/agent-bin/stamp-role-label.sh
       - uses: anthropics/claude-code-action@v1
-        # ⚠️ SUMMONED ONLY. The automatic pass is handled entirely by the scripted steps
-        # above, so it never starts a model — that pass used to cost ~2.5 min of model time
-        # on every single interaction, almost always to conclude there was nothing to do.
-        if: |
-          contains(github.event.comment.body, '@claude/owner')
-          || contains(github.event.review.body, '@claude/owner')
-        # ⚠️ PROJECTS_TOKEN is deliberately NOT in this step's env. Secret masking covers
-        # *logs* only, and a model holding `Bash(gh:*)` can run
-        # `gh issue comment N --body "$PROJECTS_TOKEN"` — that passes the allowlist and
-        # publishes the value unredacted, where masking does not reach. The PAT is
-        # long-lived and reaches every project the maintainer owns, so it stays in the
-        # scripted steps above, which are not model-controlled.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # ⚠️ No track_progress: the Owner is told to stay quiet on its automatic pass,
-          # and a tracking comment on every run would be noise.
-          #
-          # ⚠️ `@claude/` — the PREFIX, not a whole handle. The action picks its mode from
-          # the *event type*, and `issue_comment` is always tag mode, so it gates on this
-          # phrase no matter what we do; dropping track_progress does not buy agent mode.
-          # The Owner has to fire both when summoned (`@claude/owner`) and on its automatic
-          # pass, where the comment names a *different* role — and every one of those
-          # comments contains `@claude/`. Our `if:` still decides whether the job runs at
-          # all; this only has to stop the action skipping itself once it does.
-          trigger_phrase: "@claude/"
+          track_progress: true
+          trigger_phrase: "@claude/writer"
           prompt: |
-            You are the **Owner** — the maintainer's backlog agent. You own how work is
-            *filed*: issue links, parent/sub-issue relationships, milestones, labels and the
-            project board. No other role touches any of that any more; they create issues,
-            code and PRs, and leave the filing to you.
+            You are the **Writer** — the technical writer. You own the repo's documentation:
+            every `CLAUDE.md`, the agent instruction files under `.claude/skills/`, and any
+            other file whose job is to explain rather than to run. No other role edits them.
 
-            **You only run when summoned.** The comment that triggered you contains
-            `@claude/owner`, and it is an instruction from the maintainer — read it and do
-            what it asks. There is no automatic pass any more: routine filing (parenting
-            sub-issues to their epic and putting them on its milestone) is done by a script
-            before you start, from the manifest the Researcher leaves on the epic. So don't
-            redo it, and don't assume it was skipped — check before acting.
+            You are triggered by someone writing **`@claude/writer`** in a comment, on an
+            issue or a PR. Read that comment first: it is the instruction.
 
-            That also means your work is the part a script can't do: what the maintainer
-            asked for, and anything that looks *wrong* rather than merely unfiled.
+            **Where your work comes from.** Usually an Implementor or Tester PR whose handoff
+            ends with **Docs notes** — what they learned that a future reader would otherwise
+            rediscover. Start there (`gh pr view <number> --comments`), then read the diff
+            for what actually changed. If the notes are thin, say so and document what you
+            can verify from the code; don't invent rationale nobody stated.
 
-            **If you were summoned, stamp your label:**
+            ⚠️ **Write only what is true of the code as it stands.** Every path, symbol and
+            behaviour you describe must be one you have opened and checked. A confident
+            sentence about a function that moved is worse than no sentence — it is believed
+            and not re-checked.
 
-                gh api repos/$GITHUB_REPOSITORY/issues/<number>/labels -f "labels[]=@claude/owner"
+            **House style — these files are read under pressure, mid-task.**
 
-            Only when summoned. On the automatic tidy pass you run after almost everything,
-            so stamping there would put your label on every issue and PR in the repo and
-            tell the maintainer nothing.
+            - **Tight.** Cut every word that does not change what a reader would do. Prefer
+              the shortest phrasing that stays precise; do not pad to sound thorough.
+            - ⚠️ **Lists go on multiple lines, one item per line.** Never grow a paragraph by
+              appending another clause to it. This is both a readability rule and a merge
+              rule: a paragraph everyone appends to conflicts on every parallel branch, and
+              `packages/design/CLAUDE.md`'s Surface field collided in **four consecutive**
+              epic merges before it was split into one bullet per component.
+            - **A new thing gets a new line**, never an extension of an existing one.
+            - Keep the ⚠️ marker for what is genuinely easy to get wrong — it loses its force
+              if everything carries one.
+            - Say *why*, not *what*. The code already says what.
 
-            **What filing means here.** Only do the ones that actually apply:
+            The repo-root `CLAUDE.md` explains the _Legend_ of field labels every package
+            file follows; keep to it.
 
-            - **Parent sub-issues to their epic** — normally already done by the script,
-              from the `<!-- owner-manifest ... -->` block on the epic. Do it by hand only
-              when that manifest is missing or wrong (say so if it is, so the Researcher's
-              prompt can be fixed). For each child:
+            Follow the Contributing section for branch naming, commits and the PR template.
+            Open a PR — ⚠️ against the issue's stated **Base branch** if it names one, else
+            `mainline`.
 
-                  gh api repos/$GITHUB_REPOSITORY/issues/<child-number> --jq .id
-                  gh api --method POST repos/$GITHUB_REPOSITORY/issues/<epic-number>/sub_issues -F sub_issue_id=<that-id>
+            ⚠️ **Documentation only.** You do not change application code, tests, or
+            workflows. If documenting something reveals a bug, say so in a comment and leave
+            it — that is a finding for the maintainer to route, not yours to fix.
 
-              ⚠️ That API wants the child's integer REST id, **not** its issue number. If it
-              is unavailable, put a `Part of #<epic>` line in the child body instead and say
-              so.
-            - **Propagate the epic's milestone to its sub-issues** — again, normally the
-              script's job; do it by hand only if it did not happen. Read the epic's with
-              `gh issue view <epic> --json milestone --jq '.milestone.title // empty'` and
-              apply it with `gh issue edit <child> --milestone "<title>"`. ⚠️ If the epic has
-              no milestone, its children get none either — **never invent or create one**.
-              Which milestone work belongs to is the maintainer's call, and a guessed one
-              silently misreports release scope.
-            - **Link a PR to the issue it finishes.** An Implementor PR carries
-              `Closes #<issue>` in its body, and GitHub ignores it because the PR targets an
-              epic branch rather than the default branch. Comment on that issue naming the
-              PR, so a human reading the issue can find the work.
-            - ⚠️ **Check that an epic's integration PR closes only its epic.** That PR
-              targets `mainline`, so every closing keyword in it is live, and a sub-PR index
-              written as "· closes #341" silently attaches the sub-issue to the *epic's* PR:
+            Dependencies are NOT installed and you do not need them — never run
+            `npm ci`/`install` or a build. Run one command per Bash call (chaining trips the
+            permission check). A denied tool call is settled — note it and move on. Use
+            Read/Edit/Write for file contents rather than shelling out.
 
-                  gh pr view <pr> --json closingIssuesReferences
-
-              If anything other than the epic shows up, edit the body to neuter the stray
-              keyword ("closes #341" → "for #341") and say what you changed. A sub-issue is
-              closed by its own PR, never by the epic's.
-            - ⚠️ **You cannot change the project board, by design.** The token that reaches
-              it is deliberately kept out of your environment — it is long-lived and covers
-              every project the maintainer owns, and a role that can run `gh` could publish
-              it in a comment, where log masking does not reach. Board changes happen in the
-              scripted steps that run before you, on merge. If something on the board looks
-              wrong, **say so in your comment** and leave it; don't attempt a `gh project`
-              call and don't report the refusal as a failure — this is the intended
-              boundary, not a missing permission.
-            - **Prune role labels when asked.** `@claude/<role>` labels are a record of which
-              roles have *run*, and the maintainer clears them as a check-off. Remove them
-              only when the maintainer asks you to — they are their read of what has
-              happened, so clearing them unasked destroys information.
-
-            **Boundaries.** You never write application code, never open a code PR, and never
-            merge anything. You never close an issue whose work has not actually landed —
-            a merged PR is evidence, an open one is not. You do not create milestones or
-            projects. If something looks wrong rather than merely unfiled — a PR closing an
-            issue that another PR already closed, a sub-issue on a different epic's
-            milestone — say so in a comment and leave it; the maintainer decides.
-
-            Operational notes: dependencies are NOT installed and you do not need them —
-            never run `npm ci`/`install` or a build. Run one command per Bash call (chaining
-            with `&&`/`;` trips the permission check). A denied tool call is settled — note
-            it and move on. Keep any comment you post short; you run after most other roles,
-            so verbosity here is multiplied across every run.
+            Keep your task checklist to 3-5 coarse items. Never merge a PR.
           claude_args: |
             --model sonnet
-            --allowedTools "Read,Bash(gh:*)"
+            --allowedTools "Read,Edit,Write,Bash(git:*),Bash(gh:*)"
+            --max-turns 60
+
+  # ── Security ───────────────────────────────────────────────────────────────────
+  # Reviews what just landed on mainline and files issues for what it finds. Runs on
+  # merge rather than on the PR, deliberately: a review that blocks a merge gets
+  # argued with, a review that files an issue gets triaged.
+  #
+  # ⚠️ It opens issues and nothing else — no code, no PRs, no merges.
+  security:
+    if: |
+      github.event_name == 'pull_request'
+      && github.event.pull_request.merged == true
+      && github.event.pull_request.base.ref == 'mainline'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            You are the **Security** reviewer. A pull request just merged into `mainline`.
+            Review **what it changed** and file an issue for anything genuinely unsafe.
+
+            Start with the diff — `gh pr diff ${{ github.event.pull_request.number }}` — and
+            read the files it touches. Review the change, not the whole repo.
+
+            **What matters here.** This is an offline-first PWA with no backend of its own
+            and no user accounts, so weight findings accordingly:
+
+            - **Secrets and tokens** — anything committed, logged, or placed where a model or
+              a comment could echo it. A workflow that puts a long-lived credential within
+              reach of a prompt is a real finding; the built-in `GITHUB_TOKEN` scoped to one
+              run is not.
+            - **Workflow and supply chain** — a permission widened past what a job needs, an
+              allowlist loosened to a wildcard, an unpinned or newly-added action, a script
+              that interpolates untrusted input into a shell command.
+            - **Injection reaching the DOM** — `dangerouslySetInnerHTML`, `eval`, building
+              markup from stored or fetched strings.
+            - **Stored data** — anything that widens what leaves the device, or writes
+              somewhere a user cannot clear.
+
+            ⚠️ **File only what you can point at.** Every issue names the file, the line, and
+            what an attacker actually does with it. If you cannot describe the exploit
+            concretely, it is not a finding — say the review was clean instead.
+
+            ⚠️ **A clean review posts nothing.** No issue, no comment. This runs on every
+            merge to `mainline`, so a routine "no problems found" note would be noise on
+            every single one.
+
+            When you do file, use `gh issue create` — **unlabeled** — with the
+            `.github/ISSUE_TEMPLATE/claude-task.yml` headings, one issue per finding, and
+            `Base branch: mainline`. Say plainly in the Summary which PR introduced it and
+            how severe it is; a maintainer triaging a queue needs that first.
+
+            Then add each to the project:
+            `gh project item-add 4 --owner "@me" --url <issue-url>`.
+
+            Do not change code, open a PR, or comment on the merged PR. Dependencies are NOT
+            installed — never run `npm ci`/`install` or a build. Run one command per Bash
+            call. A denied tool call is settled — note it and move on.
+          claude_args: |
+            --model sonnet
+            --allowedTools "Read,Bash(git:*),Bash(gh:*)"
             --max-turns 40
+
+  # ── Merge housekeeping ─────────────────────────────────────────────────────────
+  # Closes the issues a merged PR finished and files them on the board.
+  #
+  # ⚠️ NO MODEL. "Parse the closing keyword, close the issue, set one field" is fully
+  # determined, and this is the only backlog behaviour that has worked from its first
+  # run — everything model-driven took three attempts. It is also why PROJECTS_TOKEN
+  # lives here and nowhere a prompt can reach it.
+  merge_housekeeping:
+    if: |
+      github.event_name == 'pull_request'
+      && github.event.pull_request.merged == true
+      && (contains(github.event.pull_request.labels.*.name, '@claude/manager')
+        || contains(github.event.pull_request.labels.*.name, '@claude/researcher')
+        || contains(github.event.pull_request.labels.*.name, '@claude/implementor')
+        || contains(github.event.pull_request.labels.*.name, '@claude/tester')
+        || contains(github.event.pull_request.labels.*.name, '@claude/writer')
+        || github.event.pull_request.user.type == 'Bot')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Close and file the PR's issues
+        env:
+          # Two tokens on purpose. GITHUB_TOKEN reads the PR and closes issues;
+          # PROJECTS_TOKEN is a classic PAT that exists only because it can reach
+          # user-owned Projects v2, and needs `project` + `read:org` and nothing else.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          PROJECT_OWNER: "@me"
+          PROJECT_NUMBER: "4"
+        run: .github/agent-bin/close-merged-work.sh

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -545,15 +545,26 @@ jobs:
             If your change needs no test, say that and why — an explicit "no test needed"
             is a useful answer, a silent omission isn't.
 
-            End the Handoff with a **Docs notes** section as well, for the **Writer**. You no
-            longer edit `CLAUDE.md`; you say what it should record and why:
+            **Docs candidates — optional, and only when there is something.** You no longer
+            edit `CLAUDE.md`; the **Writer** does. When you learn something a future reader
+            would otherwise rediscover, end the Handoff with a fenced `json` block so the
+            Writer can pick it up without reading your whole PR:
 
-            - The invariant a future reader would otherwise break, and what breaks.
-            - Anything that surprised you or cost you time — a gotcha nobody wrote down is
-              one everybody rediscovers.
-            - Which `CLAUDE.md` it belongs in, if you know.
-            - "Nothing to document" is a valid answer. Say it rather than leaving the
-              section off.
+                ```json
+                {"docsCandidates": [
+                  {"file": "packages/app/CLAUDE.md",
+                   "note": "creating a reading must be one mutate() — stateRef is assigned during render",
+                   "why": "two editor calls read the same stale draft; the second silently discards the first"}
+                ]}
+                ```
+
+            `file` is a hint — omit it if you're unsure. `why` is the part that earns its
+            place; a note without one is usually restating the diff.
+
+            ⚠️ **You are proposing, not deciding.** The Writer judges whether each candidate
+            is worth documenting and may reject it. So raise anything that genuinely cost
+            you time, and **omit the block entirely** when nothing did — an empty or
+            dutiful list is worse than none, because it trains the Writer to skim.
 
             A denied tool call is settled. The permission layer is policy, not a syntax
             problem, so rewording or re-quoting the same operation will be denied
@@ -740,7 +751,22 @@ jobs:
 
             Never merge a PR. Leave anything you create unlabeled, and do no backlog
             management — no linking, milestones or project edits; scripted hooks own that.
-            ⚠️ **Don't edit any `CLAUDE.md`** — documentation belongs to the **Writer**.
+
+            ⚠️ **Don't edit any `CLAUDE.md`** — documentation belongs to the **Writer**. When
+            you learn something a future spec author would otherwise rediscover — a settle
+            hazard, a locator that looks right and isn't — end your PR comment with a fenced
+            `json` block of candidates for it:
+
+                ```json
+                {"docsCandidates": [
+                  {"file": "packages/e2e/CLAUDE.md",
+                   "note": "asserting tab state needs a retrying locator assertion",
+                   "why": "the tab switch is deferred through useTransition, so a one-shot read races it"}
+                ]}
+                ```
+
+            Optional. Omit it when nothing cost you time — the Writer decides what is worth
+            documenting, and a dutiful list trains it to skim.
 
           claude_args: |
             --model sonnet
@@ -795,10 +821,27 @@ jobs:
             issue or a PR. Read that comment first: it is the instruction.
 
             **Where your work comes from.** Usually an Implementor or Tester PR whose handoff
-            ends with **Docs notes** — what they learned that a future reader would otherwise
-            rediscover. Start there (`gh pr view <number> --comments`), then read the diff
-            for what actually changed. If the notes are thin, say so and document what you
-            can verify from the code; don't invent rationale nobody stated.
+            ends with a fenced `json` block of **docs candidates**:
+
+                ```json
+                {"docsCandidates": [
+                  {"file": "packages/app/CLAUDE.md", "note": "…", "why": "…"}
+                ]}
+                ```
+
+            Start there — `gh pr view <number> --comments` — then read the diff for what
+            actually changed. The block is optional and often absent; when it is, work from
+            the diff and the comment's prose instead.
+
+            ⚠️ **A candidate is a proposal, not an order.** Judging what deserves a place is
+            your job, and the files only stay useful if you say no. Reject anything that
+            restates the diff, that a reader would infer from a good name, or that will be
+            stale within a release — and say so briefly in the PR so the proposer learns the
+            line. `why` is the field that decides it: a candidate without a real cost behind
+            it usually isn't one.
+
+            If nothing survives that filter, say so and open no PR. A run that documents
+            nothing is a correct outcome.
 
             ⚠️ **Write only what is true of the code as it stands.** Every path, symbol and
             behaviour you describe must be one you have opened and checked. A confident
@@ -897,9 +940,12 @@ jobs:
             merge to `mainline`, so a routine "no problems found" note would be noise on
             every single one.
 
-            When you do file, use `gh issue create` — **unlabeled** — with the
+            When you do file, use `gh issue create --label "@claude/security"` — with the
             `.github/ISSUE_TEMPLATE/claude-task.yml` headings, one issue per finding, and
-            `Base branch: mainline`. Say plainly in the Summary which PR introduced it and
+            `Base branch: mainline`. ⚠️ That label is the one exception to the repo's
+            "create issues unlabeled" rule: it marks provenance, so a security finding is
+            distinguishable in a queue from ordinary work. Apply it to issues **you file**
+            and to nothing else — never to an existing issue or a PR. Say plainly in the Summary which PR introduced it and
             how severe it is; a maintainer triaging a queue needs that first.
 
             Then add each to the project:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,31 +115,90 @@ Guidance for human contributors **and** for the `@claude` GitHub integration.
 - ⚠️ Renaming files under `packages/kb/data/**` changes derived ids — a breaking change (see `packages/kb/CLAUDE.md`); call it out in the PR.
 - Prefer surfacing follow-ups over silently expanding scope; note orphaned/dead code you leave rather than deleting adjacent things unasked.
 
-### The Claude GitHub roles (Manager / Researcher / Implementor / Tester / Owner)
-- **One workflow, `.github/workflows/claude-roles.yaml`, with five role jobs**, each narrowly triggered. The old single do-everything `claude.yaml` is **retired & disabled** — kept for reference but subscribes to nothing but `workflow_dispatch`, and its job `if:` matches no dispatch context, so it never runs.
-- ⚠️ **The handle in the comment routes. Labels do not.** You start a role by naming it — `@claude/manager`, `@claude/researcher`, `@claude/implementor`, `@claude/tester`, `@claude/owner`. A **bare `@claude` does nothing at all**, deliberately: a half-typed handle can never start the wrong agent. `on.issues` is still not subscribed, so labels trigger nothing either.
-- ⚠️ **`trigger_phrase` must match the handle, per job.** `track_progress: true` forces the action's own **tag mode**, which gates on `trigger_phrase` (default `@claude`) *independently of our `if:`*. `@claude/implementor` is not a match for `@claude`, so the job fired, the action skipped itself in `0s`, and it posted a placeholder *"I'll analyze this and get back to you"* — twice. Each tag-mode role therefore sets `trigger_phrase` to its own handle. ⚠️ The **Owner's phrase is the prefix `@claude/`**, not a whole handle, because it must fire both when summoned *and* on its automatic pass — where the comment names a **different** role. Every role-triggering comment contains `@claude/`, so the prefix covers both. The action picks its mode from the **event type** (`issue_comment` is always tag mode), so there is no way to opt out of the phrase gate; omitting `track_progress` does *not* buy agent mode, which is a trap I fell into — the Owner ran, reported success, and skipped itself in `0s` for its first several passes. Our `if:` still decides whether the job runs; the phrase only stops the action no-opping once it does.
-- ⚠️ **Labels are now a record of what has run**, not a route. Each role stamps its own `@claude/<role>` label on the issue or PR as it starts (`gh api repos/{owner}/{repo}/issues/<n>/labels`, which works for PRs too), so the labels read as "these agents have been here". The maintainer clears them as a check-off. A role adds **only its own** and never removes any; only the **Owner** prunes, and only when asked. All five labels must exist in the repo.
-  - **`manager` job** — shapes a rough epic into a filled-out one (Goal / Proposal / Constraints / Research path / Codebase map / **Integration branch**) by editing the issue body + a summary comment, **and cuts the epic's integration branch** (`<issue#>-<kebab-summary>`, empty, off `mainline`). No code, no sub-issues, no PR. `sonnet`, 40 turns, `issues: write` + `contents: write` — ⚠️ write *only* to push that empty branch; its prompt forbids committing to it.
-  - **`researcher` job** — the product owner: follows a well-defined epic's Research path, then creates **unlabeled** sub-issues (self-contained, `claude-task.yml` headings) and posts one index comment. ⚠️ It **propagates the epic's integration branch into every sub-issue** as a *Base branch* line naming the epic number. ⚠️ It does **not** link, parent or milestone anything — that is the Owner's, and its **index comment is the handoff**, so each sub-issue must appear there as `#<number> — <title>` or the Owner can't file it. `sonnet`, 80 turns, no `npm ci`.
-  - **`implementor` job** — the main engineer. Reads the issue + comments (or, on a PR, the description + comments + any Handoff), then changes code and opens a PR — ⚠️ **cut from** the issue's stated *Base branch*, not merely aimed at it (see below), else `mainline`. It also opens the epic's integration PR the first time it finds one missing. ⚠️ It writes **no e2e tests** (the Tester's) and does **no backlog management** beyond putting `Closes #<issue>` in the PR body — that line is the Owner's input. **`opus`**, 80 turns, write access to contents/PRs/issues (+ `actions: read` for a red **Verify**). ⚠️ It is the only role on `opus` — it is the one that writes code the maintainer has to review, and the failure mode the other roles have (a wasted run) is cheaper than the one it has (a plausible-looking wrong change). The others stay on `sonnet`.
-  - **`tester` job** — owns `packages/e2e`: turns an Implementor's *Testing notes* into Playwright specs, **runs them**, and opens a PR. Split from the Implementor because the two pull in opposite directions — an engineer finishing a feature writes the test that passes, and this repo's actual failure mode (a save that throws inside a fire-and-forget call while lint/tsc/build stay green) is only caught by a test written to distrust the change. ⚠️ It stays inside `packages/e2e`; a failing test is a *report*, not licence to edit `packages/app` (sole exception: adding a missing `aria-label` via a design component's `label` prop). `sonnet`, 80 turns; runs `npm ci` **and** `npx playwright install --with-deps chromium` as workflow steps so it can run what it writes.
-  - **`owner` job** — the backlog agent, and the only role that is **additive**: it runs when summoned with `@claude/owner`, **and automatically after** whichever role a comment started (`needs:` + `always()`), **and** after a merged PR. ⚠️ **The automatic pass runs no model.** Two scripted steps do the routine filing — parenting sub-issues to their epic and propagating its milestone (driven by the Researcher's manifest), and closing/board-filing a merged PR's issues. The model step is gated to `@claude/owner`, i.e. only when you actually ask for something. `sonnet`, 40 turns, `Read` + `Bash(gh:*)` only.
-- ⚠️ **Why the Owner runs last, not alongside.** Its whole job is to file work that already exists — link the PR the Implementor *just* opened, parent the sub-issues the Researcher *just* created. Running it in parallel would race work that isn't there yet. It is also not a blanket trigger: no role ran and nothing merged means no Owner.
-- ⚠️ **The Researcher hands off a manifest, not prose.** Its index comment on the epic ends with an HTML comment — `<!-- owner-manifest {"epic": 246, "children": [346, 347]} -->` — invisible in the rendered issue, and the *only* thing the filing script reads. The human-readable list above it is for the maintainer. Without the manifest, nothing gets parented or milestoned. ⚠️ It is an obligation on **every** Researcher run, not just the first — the script acts on the **newest** manifest alone and does not accumulate, so a follow-up must repost the **full** child list. #376/#377 sat unfiled because a follow-up posted an index comment without one. This exists because the relationship is a fact the Researcher already knows; writing it as English forced a model downstream to recover it, which cost ~2.5 min of model time on **every** interaction, almost always to conclude there was nothing to do.
-- ⚠️ **The Owner's deterministic half stays a script.** "Parse the closing keyword, close the issue, set one field" is fully determined, so it runs as its own step *before* Claude starts; the model handles only judgment work (parenting, milestones, reconciling, pruning). That step needs a **`PROJECTS_TOKEN`** secret — a **classic** PAT with the **`project` *and* `read:org`** scopes. Fine-grained tokens cannot reach *user-owned* Projects v2 at all (project #4 is user-owned), and ⚠️ `gh project` demands `read:org` even for a user-owned project — a **second gate**, separate from the owner-type probe that `--owner "@me"` handles. Its raw error (*"missing required scopes [read:org read:discussion]"*) names neither the secret nor the command, so the step preflights project access and warns rather than failing a merged PR. (`read:discussion` is listed by `gh` but not actually needed — `project` + `read:org` is enough.) It uses **two tokens**: the built-in `GITHUB_TOKEN` (`issues: write`) reads the PR and closes issues, `PROJECTS_TOKEN` touches only the board. ⚠️ **`PROJECTS_TOKEN` is never in the model step's env.** Secret masking covers *logs* only, and a role holding `Bash(gh:*)` can run `gh issue comment N --body "$PROJECTS_TOKEN"` — that passes the allowlist and publishes the value where masking doesn't reach. The PAT is long-lived and spans every project the maintainer owns, so board mutations are **script-only**; a summoned Owner reports what should change and doesn't attempt it. ⚠️ Project commands must pass `--owner "@me"`; the literal login makes `gh project` probe user-vs-org, which needs `read:org` and fails with a bare *"unknown owner type"*.
-- ⚠️ **An epic's integration PR must carry exactly ONE closing keyword — the epic's.** It targets `mainline`, so *every* keyword in it is live, and the natural way to index the sub-PRs it collects (`- #356 — Popover primitive · closes #341`) silently attaches the **sub-issue** to the **epic's** PR and would close it out from under its own PR. Seen live on #357. Sub-PRs are listed with a bare number or "for #341"; each sub-issue is closed by its own PR. The Implementor is told this at the point it opens the PR, and the Owner re-checks `closingIssuesReferences` and neuters strays.
-- ⚠️ **GitHub ignores closing keywords unless the PR targets the default branch.** Every sub-issue PR targets an epic branch instead, so its `Closes #N` is inert and `closingIssuesReferences` comes back empty. The Owner falls back to parsing the keyword out of the PR body — that is the only reason sub-issues get closed or filed at all.
-- ⚠️ **Manager and Researcher are issue-only.** Both work on an epic *issue*, so their `if:` requires `!github.event.issue.pull_request` — `issue_comment` fires for pull requests too, and the payload puts the PR in `github.event.issue`. Naming them on a PR does nothing.
-- ⚠️ **Why one workflow, not five files.** The role is chosen by a job-level `if:`, so as separate files every comment would create one real run and four skipped ones, cluttering the Actions history. As one file it is a **single run per comment**, with the unselected roles skipping *inside* it, and a dynamic `run-name` keeps that row self-describing.
-- **One epic → one branch → one PR to `mainline`.** The Manager cuts `<issue#>-<kebab-summary>` off `mainline` and records it in the epic; the Researcher stamps it onto every sub-issue as a *Base branch* line naming the epic; each Implementor branches off it and PRs **into** it. **Whichever Implementor first finds no integration PR opens it** (branch → `mainline`, `Closes #<epic>`), so it exists from the start and fills up as sub-issues merge.
-  - ⚠️ **A *Base branch* governs two things, and only naming the PR's base is the trap.** The workflow checks the runner out on **`mainline`**, so an Implementor that runs `gh pr create --base <epic-branch>` without first `git checkout -B <branch> origin/<epic-branch>` produces a PR that looks correct but whose branch was cut from `mainline` — the diff then carries every mainline change since the epic branch was cut, other epics' features included. Seen live: PR #330's parent commit was mainline's #313 merge, and its 12-file diff hauled in the whole recipe/batch delete feature. The prompt spells out the fetch/checkout and makes the Implementor verify `git log origin/<base>..HEAD` shows only its own commits.
-  - ⚠️ **The first integration PR needs a marker commit.** The Manager cuts the branch empty, so at the first Implementor's run it is identical to `mainline` and GitHub refuses the PR with *"No commits between mainline and \<branch\>"*. The Implementor pushes a single `--allow-empty` commit and retries.
-  - ⚠️ **What may be pushed straight to an integration branch** is housekeeping only: that empty marker, and merging `mainline` in to keep the branch current. **Feature work never** goes there directly; it lands by merging sub-issue PRs, which is the review the branch exists to collect.
-  - ⚠️ **A side benefit: e2e coverage starts on day one.** `functional-test.yaml` only runs on PRs **to `mainline`**, so sub-issue PRs into an epic branch never run Playwright. With the integration PR open from the start, the suite runs against the accumulating feature the whole way through.
-  - ⚠️ **`pull_request` events run the workflow from the PR's *base* branch.** A sub-PR merging into an epic branch therefore runs whatever version of this file that branch was cut with — so workflow fixes don't reach in-flight epics until `mainline` is merged into them.
-- ⚠️ **Keep the task checklist coarse — 3–5 outcome-level items** ("Add the version field to the models", not one line per file). The action narrates every checklist item back to the PR, so each item costs a turn; a 10-item list spends most of the budget before any code is written. This is the single biggest budget consumer.
-- **Deps are pre-installed (Implementor and Tester); the Implementor builds before opening the PR.** Their prompts tell them *not* to run `npm ci`/`install`. (An earlier config with no `npm ci` step made the Implementor chase a phantom TS-version error for eleven turns; that's also why the prompt says a denied tool call is settled — don't re-quote and retry — and hands it the `$`-in-filename escape directly.) Manager, Researcher and Owner don't build, so they skip `npm ci`.
-- ⚠️ **Verify on a bot-opened PR waits for approval.** A PR opened with `GITHUB_TOKEN` creates `pull_request` runs that require a maintainer to click *Approve and run* — the check isn't broken, it's held.
-- ⚠️ **The actor guard** (`github.actor != 'claude[bot]' && != 'github-actions[bot]'`) stops the `track_progress` comment from re-triggering the workflow.
-- **House rules.** Never push to a deploy branch — open a PR. May open PRs, push to feature branches, comment; may **not** merge its own PR, edit `.github/workflows/**` or secrets, or run destructive git. Pass the gate before proposing a PR. Proceed on clearly-scoped tasks; ask when a change is ambiguous, irreversible, or outward-facing.
+### The Claude GitHub roles
+
+Six roles, one workflow (`.github/workflows/claude-roles.yaml`), so a comment makes one run
+with the unselected roles skipping inside it rather than five skipped runs cluttering the
+history.
+
+**Routing.** The handle in the comment picks the role. Labels route nothing.
+
+- `@claude/manager` — issues only. Shapes a rough epic and cuts its integration branch.
+- `@claude/researcher` — issues only. Decomposes an epic into sub-issues.
+- `@claude/implementor` — issue or PR. Writes the code and opens the PR.
+- `@claude/tester` — issue or PR. Owns `packages/e2e`.
+- `@claude/writer` — issue or PR. Owns every `CLAUDE.md` and `.claude/skills/`.
+- **Security** — no handle. Runs on merge to `mainline` and files issues.
+
+⚠️ All five `@claude/*` labels must exist in the repo or the stamp hook warns and skips.
+`@claude/owner` is retired and can be deleted.
+
+⚠️ A bare `@claude` does nothing, so a half-typed handle cannot start the wrong agent.
+⚠️ Manager and Researcher require `!github.event.issue.pull_request` — `issue_comment` fires
+for PRs too, and without the guard a PR comment started a role written for an epic issue.
+
+**Backlog work is scripted, never prompted.** Hooks in `.github/agent-bin/` run around each
+model step.
+
+- `stamp-role-label.sh` — pre, every role. Stamps `@claude/<role>` on the issue or PR.
+- `file-sub-issues.sh` — post, Researcher. Parents and milestones from the epic's manifest.
+- `close-merged-work.sh` — on merge. Closes the PR's issues and files them on the board.
+
+⚠️ These were prompt instructions until a model skipped them. A label trail is worthless if
+a run can forget to stamp it, and the merge hook is the only backlog behaviour that worked
+on its first attempt — everything model-driven took three.
+⚠️ `close-merged-work.sh` is the only place `PROJECTS_TOKEN` appears. It is a long-lived
+classic PAT (`project` + `read:org`) covering every project the maintainer owns, secret
+masking covers logs only, and a role holding `Bash(gh:*)` could publish it in a comment.
+
+**Labels are a record, not a route.** Each role stamps its own as it starts, so the labels
+read as "these agents have been here". The maintainer clears them as a check-off.
+
+**Documentation belongs to the Writer.** Implementor and Tester change no `CLAUDE.md`; they
+end their handoff with **Docs notes** saying what should be recorded and why. ⚠️ This exists
+because `CLAUDE.md` was the biggest single source of merge conflicts — every role edited it,
+so parallel branches collided on prose neither was really working on.
+
+**Testing belongs to the Tester.** The Implementor writes no e2e specs and leaves
+**Testing notes** instead. An engineer finishing a feature writes the test that passes; this repo's
+actual failure mode — a save that throws inside a fire-and-forget call while lint, tsc and
+build stay green — is only caught by a test written to distrust the change.
+
+**One epic → one branch → one PR to `mainline`.**
+
+- Manager cuts `<issue#>-<kebab-summary>` off `mainline`, empty, and records it in the epic.
+- Researcher stamps it onto every sub-issue as a *Base branch* line naming the epic.
+- Each Implementor branches off it and PRs into it.
+- Whichever Implementor first finds no integration PR opens it, so it fills up as sub-issues
+  merge instead of appearing whole at the end.
+
+⚠️ A *Base branch* governs two things and naming only the PR's base is the trap. The runner
+checks out `mainline`, so `gh pr create --base <epic>` without `git checkout -B <branch>
+origin/<epic>` yields a PR that looks right but was cut from `mainline` — its diff then
+carries every mainline change since, other epics' features included. Seen on PR #330.
+⚠️ The first integration PR needs an `--allow-empty` marker commit; the branch is identical
+to `mainline` and GitHub refuses a PR with no commits between.
+⚠️ Only housekeeping may be pushed straight to an integration branch — that marker, and
+merging `mainline` in. Feature work lands by merging sub-issue PRs.
+⚠️ `pull_request` events run the workflow from the PR's **base** branch, so workflow fixes do
+not reach in-flight epics until `mainline` is merged into them.
+⚠️ GitHub ignores closing keywords unless the PR targets the default branch, so a sub-issue
+PR's `Closes #N` is inert and `closingIssuesReferences` is empty. The merge hook parses the
+keyword out of the body instead. The epic's integration PR must carry **exactly one** closing
+keyword — its own — since it does target `mainline`; a sub-PR index written as
+`· closes #341` silently attaches that sub-issue to the epic's PR.
+
+**Budgets.** `sonnet` throughout except the Implementor, which runs `opus` — it is the only
+role whose output the maintainer must review line by line. Manager 40 turns, Writer 60,
+Security 40, the rest 80. Implementor and Tester run `npm ci` as a step; nobody else builds.
+
+⚠️ Keep task checklists to 3–5 outcome-level items. The action narrates each one back to the
+PR, so a 10-item list spends most of the budget before any code is written.
+⚠️ `trigger_phrase` must match the handle per job. `track_progress: true` forces the action's
+own tag mode, which gates on that phrase independently of our `if:` — leave it at the default
+`@claude` and the job fires, the action skips in `0s`, and it posts a placeholder comment.
+⚠️ Verify on a bot-opened PR waits for a maintainer to click *Approve and run*.
+
+**House rules.** Never push to a deploy branch. May open PRs, push to feature branches and
+comment; may not merge, edit `.github/workflows/**` or secrets, or run destructive git. Pass
+the gate before proposing a PR. Ask when a change is ambiguous, irreversible or outward-facing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,9 +128,11 @@ history.
 - `@claude/implementor` — issue or PR. Writes the code and opens the PR.
 - `@claude/tester` — issue or PR. Owns `packages/e2e`.
 - `@claude/writer` — issue or PR. Owns every `CLAUDE.md` and `.claude/skills/`.
-- **Security** — no handle. Runs on merge to `mainline` and files issues.
+- **Security** — no handle. Runs on merge to `mainline` and files issues, labelled
+  `@claude/security`. ⚠️ The one exception to "create issues unlabeled": it marks
+  provenance so a finding stands out in a queue.
 
-⚠️ All five `@claude/*` labels must exist in the repo or the stamp hook warns and skips.
+⚠️ All six `@claude/*` labels must exist in the repo or the stamp hook warns and skips.
 `@claude/owner` is retired and can be deleted.
 
 ⚠️ A bare `@claude` does nothing, so a half-typed handle cannot start the wrong agent.
@@ -154,10 +156,16 @@ masking covers logs only, and a role holding `Bash(gh:*)` could publish it in a 
 **Labels are a record, not a route.** Each role stamps its own as it starts, so the labels
 read as "these agents have been here". The maintainer clears them as a check-off.
 
-**Documentation belongs to the Writer.** Implementor and Tester change no `CLAUDE.md`; they
-end their handoff with **Docs notes** saying what should be recorded and why. ⚠️ This exists
-because `CLAUDE.md` was the biggest single source of merge conflicts — every role edited it,
-so parallel branches collided on prose neither was really working on.
+**Documentation belongs to the Writer.** Implementor and Tester change no `CLAUDE.md`. They
+optionally end their handoff with a fenced `json` block of **docs candidates** —
+`{"docsCandidates": [{"file", "note", "why"}]}` — and the Writer decides what earns a place.
+
+- ⚠️ A candidate is a proposal, not an order. The files only stay useful if the Writer says
+  no to what restates the diff or goes stale within a release.
+- ⚠️ Omit the block when nothing cost you time. A dutiful list trains the Writer to skim.
+- `why` is the field that decides it — a note without a real cost behind it usually isn't one.
+- This exists because `CLAUDE.md` was the biggest single source of merge conflicts: every
+  role edited it, so parallel branches collided on prose neither was really working on.
 
 **Testing belongs to the Tester.** The Implementor writes no e2e specs and leaves
 **Testing notes** instead. An engineer finishing a feature writes the test that passes; this repo's


### PR DESCRIPTION
Items 1–3 of the four you asked for. Item 4 (the style pass across the remaining docs) follows as its own PR — see the bottom.

## 1. Writer

A tech-writer role owning **every `CLAUDE.md`** and the agent instruction files under `.claude/skills/`. Triggered by `@claude/writer` on an issue or PR.

**Implementor and Tester now change no documentation at all.** They end their handoff with a **Docs notes** section — the invariant a reader would otherwise break, what surprised them, which file it belongs in — mirroring the *Testing notes* the Tester already works from. `"Nothing to document"` is an explicit valid answer.

Its prompt carries the house style, since it's the role that enforces it: tight wording, **one item per line**, a new thing gets a new line, ⚠️ reserved for what's genuinely easy to get wrong.

## 2. Security

Runs on **merge to `mainline`**, reads the diff, files one issue per finding.

On merge rather than on the PR deliberately: a review that blocks a merge gets argued with, one that files an issue gets triaged.

- Scoped to what this repo actually is — an offline-first PWA with no backend and no accounts — so it weights secrets/workflow/supply-chain over generic web findings.
- ⚠️ **File only what you can point at**: file, line, and what an attacker concretely does.
- ⚠️ **A clean review posts nothing.** This fires on every merge; "no problems found" each time is noise.

## 3. Owner retired → scripted hooks

| hook | when | does |
|---|---|---|
| `stamp-role-label.sh` | pre, every role | stamps `@claude/<role>` |
| `file-sub-issues.sh` | post, Researcher | parents + milestones from the manifest |
| `close-merged-work.sh` | on merge | closes the PR's issues, files them on the board |

The two Owner scripts moved to files **unchanged** — they already worked. Stamping was a prompt instruction a model could skip, which makes a check-off label worthless; as a hook it costs no turns and can't be forgotten. Retiring the Owner also removes the last model that ran on nearly every interaction.

`close-merged-work.sh` stays the only place `PROJECTS_TOKEN` appears.

## Verification

- YAML parses: 7 jobs, correct `trigger_phrase`/model/hook count each.
- All three hooks pass `bash -n`; `stamp-role-label.sh` exits clean with no `NUMBER` and fails loudly without `ROLE`/`REPO`.
- `npm test --ws` ✓ — 0 errors, 6 pre-existing `design` warnings. No app code touched.
- **Routing simulated against the real `if:` expressions, 15 scenarios**, all matching intent:

```
issue @claude/writer        -> writer          PR @claude/writer          -> writer
issue @claude/owner (gone)  -> (none)          PR @claude/manager         -> (none)
bare @claude                -> (none)          review cmt @claude/tester  -> tester
merged -> mainline, bot     -> security+merge_housekeeping
merged -> epic branch, bot  -> merge_housekeeping        (Security is mainline-only)
merged -> mainline, human   -> security                  (no label needed for Security)
closed unmerged             -> (none)          bot actor                  -> (none)
```

## ⚠️ You need to create the `@claude/writer` label

The stamp hook warns and skips without it. `@claude/owner` is retired and can be deleted.

## Item 4 is deliberately not here

The style rule is **defined** in this PR (the Writer's prompt, and the root `CLAUDE.md` roles section rewritten to demonstrate it — 28 dense lines became 84 short ones, longest line 1400+ → 98 chars). **Applying** it to the other six package files is a large mechanical pass that doesn't belong in the same diff as a workflow change — a regression in either would be unattributable. Next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
