### PR TITLE
Run the Tester and Writer automatically when an Implementor opens its PR

### DIFF
--- a/.github/agent-bin/finish-pr.sh
+++ b/.github/agent-bin/finish-pr.sh
@@ -31,6 +31,13 @@ if [ -z "$pr" ]; then
     exit 0
 fi
 
+# Published so the Tester and Writer can chain off this run and be pointed at the PR it
+# produced. Left unwritten on the early exit above, so an Implementor run that opened no
+# PR yields an empty output and starts neither. Guarded for use outside Actions.
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "pr=$pr" >> "$GITHUB_OUTPUT"
+fi
+
 if gh pr edit "$pr" --repo "$REPO" --add-label "@claude/$ROLE" >/dev/null 2>&1; then
     echo "PR #$pr -> @claude/$ROLE"
 else

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -353,6 +353,10 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/implementor'))
       )
     runs-on: ubuntu-latest
+    # The PR this run produced, read by the tester and writer jobs that chain off it.
+    # Empty when the run opened none, which is what stops the chain — see their `if:`.
+    outputs:
+      pr: ${{ steps.finish.outputs.pr }}
     permissions:
       contents: write
       pull-requests: write
@@ -596,6 +600,7 @@ jobs:
             --max-turns 80
 
       - name: Label and link the PR
+        id: finish
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -620,11 +625,23 @@ jobs:
   # fire-and-forget call while lint/tsc/build stay green) is only caught by a test written
   # to distrust the change.
   tester:
+    # Chains off the Implementor as well as answering its own handle. The last clause is
+    # the chain; the three before it are unchanged and still work on their own.
+    #
+    # ⚠️ `!cancelled()` is load-bearing, not decoration. With `needs:`, a SKIPPED upstream
+    # job skips its dependents, and GitHub applies an implicit "all needs succeeded" gate.
+    # A status-check function overrides both. Drop it and a hand-typed @claude/tester can
+    # never run again: the implementor skips, so this skips. `!cancelled()` over `always()`
+    # so a cancelled run doesn't drag the job in; on an implementor *failure* it still
+    # evaluates, then correctly skips on the result check below.
+    needs: [implementor]
     if: |
-      github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
+      !cancelled() && github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude/tester')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude/tester')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/tester'))
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/tester')) ||
+        (github.event_name == 'issue_comment' && !github.event.issue.pull_request
+          && needs.implementor.result == 'success' && needs.implementor.outputs.pr != '')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -669,16 +686,21 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # ⚠️ track_progress forces the action's TAG MODE, which gates on this phrase
-          # independently of our own `if:`. Leave it at the default "@claude" and the
-          # action skips in 0s with a placeholder comment, because "@claude/tester"
-          # is not a match for "@claude".
-          trigger_phrase: "@claude/tester"
+          # independently of our own `if:`. It must therefore match EVERY comment that can
+          # start this job — and since the chain above starts it from a comment saying
+          # "@claude/implementor", a "@claude/tester" phrase would skip the step in 0s and
+          # leave a placeholder comment. "@claude/" matches any role handle; the job's own
+          # `if:` is what routes, so a @claude/writer comment still cannot start the Tester.
+          trigger_phrase: "@claude/"
           track_progress: true
           prompt: |
             You are the **Tester** — you own `packages/e2e`, the Playwright suite that
             drives the real app in a browser. You are triggered by someone writing
-            **`@claude/tester`** in a comment, on an issue or a PR. Labels never start a run
-            — they only record which roles have already been here.
+            **`@claude/tester`** in a comment, on an issue or a PR, or automatically once an
+            Implementor run finishes and opens its PR. Labels never start a run — they only
+            record which roles have already been here.
+            ${{ needs.implementor.outputs.pr && format('**This is an automatic run.** An Implementor just opened PR #{0} — that is your subject. Read it first with `gh pr view {0} --comments` and work from its Handoff Testing notes.', needs.implementor.outputs.pr) || '' }}
+            ${{ needs.implementor.outputs.pr && 'Nobody asked for this run by hand, so there is no instruction comment to read — the PR and its diff are the whole brief.' || '' }}
 
             Read `packages/e2e/CLAUDE.md` first — it is short and it is the spec for how
             this suite works. The repo-root `CLAUDE.md` covers branch/PR/commit conventions.
@@ -816,11 +838,22 @@ jobs:
   # neither of them was really working on. Implementor and Tester now report what needs
   # documenting in their handoff and change no docs themselves.
   writer:
+    # Chains off the Implementor like the Tester, but waits on the Tester too, so one
+    # Writer run sees both roles' docs candidates instead of two runs racing on the same
+    # CLAUDE.md — the merge conflicts that split this role out in the first place.
+    #
+    # ⚠️ `!cancelled()` is load-bearing — see the note on the tester job. Without it a
+    # hand-typed @claude/writer can never run again.
+    # ⚠️ Waiting on the tester means a manually-triggered Tester run leaves this job
+    # showing as *pending* in the checks list until it finishes, then skipping. Cosmetic.
+    needs: [implementor, tester]
     if: |
-      github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
+      !cancelled() && github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude/writer')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude/writer')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/writer'))
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/writer')) ||
+        (github.event_name == 'issue_comment' && !github.event.issue.pull_request
+          && needs.implementor.result == 'success' && needs.implementor.outputs.pr != '')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -845,14 +878,19 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
-          trigger_phrase: "@claude/writer"
+          # ⚠️ Must match every comment that can start this job, including the chained run's
+          # "@claude/implementor" — see the note on the tester job's trigger_phrase.
+          trigger_phrase: "@claude/"
           prompt: |
             You are the **Writer** — the technical writer. You own the repo's documentation:
             every `CLAUDE.md`, the agent instruction files under `.claude/skills/`, and any
             other file whose job is to explain rather than to run. No other role edits them.
 
             You are triggered by someone writing **`@claude/writer`** in a comment, on an
-            issue or a PR. Read that comment first: it is the instruction.
+            issue or a PR — read that comment first, it is the instruction — or automatically
+            once an Implementor run finishes and opens its PR.
+            ${{ needs.implementor.outputs.pr && format('**This is an automatic run.** An Implementor opened PR #{0}, and a Tester may have opened one of its own against the same issue. Start from `gh pr view {0} --comments` and collect the docs candidates from both.', needs.implementor.outputs.pr) || '' }}
+            ${{ needs.implementor.outputs.pr && 'There is no instruction comment on an automatic run. Apply exactly the filter you always do — for a run nobody asked for, rejecting every candidate and opening no PR is the most likely correct outcome, not a failure.' || '' }}
 
             **Where your work comes from.** Usually an Implementor or Tester PR whose handoff
             ends with a fenced `json` block of **docs candidates**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,34 @@ history.
 ⚠️ Manager and Researcher require `!github.event.issue.pull_request` — `issue_comment` fires
 for PRs too, and without the guard a PR comment started a role written for an epic issue.
 
+**Tester and Writer also run on their own, chained off the Implementor.** An Implementor run
+started *from an issue* that opens a PR is followed by a Tester and then a Writer, both pointed
+at that PR. Their handles still work by hand; the chain is a fourth way in, not a replacement.
+
+- The Implementor publishes the PR number as a job output (`finish-pr.sh` → `$GITHUB_OUTPUT`),
+  and the two jobs `needs:` it. Same workflow run, so no new credential is involved.
+- Writer waits on Tester as well, so one run sees both roles' docs candidates instead of two
+  racing on the same `CLAUDE.md`.
+- Chaining is narrowed to `issue_comment` **not** on a PR. Implementors re-run constantly from
+  review feedback, and without that guard each re-run opened another duplicate spec and docs PR.
+- An Implementor that opens no PR yields an empty output and starts neither.
+
+⚠️ **A comment cannot chain the roles**, which is why this is `needs:` and not a hook. GitHub
+refuses to start a run from an event created with `GITHUB_TOKEN`, and the `if:` guards exclude
+`github-actions[bot]` besides. Posting `@claude/tester` from a hook is silently inert; making it
+work would need a new `repo`-scoped PAT in reach of a step.
+⚠️ **`!cancelled()` in the Tester's and Writer's `if:` is load-bearing.** With `needs:`, a
+*skipped* upstream job skips its dependents, and GitHub applies an implicit "all needs
+succeeded" gate; a status-check function overrides both. Drop it and a hand-typed
+`@claude/tester` can never run again — the Implementor skips, so the Tester skips.
+⚠️ **Their `trigger_phrase` is `"@claude/"`, not their own handle.** `track_progress: true`
+forces tag mode, which gates on that phrase independently of the `if:` — and a chained run's
+triggering comment says `@claude/implementor`. With the narrower phrase the step skips in `0s`
+and posts a placeholder comment, the same failure that kept the retired Owner role from ever
+running. The `if:` is what routes, so the wider phrase cannot start the wrong role.
+⚠️ Workflow changes to any of this **cannot be tested before merge**: `issue_comment` always
+runs the workflow from the default branch, so a PR branch's version is never the one that fires.
+
 **Backlog work is scripted, never prompted.** Hooks in `.github/agent-bin/` run around each
 model step.
 


### PR DESCRIPTION
## Summary

An Implementor run started **from an issue** that opens a PR is now followed automatically by a Tester and then a Writer, both pointed at that PR. Their handles still work by hand — the chain is a fourth way in, not a replacement.

Closes #421

**Chaining by comment is impossible, which is why this is `needs:`.** GitHub refuses to start a workflow run from an event created with `GITHUB_TOKEN` (the recursion guard), and the `if:` guards exclude `github-actions[bot]` besides. A hook posting `@claude/tester` on the PR would be silently inert, and making it work would need a new `repo`-scoped PAT within reach of a step — the credential surface `PROJECTS_TOKEN` is deliberately kept away from model steps to avoid. All six roles already share one workflow, so `needs:` does it with no new secret.

### What changed

| File | Change |
|---|---|
| `.github/agent-bin/finish-pr.sh` | Publishes the already-resolved PR number to `$GITHUB_OUTPUT`. Guarded on the var being set so the script still runs outside Actions. |
| `.github/workflows/claude-roles.yaml` | `implementor` gains `outputs.pr`; `tester` gains `needs: [implementor]`; `writer` gains `needs: [implementor, tester]`; both gain a chained `if:` clause, a widened `trigger_phrase`, and a conditional prompt block naming the PR. |
| `CLAUDE.md` | Documents the chain and the traps below. |

`writer` waits on `tester` too, so one Writer run sees both roles' docs candidates instead of two runs racing on the same `CLAUDE.md` — the merge conflicts that split the role out originally.

Chaining is narrowed to `issue_comment` **not** on a PR. Implementors re-run constantly from review feedback; without that guard a PR with three review rounds would produce three duplicate spec PRs and three duplicate docs PRs.

### Two guards that read as decoration and aren't

- **`!cancelled()` in both `if:` blocks.** With `needs:`, a *skipped* upstream job skips its dependents, and GitHub applies an implicit "all needs succeeded" gate. A status-check function overrides both. Remove it and a hand-typed `@claude/tester` can **never run again** — the Implementor skips, so the Tester skips. `!cancelled()` rather than `always()` so cancelled runs don't drag the jobs in; on an Implementor *failure* it still evaluates and then correctly skips on the result check.
- **`trigger_phrase: "@claude/"`, not the role's own handle.** `track_progress: true` forces the action's tag mode, which gates on that phrase *independently of our `if:`*, and a chained run's triggering comment says `@claude/implementor`. With the narrower phrase the step skips in `0s` and posts a placeholder comment — the same failure that kept the retired Owner role from ever running (#348). The job `if:` is what routes, so the wider phrase cannot start the wrong role.

## Verification

`npm test --ws` (eslint) ✓ — 0 errors, 6 pre-existing `react-hooks/exhaustive-deps` warnings; the gate is errors-only.
`tsc --noEmit` ✓ clean.
`vite build` ✓ (`dist/sw.js`, 65 precache entries).

No application code changed — this is workflow, hook script, and docs only.

**Workflow YAML parses**, and the job graph is what was intended:

```
implementor  needs=-                          outputs=["pr"]
tester       needs=["implementor"]
writer       needs=["implementor","tester"]
implementor finish step id = "finish"
tester/writer: trigger_phrase="@claude/"  track_progress=true
```

**`finish-pr.sh` exercised directly** against a stubbed `gh`, all three paths:

| Case | Result |
|---|---|
| PR resolved | `pr=999` written to `$GITHUB_OUTPUT`, exit 0 |
| No PR found | output file **empty** (chain stops), exit 0 |
| `GITHUB_OUTPUT` unset (outside Actions) | exit 0, no error |

**The `if:` expressions were evaluated against the real strings from the file** under nine scenarios, mimicking GitHub's operator semantics (`&&`/`||` return operands, `""` falsy, `contains()` substring):

| Scenario | implementor | tester | writer |
|---|:--:|:--:|:--:|
| manual `@claude/tester` on an issue | · | **RUN** | · |
| manual `@claude/writer` on an issue | · | · | **RUN** |
| manual `@claude/tester` on a PR | · | **RUN** | · |
| implementor from issue, opened PR 418 | **RUN** | **RUN** | **RUN** |
| implementor from issue, opened no PR | **RUN** | · | · |
| implementor from a PR comment (re-run) | **RUN** | · | · |
| implementor failed | **RUN** | · | · |
| review comment `@claude/writer` | · | · | **RUN** |
| bot comment (loop guard) | · | · | · |

Rows 1–3 are the regression this change risks — manual triggering is unaffected.

## ⚠️ What could not be verified before merge

**`issue_comment` always runs the workflow from the default branch**, so this PR's version of `claude-roles.yaml` is never the one that fires. The chain cannot be exercised on a branch — the first real run of it will be the first Implementor run after this merges. The same constraint already documented for `pull_request` events and in-flight epics.

What that leaves unproven is GitHub's own behaviour, not the logic: that `!cancelled()` overrides the implicit `needs` gate as documented, and that the action's tag mode accepts `"@claude/"` as a prefix match. The second is the one with prior evidence — it is the fix that made the Owner role fire in #348.

Suggested smoke test after merge: comment `@claude/tester` on a throwaway issue (proves the manual path survived), then run an Implementor on a small issue and confirm the Tester's Claude step actually executes rather than skipping in `0s`.

## Note

The `writer` job now shows as *pending* in the checks list during a manually-triggered Tester run before skipping, because it waits on `tester`. Cosmetic, but it looks like something is queued when nothing is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
