### PR TITLE
Give the Tester the Implementor's branch/PR discipline, and have roles label their own PRs

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -426,6 +426,12 @@ jobs:
             the pull request yourself — do not stop at pushing a branch and returning a PR
             link.
 
+            ⚠️ **Label the PR `@claude/implementor`** — `gh pr create --label "@claude/implementor"`.
+            This is the exception to the repo's "leave things unlabeled" rule: a PR carries
+            the label of the role that opened it, which is how the merge hook recognises its
+            own work. Label the PR **you open** and nothing else — never an existing PR, and
+            never an issue.
+
             ⚠️ **Cut your branch FROM the issue's stated base branch.** If the issue names a
             **Base branch** (sub-issues of an epic do — they land on the epic's integration
             branch, not `mainline`), it governs two separate things, and getting only the
@@ -725,8 +731,39 @@ jobs:
             weakening the test until it passes. Never delete or `test.skip` an existing test
             to get green — if an existing test now fails, that is the headline of your report.
 
-            Open a PR with your specs, following the root CLAUDE.md's Contributing section.
-            ⚠️ **Target the issue's stated Base branch** if it names one, else `mainline`.
+            **Opening the PR.** Follow the root CLAUDE.md's Contributing section for branch
+            naming and commit style.
+
+            ⚠️ **Cut your branch FROM the issue's stated Base branch**, don't merely point at
+            it. The workflow checks you out on **`mainline`**, so you start on the wrong
+            branch whenever the issue names another — one command per Bash call:
+
+                git fetch origin <base-branch>
+                git checkout -B <your-branch> origin/<base-branch>
+
+            Then `gh pr create --base <base-branch> --head <your-branch>`. Doing only the
+            second makes a PR that *looks* right while its branch was cut from `mainline`,
+            so the diff carries every unrelated change since. Default to `mainline` only when
+            the issue names no base branch.
+
+            ⚠️ **Check your own diff first.** `git log --oneline origin/<base-branch>..HEAD`
+            must list only your own commits. If it doesn't, re-cut and reapply rather than
+            opening the PR anyway.
+
+            ⚠️ **Label the PR `@claude/tester`** — `gh pr create --label "@claude/tester"`.
+            This is the exception to the repo's "leave things unlabeled" rule: a PR carries
+            the label of the role that opened it, which is how the merge hook recognises its
+            own work. Label the PR **you open** and nothing else.
+
+            Put **`Closes #<issue>`** in the body when an issue prompted the work. That line
+            is what the merge hook parses to close the issue and file it on the board — omit
+            it and the issue stays open with nothing pointing at it.
+
+            Include a **Verification** section: `npm run test:e2e -w packages/e2e` with the
+            pass count, and `npm test --ws` (eslint). ⚠️ Run the lint before opening —
+            `packages/e2e`'s eslint is part of **Verify**, so a style slip you didn't check
+            arrives as a red PR rather than something you caught. Do **not** run `npm ci`
+            or `npm install`; dependencies and browsers are already installed.
 
             ⚠️ **Stay inside `packages/e2e`.** You do not fix app code — a failing test is a
             report, not an invitation to change `packages/app`. The one exception is adding
@@ -867,7 +904,17 @@ jobs:
 
             Follow the Contributing section for branch naming, commits and the PR template.
             Open a PR — ⚠️ against the issue's stated **Base branch** if it names one, else
-            `mainline`.
+            `mainline`, and cut your branch **from** that base rather than from whatever the
+            workflow checked out.
+
+            ⚠️ **Label the PR `@claude/writer`** — `gh pr create --label "@claude/writer"`.
+            A PR carries the label of the role that opened it; that is how the merge hook
+            recognises its own work. Label the PR **you open** and nothing else.
+
+            Put **`Closes #<issue>`** in the body when an issue prompted the work — that line
+            is what the merge hook parses to close it and file it on the board. Include a
+            **Verification** line saying `npm test --ws` (eslint) is clean; you change no
+            code, so there is nothing else to run, and you must not run `npm ci`/`install`.
 
             ⚠️ **Documentation only.** You do not change application code, tests, or
             workflows. If documenting something reveals a bug, say so in a comment and leave

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,12 @@ masking covers logs only, and a role holding `Bash(gh:*)` could publish it in a 
 **Labels are a record, not a route.** Each role stamps its own as it starts, so the labels
 read as "these agents have been here". The maintainer clears them as a check-off.
 
+- `stamp-role-label.sh` stamps the issue or PR that **triggered** the run.
+- A role that **opens** a PR labels it itself (`gh pr create --label "@claude/<role>"`) — the
+  triggering stamp cannot reach a PR that did not exist yet.
+- ⚠️ Two carve-outs from "create things unlabeled": a role labels the PR it opens, and
+  Security labels the issues it files. Nothing else, and never someone else's.
+
 **Documentation belongs to the Writer.** Implementor and Tester change no `CLAUDE.md`. They
 optionally end their handoff with a fenced `json` block of **docs candidates** —
 `{"docsCandidates": [{"file", "note", "why"}]}` — and the Writer decides what earns a place.


### PR DESCRIPTION
## Summary

Two changes, so the Tester can be fired at #413–#416 and behave like the Implementor you're used to.

### 1. Tester gets the Implementor's branch/PR discipline

It knew to "open a PR" and "target the Base branch" — and nothing else:

| | Implementor | Tester (before) |
|---|---|---|
| cuts **from** the base branch | ✅ | ❌ |
| `Closes #<issue>` in the body | ✅ | ❌ |
| Verification section | ✅ | ❌ |
| runs the gate before opening | ✅ | ❌ |

⚠️ **`Closes #<issue>` is the one that loses work.** `close-merged-work.sh` finds what a PR finished by parsing that keyword, so without it every Tester PR would merge and leave its issue open and off the board — silently.

The missing lint run matters too: `packages/e2e`'s eslint is part of **Verify**, so a style slip would arrive as a red PR rather than something the Tester caught itself.

And the branch instruction was the same weak form the Implementor had **before #332** — "target the base branch" without "cut from it" — while the runner checks out `mainline`. Harmless for #413–#416 (all based on `mainline`), dormant for the first Tester issue on an epic branch. It now carries the explicit fetch/checkout plus the `git log origin/<base>..HEAD` self-check.

### 2. Roles label the PRs they open

`gh pr create --label "@claude/<role>"` for **Implementor, Tester and Writer**.

The pre-hook stamps the issue or PR that *triggered* a run — it can't reach a PR that didn't exist yet, which is why this belongs at creation. It also lets `merge_housekeeping` recognise the work by label rather than only by bot authorship.

I included the **Writer** as well as the two you named — it opens PRs too, and you said you wanted the behaviour expanded. Say if you'd rather it didn't.

⚠️ Writer also gained `Closes #`/Verification, which it was missing for the same reason the Tester was. Fixing one and not the other would have reproduced the bug on its first run.

## Verification

Prompt and docs only — no app code, no job structure change.

- YAML parses; all seven jobs intact.
- All three PR-opening roles now carry: labels own PR ✓, `Closes #` ✓, Verification ✓.
- `npm test --ws` ✓ — 0 errors, 6 pre-existing `design` warnings.
- Routing re-simulated, confirming a labelled PR reaches the merge hook:

```
tester PR merged to mainline  -> security+merge_housekeeping
writer PR merged to mainline  -> security+merge_housekeeping
tester PR merged to epic      -> merge_housekeeping   (Security is mainline-only)
issue @claude/tester          -> tester
issue @claude/writer          -> writer
```

`CLAUDE.md` now states the two carve-outs from "create things unlabeled" together: a role labels the PR it opens, and Security labels the issues it files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
