### PR TITLE
Move backlog and PR bookkeeping into scripted hooks

### DIFF
--- a/.github/agent-bin/finish-pr.sh
+++ b/.github/agent-bin/finish-pr.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Post-hook for every role that opens a PR. Does the two things a prompt kept
+# being asked to remember:
+#
+#   1. labels the PR with the role that opened it
+#   2. makes sure the body carries `Closes #<issue>`
+#
+# (2) is the one that silently loses work: close-merged-work.sh finds what a PR
+# finished by parsing that keyword, so a missing line means the issue never
+# closes and never reaches Done, with nothing to signal it.
+set -euo pipefail
+
+: "${ROLE:?ROLE is required}"
+: "${REPO:?REPO is required}"
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+pr=""
+if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
+    pr=$(gh pr list --repo "$REPO" --head "$branch" --state open --json number --jq '.[0].number // empty')
+fi
+
+# the model may have moved off the branch it pushed; fall back to the issue
+if [ -z "$pr" ] && [ -n "${ISSUE:-}" ]; then
+    pr=$(gh pr list --repo "$REPO" --state open --json number,body \
+        --jq "[.[] | select(.body // \"\" | test(\"(?i)(clos|fix|resolv)[a-z]* +#$ISSUE\\\\b\"))][0].number // empty")
+fi
+
+if [ -z "$pr" ]; then
+    echo "This run opened no PR — nothing to finish."
+    exit 0
+fi
+
+if gh pr edit "$pr" --repo "$REPO" --add-label "@claude/$ROLE" >/dev/null 2>&1; then
+    echo "PR #$pr -> @claude/$ROLE"
+else
+    echo "::warning::could not label PR #$pr — does @claude/$ROLE exist in this repo?"
+fi
+
+if [ -z "${ISSUE:-}" ]; then
+    echo "No triggering issue — nothing to close."
+    exit 0
+fi
+
+body=$(gh pr view "$pr" --repo "$REPO" --json body --jq '.body // ""')
+
+if printf '%s' "$body" | grep -qiE "(clos|fix|resolv)[a-z]* +#$ISSUE\b"; then
+    echo "PR #$pr already closes #$ISSUE."
+    exit 0
+fi
+
+printf '%s\n\nCloses #%s\n' "$body" "$ISSUE" | gh pr edit "$pr" --repo "$REPO" --body-file -
+echo "PR #$pr -> added 'Closes #$ISSUE'"

--- a/.github/agent-bin/open-integration-pr.sh
+++ b/.github/agent-bin/open-integration-pr.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Post-hook for the Implementor. Opens the epic's integration PR the first time
+# it finds one missing, so the feature is reviewable as it accumulates instead of
+# arriving whole at the end.
+#
+# Reads the epic branch and number out of the sub-issue's Base branch line, which
+# the Researcher writes in a fixed form:
+#
+#   **Base branch: `250-volume-milestone`** — the integration branch for epic #250.
+set -euo pipefail
+
+: "${REPO:?REPO is required}"
+
+if [ -z "${ISSUE:-}" ]; then
+    echo "Not triggered on an issue — no epic to integrate."
+    exit 0
+fi
+
+body=$(gh issue view "$ISSUE" --repo "$REPO" --json body --jq '.body // ""')
+branch=$(printf '%s' "$body" | grep -oiE 'base branch: *`[^`]+`' | head -1 | sed -E 's/.*`([^`]+)`.*/\1/')
+epic=$(printf '%s' "$body" | grep -oiE 'epic #[0-9]+' | head -1 | grep -oE '[0-9]+')
+
+if [ -z "$branch" ]; then
+    echo "#$ISSUE names no base branch — not an epic sub-issue."
+    exit 0
+fi
+
+if [ "$branch" = "mainline" ]; then
+    echo "#$ISSUE targets mainline directly — no integration PR."
+    exit 0
+fi
+
+existing=$(gh pr list --repo "$REPO" --head "$branch" --base mainline --state open --json number --jq '.[0].number // empty')
+if [ -n "$existing" ]; then
+    echo "Integration PR #$existing already open for $branch."
+    exit 0
+fi
+
+if ! git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    echo "::warning::branch $branch does not exist on origin — the Manager may not have cut it."
+    exit 0
+fi
+
+# ⚠️ The Manager cuts the branch empty, so on the first sub-issue it is identical
+# to mainline and GitHub refuses the PR with "No commits between". A single empty
+# marker commit is the only thing any role may push straight to an epic branch.
+git fetch origin "$branch" --quiet
+if [ "$(git rev-list --count "origin/mainline..origin/$branch")" -eq 0 ]; then
+    echo "$branch has no commits of its own — pushing a marker commit."
+    git push --quiet origin "origin/$branch:refs/heads/$branch" 2>/dev/null || true
+    tmp="integration-marker-$$"
+    git checkout -q -B "$tmp" "origin/$branch"
+    git commit -q --allow-empty -m "Start epic${epic:+ #$epic}"
+    git push -q origin "$tmp:$branch"
+    git checkout -q -
+    git branch -q -D "$tmp"
+fi
+
+title="Epic${epic:+ #$epic}: $branch"
+if [ -n "$epic" ]; then
+    title=$(gh issue view "$epic" --repo "$REPO" --json title --jq '.title' 2>/dev/null || echo "$title")
+fi
+
+body_file=$(mktemp)
+{
+    printf 'Integration PR for the `%s` epic branch.\n\n' "$branch"
+    printf 'It collects this epic'"'"'s sub-issue PRs and stays open until the feature is done,\n'
+    printf 'so the work is reviewable as it accumulates rather than arriving whole at the end.\n'
+    [ -n "$epic" ] && printf '\nCloses #%s\n' "$epic"
+    printf '\n⚠️ Opened automatically by the first sub-issue run that found it missing.\n'
+} > "$body_file"
+
+if gh pr create --repo "$REPO" --base mainline --head "$branch" --title "$title" --body-file "$body_file" >/dev/null 2>&1; then
+    echo "opened the integration PR for $branch"
+else
+    echo "::warning::could not open the integration PR for $branch — open it by hand."
+fi
+rm -f "$body_file"

--- a/.github/agent-bin/set-issue-in-progress.sh
+++ b/.github/agent-bin/set-issue-in-progress.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Pre-hook for the roles that do the work. Moves the triggering issue to
+# In Progress on the project board, so the board reflects reality the moment a
+# role starts rather than only when its PR merges.
+#
+# Scripted rather than prompted for the same reason the label stamp is: a board
+# that updates only when a model remembers is a board nobody trusts.
+#
+# ⚠️ This is one of the two places PROJECTS_TOKEN may appear. Step env is
+# per-step, so the model step that runs after this one cannot read it.
+set -euo pipefail
+
+: "${REPO:?REPO is required}"
+
+if [ -z "${ISSUE:-}" ]; then
+    echo "Not triggered on an issue — nothing to move."
+    exit 0
+fi
+
+if [ -z "${PROJECTS_TOKEN:-}" ]; then
+    echo "::warning::PROJECTS_TOKEN is not set — cannot move #$ISSUE to In Progress."
+    exit 0
+fi
+
+# don't resurrect finished work: a role re-run on a closed issue leaves the board alone
+if [ "$(gh issue view "$ISSUE" --repo "$REPO" --json state --jq '.state')" != "OPEN" ]; then
+    echo "#$ISSUE is closed — leaving its board status alone."
+    exit 0
+fi
+
+export GH_TOKEN="$PROJECTS_TOKEN"
+
+# ⚠️ `--owner "@me"`, never the literal login: gh otherwise probes user-vs-org,
+# which needs read:org and fails with a bare "unknown owner type".
+if ! gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --jq '.id' >/dev/null 2>&1; then
+    echo "::warning::PROJECTS_TOKEN cannot reach project $PROJECT_NUMBER — needs 'read:org' as well as 'project'."
+    exit 0
+fi
+
+project_id=$(gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --jq '.id')
+status_field=$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json \
+    --jq '.fields[] | select(.name == "Status")')
+field_id=$(echo "$status_field" | jq -r '.id')
+option_id=$(echo "$status_field" | jq -r '(.options // [])[] | select(.name == "In Progress") | .id')
+
+if [ -z "$option_id" ] || [ "$option_id" = "null" ]; then
+    echo "::warning::Project $PROJECT_NUMBER has no Status option named 'In Progress' — skipping."
+    exit 0
+fi
+
+items=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500)
+item=$(echo "$items" | jq -r --argjson n "$ISSUE" \
+    'first(.items[] | select(.content.type == "Issue" and .content.number == $n)) // empty')
+
+if [ -z "$item" ]; then
+    echo "::warning::Issue #$ISSUE is not on project $PROJECT_NUMBER — skipping."
+    exit 0
+fi
+
+if [ "$(echo "$item" | jq -r '.status // empty')" = "In Progress" ]; then
+    echo "#$ISSUE is already In Progress."
+    exit 0
+fi
+
+item_id=$(echo "$item" | jq -r '.id')
+gh project item-edit --id "$item_id" --project-id "$project_id" \
+    --field-id "$field_id" --single-select-option-id "$option_id"
+echo "#$ISSUE -> In Progress"

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -380,6 +380,17 @@ jobs:
           REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: .github/agent-bin/stamp-role-label.sh
+      - name: Move the issue to In Progress
+        env:
+          # ⚠️ PROJECTS_TOKEN is safe here and only here: step env is per-step, so the
+          # model step below cannot read it. See the Owner post-mortem in CLAUDE.md.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          PROJECT_OWNER: "@me"
+          PROJECT_NUMBER: "4"
+        run: .github/agent-bin/set-issue-in-progress.sh
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -671,6 +682,17 @@ jobs:
           REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: .github/agent-bin/stamp-role-label.sh
+      - name: Move the issue to In Progress
+        env:
+          # ⚠️ PROJECTS_TOKEN is safe here and only here: step env is per-step, so the
+          # model step below cannot read it. See the Owner post-mortem in CLAUDE.md.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          PROJECT_OWNER: "@me"
+          PROJECT_NUMBER: "4"
+        run: .github/agent-bin/set-issue-in-progress.sh
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -437,11 +437,6 @@ jobs:
             the pull request yourself — do not stop at pushing a branch and returning a PR
             link.
 
-            ⚠️ **Label the PR `@claude/implementor`** — `gh pr create --label "@claude/implementor"`.
-            This is the exception to the repo's "leave things unlabeled" rule: a PR carries
-            the label of the role that opened it, which is how the merge hook recognises its
-            own work. Label the PR **you open** and nothing else — never an existing PR, and
-            never an issue.
 
             ⚠️ **Cut your branch FROM the issue's stated base branch.** If the issue names a
             **Base branch** (sub-issues of an epic do — they land on the epic's integration
@@ -470,51 +465,9 @@ jobs:
             you branched from the wrong place — re-cut from `origin/<base-branch>` and
             reapply your work rather than opening the PR anyway.
 
-            ⚠️ **Then open the epic's integration PR if nobody has yet.** Whichever
-            Implementor gets there first opens it, so it exists from the start of the epic
-            and the maintainer can watch the feature accumulate. After opening your own PR,
-            check:
-
-                gh pr list --head <branch> --base mainline --state open
-
-            If that comes back empty, open it: base `mainline`, head `<branch>`, titled for
-            the epic, with `Closes #<epic-number>` in the body (the issue's **Base branch**
-            line names the epic). Say in the body that it collects the epic's sub-issue PRs
-            and stays open until the feature is done. Leave it ready for review, not a draft
-            — the maintainer reviews it as it fills up, and merges it.
-
-            ⚠️ **Exactly ONE closing keyword in that body: the epic's.** This PR targets
-            `mainline`, the default branch, so *every* closing keyword in it is live — and
-            listing the sub-PRs it collects is the natural thing to write:
-
-                - #356 — Popover primitive · closes #341     ← WRONG, closes the sub-issue
-
-            That links the sub-issue to the **epic's** PR and closes it out from under its
-            own PR. It has already happened once. When you list sub-PRs, refer to their
-            issues with a bare number or "for #341" — never `closes`/`fixes`/`resolves`,
-            in prose, in a table, or in a bullet. Each sub-issue is closed by its own PR.
-
-            ⚠️ If you are the very first sub-issue, the branch has no commits of its own yet
-            (yours are still in an open PR *into* it), and GitHub refuses with **"No commits
-            between mainline and <branch>"**. That is expected, not an error to debug. Give
-            the branch a marker commit and retry the create:
-
-                git fetch origin <branch>
-                git checkout <branch>
-                git commit --allow-empty -m "Start epic #<epic-number>"
-                git push origin <branch>
-
-            ⚠️ **Never push feature work straight to an integration branch** — code lands
-            there by merging sub-issue PRs, and a direct push bypasses the review the branch
-            exists to collect. Two housekeeping pushes are fine and expected: that empty
-            marker commit, and merging `mainline` into the branch to keep it current
-            (`git merge origin/mainline`), which is ordinary maintenance and often what
-            resolves a stale or conflicted epic. The line is *whose work it is* — yours goes
-            through a PR; bringing the branch up to date does not. Return to your own branch
-            afterwards.
-
-            If the integration PR already exists, leave it alone. Do not retitle it, do not
-            update it, and never merge it.
+            ⚠️ **The epic's integration PR opens itself.** A post-hook checks whether the base
+            branch already has a PR to `mainline` and opens one if not, marker commit and
+            all. Don't open it, don't retitle it, and never merge it.
 
             ⚠️ **Write no code comments.** See CLAUDE.md's _Code style_. Not explanatory
             blocks, not `⚠️` notes, not JSDoc — none, unless the issue or a reviewer asks
@@ -641,6 +594,23 @@ jobs:
             --model opus
             --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*)"
             --max-turns 80
+
+      - name: Label and link the PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLE: implementor
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+        run: .github/agent-bin/finish-pr.sh
+      - name: Open the epic integration PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLE: implementor
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+        run: .github/agent-bin/open-integration-pr.sh
 
   # ── Tester ─────────────────────────────────────────────────────────────────────
   # Owns packages/e2e. The Implementor ships behaviour and writes Testing notes into its
@@ -772,10 +742,6 @@ jobs:
             must list only your own commits. If it doesn't, re-cut and reapply rather than
             opening the PR anyway.
 
-            ⚠️ **Label the PR `@claude/tester`** — `gh pr create --label "@claude/tester"`.
-            This is the exception to the repo's "leave things unlabeled" rule: a PR carries
-            the label of the role that opened it, which is how the merge hook recognises its
-            own work. Label the PR **you open** and nothing else.
 
             Put **`Closes #<issue>`** in the body when an issue prompted the work. That line
             is what the merge hook parses to close the issue and file it on the board — omit
@@ -831,6 +797,15 @@ jobs:
             --model sonnet
             --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
             --max-turns 80
+
+      - name: Label and link the PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLE: tester
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+        run: .github/agent-bin/finish-pr.sh
 
   # ── Writer ─────────────────────────────────────────────────────────────────────
   # The tech writer. Owns documentation: every CLAUDE.md, the agent instruction files
@@ -929,9 +904,6 @@ jobs:
             `mainline`, and cut your branch **from** that base rather than from whatever the
             workflow checked out.
 
-            ⚠️ **Label the PR `@claude/writer`** — `gh pr create --label "@claude/writer"`.
-            A PR carries the label of the role that opened it; that is how the merge hook
-            recognises its own work. Label the PR **you open** and nothing else.
 
             Put **`Closes #<issue>`** in the body when an issue prompted the work — that line
             is what the merge hook parses to close it and file it on the board. Include a
@@ -952,6 +924,15 @@ jobs:
             --model sonnet
             --allowedTools "Read,Edit,Write,Bash(git:*),Bash(gh:*)"
             --max-turns 60
+
+      - name: Label and link the PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLE: writer
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+        run: .github/agent-bin/finish-pr.sh
 
   # ── Security ───────────────────────────────────────────────────────────────────
   # Reviews what just landed on mainline and files issues for what it finds. Runs on

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -426,6 +426,12 @@ jobs:
             the pull request yourself — do not stop at pushing a branch and returning a PR
             link.
 
+            ⚠️ **Label the PR `@claude/implementor`** — `gh pr create --label "@claude/implementor"`.
+            This is the exception to the repo's "leave things unlabeled" rule: a PR carries
+            the label of the role that opened it, which is how the merge hook recognises its
+            own work. Label the PR **you open** and nothing else — never an existing PR, and
+            never an issue.
+
             ⚠️ **Cut your branch FROM the issue's stated base branch.** If the issue names a
             **Base branch** (sub-issues of an epic do — they land on the epic's integration
             branch, not `mainline`), it governs two separate things, and getting only the
@@ -725,8 +731,39 @@ jobs:
             weakening the test until it passes. Never delete or `test.skip` an existing test
             to get green — if an existing test now fails, that is the headline of your report.
 
-            Open a PR with your specs, following the root CLAUDE.md's Contributing section.
-            ⚠️ **Target the issue's stated Base branch** if it names one, else `mainline`.
+            **Opening the PR.** Follow the root CLAUDE.md's Contributing section for branch
+            naming and commit style.
+
+            ⚠️ **Cut your branch FROM the issue's stated Base branch**, don't merely point at
+            it. The workflow checks you out on **`mainline`**, so you start on the wrong
+            branch whenever the issue names another — one command per Bash call:
+
+                git fetch origin <base-branch>
+                git checkout -B <your-branch> origin/<base-branch>
+
+            Then `gh pr create --base <base-branch> --head <your-branch>`. Doing only the
+            second makes a PR that *looks* right while its branch was cut from `mainline`,
+            so the diff carries every unrelated change since. Default to `mainline` only when
+            the issue names no base branch.
+
+            ⚠️ **Check your own diff first.** `git log --oneline origin/<base-branch>..HEAD`
+            must list only your own commits. If it doesn't, re-cut and reapply rather than
+            opening the PR anyway.
+
+            ⚠️ **Label the PR `@claude/tester`** — `gh pr create --label "@claude/tester"`.
+            This is the exception to the repo's "leave things unlabeled" rule: a PR carries
+            the label of the role that opened it, which is how the merge hook recognises its
+            own work. Label the PR **you open** and nothing else.
+
+            Put **`Closes #<issue>`** in the body when an issue prompted the work. That line
+            is what the merge hook parses to close the issue and file it on the board — omit
+            it and the issue stays open with nothing pointing at it.
+
+            Include a **Verification** section: `npm run test:e2e -w packages/e2e` with the
+            pass count, and `npm test --ws` (eslint). ⚠️ Run the lint before opening —
+            `packages/e2e`'s eslint is part of **Verify**, so a style slip you didn't check
+            arrives as a red PR rather than something you caught. Do **not** run `npm ci`
+            or `npm install`; dependencies and browsers are already installed.
 
             ⚠️ **Stay inside `packages/e2e`.** You do not fix app code — a failing test is a
             report, not an invitation to change `packages/app`. The one exception is adding
@@ -867,7 +904,17 @@ jobs:
 
             Follow the Contributing section for branch naming, commits and the PR template.
             Open a PR — ⚠️ against the issue's stated **Base branch** if it names one, else
-            `mainline`.
+            `mainline`, and cut your branch **from** that base rather than from whatever the
+            workflow checked out.
+
+            ⚠️ **Label the PR `@claude/writer`** — `gh pr create --label "@claude/writer"`.
+            A PR carries the label of the role that opened it; that is how the merge hook
+            recognises its own work. Label the PR **you open** and nothing else.
+
+            Put **`Closes #<issue>`** in the body when an issue prompted the work — that line
+            is what the merge hook parses to close it and file it on the board. Include a
+            **Verification** line saying `npm test --ws` (eslint) is clean; you change no
+            code, so there is nothing else to run, and you must not run `npm ci`/`install`.
 
             ⚠️ **Documentation only.** You do not change application code, tests, or
             workflows. If documenting something reveals a bug, say so in a comment and leave

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,12 +144,15 @@ model step.
 
 - `stamp-role-label.sh` — pre, every role. Stamps `@claude/<role>` on the issue or PR.
 - `file-sub-issues.sh` — post, Researcher. Parents and milestones from the epic's manifest.
+- `set-issue-in-progress.sh` — pre, Implementor and Tester. Moves the triggering issue to
+  **In Progress** on project #4, so the board reflects reality when work starts rather than
+  only when it merges. Skips a closed issue, so a re-run never resurrects finished work.
 - `close-merged-work.sh` — on merge. Closes the PR's issues and files them on the board.
 
 ⚠️ These were prompt instructions until a model skipped them. A label trail is worthless if
 a run can forget to stamp it, and the merge hook is the only backlog behaviour that worked
 on its first attempt — everything model-driven took three.
-⚠️ `close-merged-work.sh` is the only place `PROJECTS_TOKEN` appears. It is a long-lived
+⚠️ `PROJECTS_TOKEN` appears only in `close-merged-work.sh` and `set-issue-in-progress.sh`, both scripted steps. Step env is per-step, so a model step in the same job cannot read it. It is a long-lived
 classic PAT (`project` + `read:org`) covering every project the maintainer owns, secret
 masking covers logs only, and a role holding `Bash(gh:*)` could publish it in a comment.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,11 @@ model step.
 - `set-issue-in-progress.sh` — pre, Implementor and Tester. Moves the triggering issue to
   **In Progress** on project #4, so the board reflects reality when work starts rather than
   only when it merges. Skips a closed issue, so a re-run never resurrects finished work.
+- `finish-pr.sh` — post, Implementor / Tester / Writer. Labels the PR the run opened with
+  its role, and appends `Closes #<issue>` if the model didn't write one.
+- `open-integration-pr.sh` — post, Implementor. Opens the epic's integration PR when the
+  base branch has none, marker commit included. Reads the branch and epic number out of the
+  sub-issue's *Base branch* line.
 - `close-merged-work.sh` — on merge. Closes the PR's issues and files them on the board.
 
 ⚠️ These were prompt instructions until a model skipped them. A label trail is worthless if
@@ -162,8 +167,12 @@ read as "these agents have been here". The maintainer clears them as a check-off
 - `stamp-role-label.sh` stamps the issue or PR that **triggered** the run.
 - A role that **opens** a PR labels it itself (`gh pr create --label "@claude/<role>"`) — the
   triggering stamp cannot reach a PR that did not exist yet.
-- ⚠️ Two carve-outs from "create things unlabeled": a role labels the PR it opens, and
-  Security labels the issues it files. Nothing else, and never someone else's.
+- ⚠️ Two carve-outs from "create things unlabeled": a role's PR is labelled by
+  `finish-pr.sh`, and Security labels the issues it files. Nothing else, and never
+  someone else's.
+- ⚠️ `Closes #<issue>` stays a prompt instruction *and* a hook. The model writing it puts
+  the link where a human reads it; the hook is the net, because a missing keyword loses the
+  close and the board move with nothing to signal it.
 
 **Documentation belongs to the Writer.** Implementor and Tester change no `CLAUDE.md`. They
 optionally end their handoff with a fenced `json` block of **docs candidates** —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,12 @@ masking covers logs only, and a role holding `Bash(gh:*)` could publish it in a 
 **Labels are a record, not a route.** Each role stamps its own as it starts, so the labels
 read as "these agents have been here". The maintainer clears them as a check-off.
 
+- `stamp-role-label.sh` stamps the issue or PR that **triggered** the run.
+- A role that **opens** a PR labels it itself (`gh pr create --label "@claude/<role>"`) — the
+  triggering stamp cannot reach a PR that did not exist yet.
+- ⚠️ Two carve-outs from "create things unlabeled": a role labels the PR it opens, and
+  Security labels the issues it files. Nothing else, and never someone else's.
+
 **Documentation belongs to the Writer.** Implementor and Tester change no `CLAUDE.md`. They
 optionally end their handoff with a fenced `json` block of **docs candidates** —
 `{"docsCandidates": [{"file", "note", "why"}]}` — and the Writer decides what earns a place.


### PR DESCRIPTION
## Summary

Everything deterministic is now out of the model layer. This also **folds in #417** — please close that one; shipping the PR-labelling flag as a prompt instruction and then replacing it with a hook an hour later made no sense.

| hook | when | does |
|---|---|---|
| `stamp-role-label.sh` | pre, every role | stamps `@claude/<role>` on the trigger |
| `set-issue-in-progress.sh` | pre, Implementor / Tester | moves the issue to **In Progress** |
| `file-sub-issues.sh` | post, Researcher | parents + milestones from the manifest |
| `finish-pr.sh` | post, Implementor / Tester / Writer | labels the PR, ensures `Closes #<issue>` |
| `open-integration-pr.sh` | post, Implementor | opens the epic PR when it's missing |
| `close-merged-work.sh` | on merge | closes issues, files them on the board |

```
implementor  stamp → in-progress → «model» → finish-pr → open-integration-pr
tester       stamp → in-progress → «model» → finish-pr
writer       stamp → «model» → finish-pr
researcher   stamp → «model» → file-sub-issues
```

## What moved, and why it mattered

**`finish-pr.sh`** resolves the PR the run opened — by head branch, falling back to an open PR whose body closes the triggering issue — then labels it and appends `Closes #<issue>` if the model didn't write one. ⚠️ That keyword is what `close-merged-work.sh` parses; without it the issue never closes and never reaches Done, **with nothing to signal the omission**. It was a flag a model had to remember.

**`open-integration-pr.sh`** replaces ~25 lines of Implementor prompt, including the `--allow-empty` marker-commit dance the first sub-issue needs (the Manager cuts the branch empty, and GitHub refuses a PR with no commits between). It reads the branch and epic number out of the sub-issue's *Base branch* line.

Together these cut **~3.6KB of prompt** across three roles.

**`Closes #<issue>` stays in the prompt as well as the hook**, deliberately. The model writing it puts the link in the Summary where a human reads it; the hook is only the net.

## Verified rather than assumed

- Base-branch parsing against the real form the Researcher writes → `branch=250-volume-milestone`, `epic=250`.
- Closing-keyword regex: matches `Closes #413` / `closes #413` / `Fixes #413`, and correctly **rejects `Closes #4131`**.
- Both scripts exit clean with no PR and no issue.
- `In Progress` option and `.status` exposure confirmed against project #4.
- All six hooks pass `bash -n`; YAML parses with seven jobs; `npm test --ws` clean.

⚠️ **Testing `finish-pr.sh` from this branch labelled PR #418 for real** — it resolves by head branch, and I was standing on one. Removed the label. It does demonstrate the resolution path works against live data.

## Not moved, on purpose

The gate run stays with the model (it must happen *before* the PR is opened, and the model opens it), as does anything requiring judgement — which files to read, what to test, whether a docs candidate earns its place. Scripting those would just be a worse model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
