### PR TITLE
Discover an epic's sub-issues instead of relying on a model-written manifest

### DIFF
--- a/.github/agent-bin/file-sub-issues.sh
+++ b/.github/agent-bin/file-sub-issues.sh
@@ -1,52 +1,110 @@
 #!/usr/bin/env bash
+# Post-hook for the Researcher. Parents the epic's sub-issues to it and copies the
+# epic's milestone down.
+#
+# Children are DISCOVERED, not declared. This used to read a machine-readable manifest
+# the model left in a comment; across nine epics the model wrote one exactly once, so the
+# hook silently filed nothing. The anchor now is the *Base branch* line the Researcher
+# must already put in every sub-issue body, which open-integration-pr.sh also parses:
+#
+#   **Base branch: `412-brewtimer`** — the integration branch for epic #412.
+#
+# A manifest is still honoured when one exists, unioned with what was discovered, so
+# epics decomposed under the old contract keep working.
 set -euo pipefail
 
+: "${REPO:?REPO is required}"
+: "${ISSUE:?ISSUE is required}"
+
+manifest_children=""
 manifest=$(gh api "repos/$REPO/issues/$ISSUE/comments" --paginate \
-  --jq '[.[] | select(.body | contains("owner-manifest")) | .body] | last // empty')
+    --jq '[.[] | select(.body | contains("owner-manifest")) | .body] | last // empty')
 
-if [ -z "$manifest" ]; then
-  echo "No owner-manifest on #$ISSUE — nothing to file."
-  exit 0
+if [ -n "$manifest" ]; then
+    # one line on purpose: a python heredoc indented inside a YAML block would arrive
+    # with its leading spaces intact and die on IndentationError
+    manifest_children=$(printf '%s' "$manifest" | python3 -c 'import sys,re,json; m=re.search(r"owner-manifest\s*(\{.*?\})\s*-->", sys.stdin.read(), re.S); print("\n".join(str(c) for c in (json.loads(m.group(1)).get("children") or [])) if m else "")' 2>/dev/null || true)
+    if [ -n "$manifest_children" ]; then
+        echo "manifest on #$ISSUE lists: $(printf '%s' "$manifest_children" | tr '\n' ' ')"
+    else
+        echo "::warning::#$ISSUE has an owner-manifest marker with no usable children — ignoring it."
+    fi
 fi
 
-# one line on purpose: a python heredoc indented inside this YAML block would
-# arrive with its leading spaces intact and die on IndentationError
-payload=$(printf '%s' "$manifest" | python3 -c 'import sys,re; m=re.search(r"owner-manifest\s*(\{.*?\})\s*-->", sys.stdin.read(), re.S); print(m.group(1) if m else "")')
+# ⚠️ The REST list endpoint, never the search API. Issue search is asynchronously indexed
+# and these issues are seconds old when this hook runs, so a search would intermittently
+# return nothing at all. This list is direct and has no such lag.
+#
+# Three markers, all required:
+#
+#   1. the author is a Bot — the Researcher creates sub-issues through the action
+#   2. a Base branch line whose branch is the epic's own `<epic#>-<summary>` branch
+#   3. a reference to `epic #<N>`
+#
+# ⚠️ The body markers alone are not enough, and this repo is exactly where that breaks:
+# it has meta-issues *about* the agent workflow, and one of them quoted the Base branch
+# convention verbatim as an example. It satisfied every text rule and was adopted as a
+# sub-issue of the epic it was describing. No prose heuristic can survive documentation
+# that quotes the prose — the author check is what makes this sound, since a human-written
+# issue is type User and a Researcher-created one is type Bot.
+#
+# ⚠️ The consequence is that a sub-issue the maintainer writes BY HAND is never
+# auto-parented. That is the intended trade: this hook exists to clean up after the model.
+#
+# The trailing (non-digit|end) stops `epic #412` from matching `epic #4123`.
+#
+# `.number > epic` is both a correctness filter and the pagination bound: a child is
+# always created after its epic, so it always has a higher number. Without paginating,
+# one page of 100 only reached back a few weeks and an older epic re-run found nothing.
+#
+# EPIC is passed through the environment and read with jq's `env` so this filter can stay
+# single-quoted — a double-quoted shell string would treat the backtick before the branch
+# name as command substitution. It also keeps everything inside gh's built-in jq, so the
+# script needs no standalone jq on PATH.
+discovered=$(EPIC="$ISSUE" gh api --paginate \
+    "repos/$REPO/issues?state=all&sort=created&direction=desc&per_page=100" \
+    --jq '[ .[]
+            | select(.pull_request == null)
+            | select(.number > (env.EPIC | tonumber))
+            | select(.user.type == "Bot")
+            | select((.body // "") | test("(?i)base *branch *: *.?`" + env.EPIC + "-"))
+            | select((.body // "") | test("(?i)epic +#" + env.EPIC + "([^0-9]|$)"))
+            | .number ] | .[]' 2>/dev/null || true)
 
-if [ -z "$payload" ]; then
-  echo "::warning::#$ISSUE has an owner-manifest marker whose JSON could not be parsed — leaving it alone."
-  exit 0
+if [ -n "$discovered" ]; then
+    echo "discovered for #$ISSUE: $(printf '%s' "$discovered" | tr '\n' ' ')"
+else
+    echo "no issue body carries a Base branch line naming epic #$ISSUE"
 fi
 
-epic=$(printf '%s' "$payload" | jq -r '.epic')
-children=$(printf '%s' "$payload" | jq -r '(.children // [])[]')
+children=$(printf '%s\n%s\n' "$manifest_children" "$discovered" | grep -E '^[0-9]+$' | sort -un || true)
 
 if [ -z "$children" ]; then
-  echo "Manifest on #$ISSUE lists no children — nothing to file."
-  exit 0
+    echo "Nothing to file for #$ISSUE."
+    exit 0
 fi
 
-milestone=$(gh issue view "$epic" --repo "$REPO" --json milestone --jq '.milestone.title // empty')
-existing=" $(gh api "repos/$REPO/issues/$epic/sub_issues" --jq '[.[].number] | join(" ")' 2>/dev/null || true) "
+milestone=$(gh issue view "$ISSUE" --repo "$REPO" --json milestone --jq '.milestone.title // empty')
+existing=" $(gh api "repos/$REPO/issues/$ISSUE/sub_issues" --jq '[.[].number] | join(" ")' 2>/dev/null || true) "
 
 for child in $children; do
-  if [ "${existing#* $child }" != "$existing" ]; then
-    echo "#$child already a sub-issue of #$epic"
-  else
-    # ⚠️ this API wants the child's integer REST id, not its issue number
-    cid=$(gh api "repos/$REPO/issues/$child" --jq .id)
-    if gh api --method POST "repos/$REPO/issues/$epic/sub_issues" -F sub_issue_id="$cid" >/dev/null 2>&1; then
-      echo "#$child -> sub-issue of #$epic"
+    if [ "${existing#* $child }" != "$existing" ]; then
+        echo "#$child already a sub-issue of #$ISSUE"
     else
-      echo "::warning::could not parent #$child to #$epic"
+        # ⚠️ this API wants the child's integer REST id, not its issue number
+        cid=$(gh api "repos/$REPO/issues/$child" --jq .id)
+        if gh api --method POST "repos/$REPO/issues/$ISSUE/sub_issues" -F sub_issue_id="$cid" >/dev/null 2>&1; then
+            echo "#$child -> sub-issue of #$ISSUE"
+        else
+            echo "::warning::could not parent #$child to #$ISSUE"
+        fi
     fi
-  fi
 
-  if [ -n "$milestone" ]; then
-    if gh issue edit "$child" --repo "$REPO" --milestone "$milestone" >/dev/null 2>&1; then
-      echo "#$child -> milestone $milestone"
-    else
-      echo "::warning::could not set milestone '$milestone' on #$child"
+    if [ -n "$milestone" ]; then
+        if gh issue edit "$child" --repo "$REPO" --milestone "$milestone" >/dev/null 2>&1; then
+            echo "#$child -> milestone $milestone"
+        else
+            echo "::warning::could not set milestone '$milestone' on #$child"
+        fi
     fi
-  fi
 done

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -271,39 +271,20 @@ jobs:
             - ⚠️ **Don't link, parent, or milestone anything — a script does it.**
               You create the issues and nothing else about the backlog: no `sub_issues` API
               calls, no `--milestone`, no project edits. A post-hook runs the moment you
-              finish and does all of it from the manifest you leave (below), so that
-              manifest is the handoff, not a decoration. Doing it yourself duplicates work
-              and makes the two of you fight over the same fields.
+              finish and does all of it. Doing it yourself duplicates work and makes the two
+              of you fight over the same fields.
+              ⚠️ It finds the sub-issues by reading their **Base branch** line, so that line
+              is what makes a sub-issue findable at all — an issue missing it is never
+              parented and never gets the milestone. Nothing else is asked of you: there is
+              no list to leave behind, and a re-run picks up anything an earlier run missed.
             - Don't give any sub-issue the job of opening the epic's integration PR. The
               Implementor now opens it on the **first** run that finds it missing, so it
               exists from the start of the epic and the maintainer can watch the feature
               accumulate. Nothing about it belongs in a sub-issue body.
             - Post ONE comment on this epic listing the sub-issues in prerequisite order,
-              **ending with the manifest above** — on a follow-up run this comment can be
-              short (what changed, plus the full manifest); it does not have to restate the
-              whole decomposition.
-              marking which are parallel vs blocked — a single index to review.
-              ⚠️ **End that comment with a machine-readable manifest**, exactly this shape,
-              as the last thing in the comment:
-
-                  <!-- owner-manifest
-                  {"epic": 246, "children": [346, 347]}
-                  -->
-
-              An HTML comment, so it is invisible in the rendered issue. The post-hook files the
-              sub-issues from **this**, not from your prose — a script reads it, with no
-              model involved, which is why it has to be exact. Keep the human-readable list
-              above it as well; that is what the maintainer reads.
-
-              ⚠️ **This is an obligation on EVERY run, not just the first.** `children` must
-              list **every** sub-issue of this epic — the ones you created just now *and*
-              any from earlier runs — because the script acts on the newest manifest alone
-              and does not accumulate. So on a follow-up, even one that only adds a single
-              sub-issue or answers a question, post a fresh manifest carrying the full set
-              before you finish. Reread the epic's existing sub-issues if you need to
-              rebuild the list. Skipping this is what leaves sub-issues unparented and off
-              the milestone, and it has already happened: #376 and #377 sat unfiled because
-              a follow-up run posted an index comment with no manifest.
+              marking which are parallel vs blocked — a single index for the maintainer to
+              review. On a follow-up run this comment can be short (just what changed); it
+              does not have to restate the whole decomposition.
 
             Carry these standing Out-of-scope items into every sub-issue: don't hand-edit
             generated files (`routeTree.gen.ts`); don't add lodash (use

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,10 @@ runs the workflow from the default branch, so a PR branch's version is never the
 model step.
 
 - `stamp-role-label.sh` — pre, every role. Stamps `@claude/<role>` on the issue or PR.
-- `file-sub-issues.sh` — post, Researcher. Parents and milestones from the epic's manifest.
+- `file-sub-issues.sh` — post, Researcher. Parents the epic's sub-issues and copies its
+  milestone down. **Discovers** them — a bot-authored issue, numbered above the epic, whose
+  body carries a *Base branch* line naming the epic's own `<epic#>-…` branch. Honours an
+  old `owner-manifest` comment too, unioned.
 - `set-issue-in-progress.sh` — pre, Implementor and Tester. Moves the triggering issue to
   **In Progress** on project #4, so the board reflects reality when work starts rather than
   only when it merges. Skips a closed issue, so a re-run never resurrects finished work.
@@ -185,6 +188,17 @@ model step.
 ⚠️ These were prompt instructions until a model skipped them. A label trail is worthless if
 a run can forget to stamp it, and the merge hook is the only backlog behaviour that worked
 on its first attempt — everything model-driven took three.
+⚠️ **A scripted hook fed by model-written input is still model-driven.** Sub-issue filing
+read a machine-readable manifest the Researcher was told to leave; across nine epics it
+wrote one exactly once, and the hook logged `No owner-manifest — nothing to file` and did
+nothing. Moving the instruction from "call the API" to "write a JSON block" only moved
+where it got skipped. Derive the input from something the model must produce **for another
+reason** — here the *Base branch* line, which the integration PR already depends on.
+⚠️ **A prose marker cannot be the only marker in a repo whose issues quote its own
+conventions.** The first version matched a *Base branch* line plus `epic #N` and adopted a
+meta-issue that quoted the convention verbatim as an example. The author check
+(`.user.type == "Bot"`) is what makes it sound — with the consequence, accepted, that a
+hand-written sub-issue is never auto-parented.
 ⚠️ `PROJECTS_TOKEN` appears only in `close-merged-work.sh` and `set-issue-in-progress.sh`, both scripted steps. Step env is per-step, so a model step in the same job cannot read it. It is a long-lived
 classic PAT (`project` + `read:org`) covering every project the maintainer owns, secret
 masking covers logs only, and a role holding `Bash(gh:*)` could publish it in a comment.


### PR DESCRIPTION
## Summary

Sub-issue association was already scripted — `file-sub-issues.sh` has always done the parenting and milestoning. What failed was its **input**: an `<!-- owner-manifest -->` comment the *model* had to write, and didn't.

The hook's own output from the most recent Researcher run (epic #412):

```
No owner-manifest on #412 — nothing to file.
```

Across nine epics the Researcher has touched, exactly one has a manifest comment. The epics that *do* have sub-issues got them from the local `plan-feature` skill calling the `sub_issues` API directly — not from this hook. Moving the instruction from "call the API" to "write a JSON block" moved where it got skipped, not whether.

Closes #424

### What changed

Children are now **derived** from something the Researcher must produce for another reason — the *Base branch* line, which `open-integration-pr.sh` already parses to open the epic's integration PR. A child is:

1. authored by a **Bot**,
2. numbered **above** the epic,
3. carrying a *Base branch* line naming the epic's own `<epic#>-…` branch, **and**
4. referencing `epic #<N>`.

An existing manifest is still honoured and unioned in, so anything mid-flight keeps working. The prompt's manifest obligation is dropped — including its "`children` must list **every** sub-issue on **every** run" rule, since discovery self-heals and a re-run now picks up whatever an earlier one missed.

### ⚠️ The author check is not belt-and-braces

The first version matched the two body markers only. Run against live data it adopted **#424 — the issue for this very change** — because that issue quotes the *Base branch* convention verbatim as an example, and so satisfied every text rule:

```
epic #412 -> [424, 422]      # 424 is a meta-issue, not a sub-issue
```

In a repo that documents its own agent conventions in its own issue tracker, no prose heuristic survives contact with the documentation. `.user.type == "Bot"` is what makes it sound — real sub-issues are `claude[bot]`, meta-issues are `User`:

```
epic #412 -> [422]           # after adding the author check
```

The accepted consequence: **a sub-issue the maintainer writes by hand is never auto-parented.** That's the intended trade — this hook exists to clean up after the model.

## Verification

`npm test --ws` (eslint) ✓ · `tsc --noEmit` ✓ clean · `vite build` ✓ · workflow YAML parses ✓ · `bash -n` ✓.
No application code changed — hook script, workflow prompt, and docs only.

**Discovery checked against every epic, comparing to what GitHub already records:**

| epic | recorded sub-issues | discovered |
|---|---|---|
| #412 | *(none)* | **422** ← the orphan this fixes |
| #244 | 341 342 343 344 345 | 341 342 343 344 345 |
| #300 | 302 303 304 305 | 302 303 304 305 |
| #259 | 281 282 283 | *(none)* — see below |
| #252 | 376 377 | 376 377 |
| #251 | 306 308 | 306 308 |
| #250 | 307 309 | 307 309 |
| #247 | 351 353 354 355 | 351 353 354 355 |
| #246 | 346 347 | 346 347 |

Exact reproduction on 7 of 8 epics that have sub-issues, plus the orphan on the 8th.

**The #259 miss is explained, not hand-waved:** #281 was created 2026-07-31 and carries neither marker — the *Base branch* convention landed 2026-08-01 (#418). Pre-convention issues are undiscoverable by construction. #259 is closed and its children are already recorded, so nothing is lost.

**The script itself run end-to-end against a stubbed `gh`**, all five paths:

| Case | Output |
|---|---|
| no manifest, one discovered child | `discovered for #412: 422` → parented + milestoned |
| child already parented | `#422 already a sub-issue of #412` (idempotent) |
| legacy manifest + discovered child | union → `376`, `377`, `422` all filed |
| nothing found | `Nothing to file for #412.`, exit 0 |
| unparseable manifest marker | warns, falls through to discovery, exit 0 |

**Two incidental fixes** while in the prompt: a dangling sentence fragment left by an earlier edit (`marking which are parallel vs blocked` was orphaned mid-paragraph), and the script no longer needs a standalone `jq` — everything runs through `gh`'s built-in one via `env`, which also made it testable off-runner.

## Not verified before merge

Same constraint as #423: `issue_comment` runs the workflow from the default branch, so the hook can only be exercised for real after this lands. Everything above is the script run directly against live API data, which is the closest available.

After merge, `@claude/researcher` on #412 should parent #422 and set its milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
