### PR TITLE
Revert the Tester/Writer chain off the Implementor

### DIFF
--- a/.github/agent-bin/finish-pr.sh
+++ b/.github/agent-bin/finish-pr.sh
@@ -31,13 +31,6 @@ if [ -z "$pr" ]; then
     exit 0
 fi
 
-# Published so the Tester and Writer can chain off this run and be pointed at the PR it
-# produced. Left unwritten on the early exit above, so an Implementor run that opened no
-# PR yields an empty output and starts neither. Guarded for use outside Actions.
-if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    echo "pr=$pr" >> "$GITHUB_OUTPUT"
-fi
-
 if gh pr edit "$pr" --repo "$REPO" --add-label "@claude/$ROLE" >/dev/null 2>&1; then
     echo "PR #$pr -> @claude/$ROLE"
 else

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -35,9 +35,6 @@ run-name: >-
 # ⚠️ A BARE "@claude" DOES NOTHING, deliberately, so a half-typed handle cannot start the
 # wrong agent. Labels trigger nothing either — `on.issues` is not subscribed.
 #
-# ⚠️ TESTER AND WRITER ALSO START WITHOUT A HANDLE. They `needs:` the Implementor and run
-# on the PR it opened, so a handle is not the only route any more. See their `if:` blocks.
-#
 # ⚠️ BACKLOG WORK IS SCRIPTED, NOT PROMPTED. Every role carries hard-coded hooks around
 # its model step, in `.github/agent-bin/`:
 #
@@ -380,10 +377,6 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/implementor'))
       )
     runs-on: ubuntu-latest
-    # The PR this run produced, read by the tester and writer jobs that chain off it.
-    # Empty when the run opened none, which is what stops the chain — see their `if:`.
-    outputs:
-      pr: ${{ steps.finish.outputs.pr }}
     permissions:
       contents: write
       pull-requests: write
@@ -632,7 +625,6 @@ jobs:
             --max-turns 80
 
       - name: Label and link the PR
-        id: finish
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -657,23 +649,11 @@ jobs:
   # fire-and-forget call while lint/tsc/build stay green) is only caught by a test written
   # to distrust the change.
   tester:
-    # Chains off the Implementor as well as answering its own handle. The last clause is
-    # the chain; the three before it are unchanged and still work on their own.
-    #
-    # ⚠️ `!cancelled()` is load-bearing, not decoration. With `needs:`, a SKIPPED upstream
-    # job skips its dependents, and GitHub applies an implicit "all needs succeeded" gate.
-    # A status-check function overrides both. Drop it and a hand-typed @claude/tester can
-    # never run again: the implementor skips, so this skips. `!cancelled()` over `always()`
-    # so a cancelled run doesn't drag the job in; on an implementor *failure* it still
-    # evaluates, then correctly skips on the result check below.
-    needs: [implementor]
     if: |
-      !cancelled() && github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
+      github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude/tester')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude/tester')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/tester')) ||
-        (github.event_name == 'issue_comment' && !github.event.issue.pull_request
-          && needs.implementor.result == 'success' && needs.implementor.outputs.pr != '')
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/tester'))
       )
     runs-on: ubuntu-latest
     permissions:
@@ -723,21 +703,16 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # ⚠️ track_progress forces the action's TAG MODE, which gates on this phrase
-          # independently of our own `if:`. It must therefore match EVERY comment that can
-          # start this job — and since the chain above starts it from a comment saying
-          # "@claude/implementor", a "@claude/tester" phrase would skip the step in 0s and
-          # leave a placeholder comment. "@claude/" matches any role handle; the job's own
-          # `if:` is what routes, so a @claude/writer comment still cannot start the Tester.
-          trigger_phrase: "@claude/"
+          # independently of our own `if:`. Leave it at the default "@claude" and the
+          # action skips in 0s with a placeholder comment, because "@claude/tester"
+          # is not a match for "@claude".
+          trigger_phrase: "@claude/tester"
           track_progress: true
           prompt: |
             You are the **Tester** — you own `packages/e2e`, the Playwright suite that
             drives the real app in a browser. You are triggered by someone writing
-            **`@claude/tester`** in a comment, on an issue or a PR, or automatically once an
-            Implementor run finishes and opens its PR. Labels never start a run — they only
-            record which roles have already been here.
-            ${{ needs.implementor.outputs.pr && format('**This is an automatic run.** An Implementor just opened PR #{0} — that is your subject. Read it first with `gh pr view {0} --comments` and work from its Handoff Testing notes.', needs.implementor.outputs.pr) || '' }}
-            ${{ needs.implementor.outputs.pr && 'Nobody asked for this run by hand, so there is no instruction comment to read — the PR and its diff are the whole brief.' || '' }}
+            **`@claude/tester`** in a comment, on an issue or a PR. Labels never start a run
+            — they only record which roles have already been here.
 
             Read `packages/e2e/CLAUDE.md` first — it is short and it is the spec for how
             this suite works. The repo-root `CLAUDE.md` covers branch/PR/commit conventions.
@@ -875,22 +850,11 @@ jobs:
   # neither of them was really working on. Implementor and Tester now report what needs
   # documenting in their handoff and change no docs themselves.
   writer:
-    # Chains off the Implementor like the Tester, but waits on the Tester too, so one
-    # Writer run sees both roles' docs candidates instead of two runs racing on the same
-    # CLAUDE.md — the merge conflicts that split this role out in the first place.
-    #
-    # ⚠️ `!cancelled()` is load-bearing — see the note on the tester job. Without it a
-    # hand-typed @claude/writer can never run again.
-    # ⚠️ Waiting on the tester means a manually-triggered Tester run leaves this job
-    # showing as *pending* in the checks list until it finishes, then skipping. Cosmetic.
-    needs: [implementor, tester]
     if: |
-      !cancelled() && github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
+      github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude/writer')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude/writer')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/writer')) ||
-        (github.event_name == 'issue_comment' && !github.event.issue.pull_request
-          && needs.implementor.result == 'success' && needs.implementor.outputs.pr != '')
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/writer'))
       )
     runs-on: ubuntu-latest
     permissions:
@@ -920,19 +884,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
-          # ⚠️ Must match every comment that can start this job, including the chained run's
-          # "@claude/implementor" — see the note on the tester job's trigger_phrase.
-          trigger_phrase: "@claude/"
+          trigger_phrase: "@claude/writer"
           prompt: |
             You are the **Writer** — the technical writer. You own the repo's documentation:
             every `CLAUDE.md`, the agent instruction files under `.claude/skills/`, and any
             other file whose job is to explain rather than to run. No other role edits them.
 
             You are triggered by someone writing **`@claude/writer`** in a comment, on an
-            issue or a PR — read that comment first, it is the instruction — or automatically
-            once an Implementor run finishes and opens its PR.
-            ${{ needs.implementor.outputs.pr && format('**This is an automatic run.** An Implementor opened PR #{0}, and a Tester may have opened one of its own against the same issue. Start from `gh pr view {0} --comments` and collect the docs candidates from both.', needs.implementor.outputs.pr) || '' }}
-            ${{ needs.implementor.outputs.pr && 'There is no instruction comment on an automatic run. Apply exactly the filter you always do — for a run nobody asked for, rejecting every candidate and opening no PR is the most likely correct outcome, not a failure.' || '' }}
+            issue or a PR. Read that comment first: it is the instruction.
 
             **Where your work comes from.** Usually an Implementor or Tester PR whose handoff
             ends with a fenced `json` block of **docs candidates**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,31 +139,17 @@ history.
 ⚠️ Manager and Researcher require `!github.event.issue.pull_request` — `issue_comment` fires
 for PRs too, and without the guard a PR comment started a role written for an epic issue.
 
-**Tester and Writer also run on their own, chained off the Implementor.** An Implementor run
-started *from an issue* that opens a PR is followed by a Tester and then a Writer, both pointed
-at that PR. Their handles still work by hand; the chain is a fourth way in, not a replacement.
-
-- The Implementor publishes the PR number as a job output (`finish-pr.sh` → `$GITHUB_OUTPUT`),
-  and the two jobs `needs:` it. Same workflow run, so no new credential is involved.
-- Writer waits on Tester as well, so one run sees both roles' docs candidates instead of two
-  racing on the same `CLAUDE.md`.
-- Chaining is narrowed to `issue_comment` **not** on a PR. Implementors re-run constantly from
-  review feedback, and without that guard each re-run opened another duplicate spec and docs PR.
-- An Implementor that opens no PR yields an empty output and starts neither.
-
-⚠️ **A comment cannot chain the roles**, which is why this is `needs:` and not a hook. GitHub
-refuses to start a run from an event created with `GITHUB_TOKEN`, and the `if:` guards exclude
-`github-actions[bot]` besides. Posting `@claude/tester` from a hook is silently inert; making it
-work would need a new `repo`-scoped PAT in reach of a step.
-⚠️ **`!cancelled()` in the Tester's and Writer's `if:` is load-bearing.** With `needs:`, a
-*skipped* upstream job skips its dependents, and GitHub applies an implicit "all needs
-succeeded" gate; a status-check function overrides both. Drop it and a hand-typed
-`@claude/tester` can never run again — the Implementor skips, so the Tester skips.
-⚠️ **Their `trigger_phrase` is `"@claude/"`, not their own handle.** `track_progress: true`
-forces tag mode, which gates on that phrase independently of the `if:` — and a chained run's
-triggering comment says `@claude/implementor`. With the narrower phrase the step skips in `0s`
-and posts a placeholder comment, the same failure that kept the retired Owner role from ever
-running. The `if:` is what routes, so the wider phrase cannot start the wrong role.
+⚠️ Every role is started by hand. **Tester and Writer briefly chained off the Implementor via
+`needs:` and it was reverted** — the job graph left them queued behind every run, and a role
+that skips after waiting reports as cancelled, so the history filled with cancelled jobs. If
+it is ever retried, the constraint that shaped it still holds: a comment cannot chain the
+roles, because GitHub refuses to start a run from an event created with `GITHUB_TOKEN` and the
+`if:` guards exclude `github-actions[bot]` besides. `needs:` within the one workflow was the
+only route without a new `repo`-scoped PAT in reach of a step — and `needs:` is what produced
+the noise. Cost the chain carried, for whoever revisits it: `!cancelled()` in both `if:` blocks
+(without it a skipped Implementor skips them, so a hand-typed handle could never run), and
+`trigger_phrase: "@claude/"` (tag mode gates on the phrase independently of the `if:`, and a
+chained run's comment says `@claude/implementor`).
 ⚠️ Workflow changes to any of this **cannot be tested before merge**: `issue_comment` always
 runs the workflow from the default branch, so a PR branch's version is never the one that fires.
 


### PR DESCRIPTION
## Summary

Reverts the Tester/Writer chain from #423. The `needs:` edge put both jobs in the graph of **every** run, and a job that waits on an upstream and then skips reports as **cancelled** — so the Actions history filled with cancelled jobs for work nobody asked for. Both roles go back to being started by hand.

### Removed

- `needs: [implementor]` on `tester`, `needs: [implementor, tester]` on `writer`
- the chained fourth clause in both `if:` blocks
- `!cancelled()` — it existed only to survive `needs:`
- the implementor's `outputs.pr` and the `id: finish` that fed it
- the `$GITHUB_OUTPUT` write in `finish-pr.sh`
- the conditional prompt blocks naming the PR, and the prose in both prompts claiming an automatic path exists
- `trigger_phrase: "@claude/"` → back to `"@claude/tester"` / `"@claude/writer"`. The wide phrase existed only so a chained run — triggered by a comment saying `@claude/implementor` — could get past tag mode's own gate. With no chain, the narrow phrase is correct again and restores it as a second line of defence behind the `if:`.

## Verification

`npm test --ws` (eslint) ✓ · `tsc --noEmit` ✓ clean · `vite build` ✓ · workflow YAML parses ✓ · `bash -n` on the hook ✓. No application code changed.

**Diffed against the commit before #423 merged** (`9c47972`) — the three affected jobs are byte-identical to their pre-chain configuration:

```
tester       if/needs/outputs identical to pre-#423: true
             trigger_phrase "@claude/tester" -> "@claude/tester"
writer       if/needs/outputs identical to pre-#423: true
             trigger_phrase "@claude/writer" -> "@claude/writer"
implementor  if/needs/outputs identical to pre-#423: true
             trigger_phrase "@claude/implementor" -> "@claude/implementor"
```

Nothing chain-related survives anywhere:

| probe | workflow | finish-pr.sh |
|---|---|---|
| `needs:` | 0 | 0 |
| `!cancelled` | 0 | 0 |
| `needs.implementor` | 0 | 0 |
| `GITHUB_OUTPUT` | 0 | 0 |
| `id: finish` | 0 | 0 |
| `trigger_phrase: "@claude/"` | 0 | 0 |

Neither prompt references a `needs.*` context any more — required, since a `needs` reference in a job without a `needs:` edge is invalid.

## Note

`CLAUDE.md` keeps a short note that the chain was tried and reverted, including the two non-obvious costs it carried — `!cancelled()` and the `trigger_phrase` widening. Both are things a future attempt would otherwise rediscover the hard way, and the reason a comment-based chain is impossible (GitHub won't start a run from a `GITHUB_TOKEN` event) is worth keeping so nobody re-proposes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
