### PR TITLE
Name Actions runs after the issue, and fix three stale header claims

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -1,5 +1,23 @@
 name: Claude
-run-name: "Claude · ${{ github.event_name == 'pull_request' && 'merge hooks' || contains(github.event.comment.body || github.event.review.body, '@claude/manager') && 'Manager' || contains(github.event.comment.body || github.event.review.body, '@claude/researcher') && 'Researcher' || contains(github.event.comment.body || github.event.review.body, '@claude/tester') && 'Tester' || contains(github.event.comment.body || github.event.review.body, '@claude/writer') && 'Writer' || 'Implementor' }} #${{ github.event.issue.number || github.event.pull_request.number }}"
+# ⚠️ A ternary chain because `run-name` has no variables and no `needs` context — this
+# shape is the only one available. `>-` folds the newlines to spaces, and YAML parses
+# before expressions evaluate, so it is one line by the time it runs. There is no
+# substring function in GitHub expressions, so a long title cannot be truncated here.
+#
+# ⚠️ EVERY CONTINUATION LINE SITS AT THE SAME INDENT as `Claude ·`. A folded scalar keeps
+# a *more*-indented line literal, newline and all — indenting the `||` arms to line them
+# up reads better and silently leaves real newlines inside the expression.
+run-name: >-
+  Claude ·
+  ${{ github.event_name == 'pull_request'
+  && (github.event.pull_request.merged && 'Post-merge' || 'PR closed')
+  || contains(github.event.comment.body || github.event.review.body, '@claude/manager') && 'Manager'
+  || contains(github.event.comment.body || github.event.review.body, '@claude/researcher') && 'Researcher'
+  || contains(github.event.comment.body || github.event.review.body, '@claude/tester') && 'Tester'
+  || contains(github.event.comment.body || github.event.review.body, '@claude/writer') && 'Writer'
+  || 'Implementor' }}
+  · #${{ github.event.issue.number || github.event.pull_request.number }}
+  ${{ github.event.issue.title || github.event.pull_request.title }}
 
 # SIX ROLES, ONE WORKFLOW. Manager / Researcher / Implementor / Tester / Writer are jobs
 # here rather than separate files to keep the Actions history readable: the role is picked
@@ -17,18 +35,27 @@ run-name: "Claude · ${{ github.event_name == 'pull_request' && 'merge hooks' ||
 # ⚠️ A BARE "@claude" DOES NOTHING, deliberately, so a half-typed handle cannot start the
 # wrong agent. Labels trigger nothing either — `on.issues` is not subscribed.
 #
+# ⚠️ TESTER AND WRITER ALSO START WITHOUT A HANDLE. They `needs:` the Implementor and run
+# on the PR it opened, so a handle is not the only route any more. See their `if:` blocks.
+#
 # ⚠️ BACKLOG WORK IS SCRIPTED, NOT PROMPTED. Every role carries hard-coded hooks around
 # its model step, in `.github/agent-bin/`:
 #
-#   pre   every role   stamp-role-label.sh    stamps @claude/<role> on the issue or PR
-#   post  researcher   file-sub-issues.sh     parents + milestones from the epic's manifest
-#   merge (no role)    close-merged-work.sh   closes the PR's issues, files them on the board
+#   pre   every role      stamp-role-label.sh      stamps @claude/<role> on the issue or PR
+#   pre   impl + tester   set-issue-in-progress.sh moves the issue to In Progress on the board
+#   post  researcher      file-sub-issues.sh       parents + milestones the epic's sub-issues
+#   post  impl/test/write finish-pr.sh             labels the PR, appends `Closes #<issue>`
+#   post  implementor     open-integration-pr.sh   opens the epic's integration PR if missing
+#   merge (no role)       close-merged-work.sh     closes the PR's issues, files them on the board
 #
 # These used to be prompt instructions, and a model could skip them — the label trail is
 # worthless if a run can forget to stamp it. They cost no turns and cannot be forgotten.
-# `close-merged-work.sh` is also the only place PROJECTS_TOKEN appears: it is a long-lived
-# classic PAT covering every project the maintainer owns, and secret masking covers logs
-# only, so it stays out of any environment a prompt can read.
+#
+# ⚠️ PROJECTS_TOKEN appears in `close-merged-work.sh` and `set-issue-in-progress.sh`, and
+# nowhere else. It is a long-lived classic PAT covering every project the maintainer owns,
+# and secret masking covers logs only — not an API payload a model could write — so it
+# stays out of any environment a prompt can read. Step env is per-step, which is what makes
+# these two safe: the model step in the same job cannot see it.
 on:
   issue_comment:
     types: [created]


### PR DESCRIPTION
## Summary

Actions runs read `Claude · merge hooks #425` — no title, and a name describing the implementation rather than what happened. They now read:

```
Claude · Post-merge  · #425 Discover an epic's sub-issues instead of relying on a manifest
Claude · Implementor · #422 Switch elapsedSeconds to wall-clock-since-first-start
Claude · Tester      · #413 Cover Shopping cost/purchased persistence
```

Closes #426

The title comes from `github.event.issue.title || github.event.pull_request.title`, which covers all four event shapes — `issue_comment` carries `issue`, the review events carry `pull_request`.

`pull_request: closed` also fires on close-**without**-merge, where every job skips. `github.event.pull_request.merged` distinguishes them, so such a run no longer claims to be a merge. **Post-merge** rather than a hook name, since that run is Security as well as `close-merged-work.sh`.

### Three stale header claims

| Claim | Reality |
|---|---|
| `file-sub-issues.sh — parents + milestones from the epic's manifest` | Discovers them from the *Base branch* line as of #425. |
| The hook table listed three hooks | Six exist; all six are now listed. |
| "`close-merged-work.sh` is **the only place** PROJECTS_TOKEN appears" | It is also in `set-issue-in-progress.sh`. |

The `PROJECTS_TOKEN` reasoning was sound — both are scripted steps, and step env is per-step — but a false claim about where a credential lives is the wrong kind of wrong to leave sitting.

Also added a line noting Tester and Writer no longer need a handle to start (#423), since the block asserts the handle is what routes.

## ⚠️ The folded-scalar trap, caught by testing

My first version indented the `||` arms to line them up under the opening expression. **A YAML folded scalar keeps a *more*-indented line literal, newline and all** — so the "one line" run name still contained real newlines inside the `${{ }}`:

```
folded to ONE line: false
raw: "Claude · ${{ github.event_name == 'pull_request'\n    && (git"...
```

Every continuation line now sits at the same indent as `Claude ·`. Caught by asserting the parsed value contains no newline; it is invisible by eye, and the prettier-looking formatting is the broken one. Noted in a `⚠️` above the block.

## Verification

`npm test --ws` (eslint) ✓ · `tsc --noEmit` ✓ clean · `vite build` ✓. No application code changed — `run-name` and comments only.

**Parsed value asserted newline-free**, then the real string evaluated under GitHub's operator semantics for every event shape:

| Event | Resulting run name |
|---|---|
| merged PR | `Claude · Post-merge · #425 Discover an epic's sub-issues` |
| closed, unmerged | `Claude · PR closed · #399 Abandoned spike` |
| `@claude/manager` | `Claude · Manager · #412 Quick change to brewtimer behavior` |
| `@claude/researcher` | `Claude · Researcher · #412 Quick change to brewtimer behavior` |
| `@claude/implementor` | `Claude · Implementor · #422 Switch elapsedSeconds to wall-clock` |
| `@claude/tester` | `Claude · Tester · #413 Cover Shopping persistence` |
| `@claude/writer` | `Claude · Writer · #409 CLAUDE.md house style` |
| review submission | `Claude · Implementor · #423 Chain the Tester and Writer` |

Confirmed no reference to the manifest as the source of sub-issues remains anywhere in the file.

## Note

Long titles run long — GitHub expressions have no substring function, so the name cannot be truncated here. The runs list truncates visually, which is the accepted outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
