### PR TITLE
Upload a redacted execution transcript when a role run fails

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -199,6 +199,33 @@ jobs:
             --model sonnet
             --allowedTools "Read,Edit,Write,Bash(gh:*),Bash(git:*)"
             --max-turns 40
+      # ⚠️ Redact before upload. Artifact BYTES ARE NOT MASKED — the `***` substitution
+      # applies to log output only. GH_TOKEN is in every model step's env and every role
+      # holds Bash(gh:*), so `gh auth token` prints it straight into a tool result, and
+      # `git config --list` exposes the checkout action's http.extraheader, which is
+      # base64 of `x-access-token:<token>`. Both forms are scrubbed.
+      # ⚠️ Best-effort: this removes the token forms we know of, not anything else a model
+      # may have echoed. retention-days stays at the 1-day floor for that reason.
+      - name: Redact the execution transcript
+        if: failure()
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          f="$RUNNER_TEMP/claude-execution-output.json"
+          [ -f "$f" ] || exit 0
+          b64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" "$f" > "$f.tmp"
+          mv "$f.tmp" "$f"
+      - name: Upload the execution transcript
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-${{ github.job }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/claude-execution-output.json
+          # a job can fail BEFORE the model step writes the file (the exit-127 hook
+          # failures did); a missing-file error on top of the real one is noise
+          if-no-files-found: ignore
+          retention-days: 1
 
   # ── Researcher ─────────────────────────────────────────────────────────────────
   # The product owner. Takes a well-defined epic, follows its Research path, does the
@@ -361,6 +388,33 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
         run: "$RUNNER_TEMP/agent-bin/file-sub-issues.sh"
+      # ⚠️ Redact before upload. Artifact BYTES ARE NOT MASKED — the `***` substitution
+      # applies to log output only. GH_TOKEN is in every model step's env and every role
+      # holds Bash(gh:*), so `gh auth token` prints it straight into a tool result, and
+      # `git config --list` exposes the checkout action's http.extraheader, which is
+      # base64 of `x-access-token:<token>`. Both forms are scrubbed.
+      # ⚠️ Best-effort: this removes the token forms we know of, not anything else a model
+      # may have echoed. retention-days stays at the 1-day floor for that reason.
+      - name: Redact the execution transcript
+        if: failure()
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          f="$RUNNER_TEMP/claude-execution-output.json"
+          [ -f "$f" ] || exit 0
+          b64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" "$f" > "$f.tmp"
+          mv "$f.tmp" "$f"
+      - name: Upload the execution transcript
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-${{ github.job }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/claude-execution-output.json
+          # a job can fail BEFORE the model step writes the file (the exit-127 hook
+          # failures did); a missing-file error on top of the real one is noise
+          if-no-files-found: ignore
+          retention-days: 1
 
   # ── Implementor ────────────────────────────────────────────────────────────────
   # The main engineer. Executes issues and handles follow-up engineering (bug fixes,
@@ -640,6 +694,33 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         run: "$RUNNER_TEMP/agent-bin/open-integration-pr.sh"
+      # ⚠️ Redact before upload. Artifact BYTES ARE NOT MASKED — the `***` substitution
+      # applies to log output only. GH_TOKEN is in every model step's env and every role
+      # holds Bash(gh:*), so `gh auth token` prints it straight into a tool result, and
+      # `git config --list` exposes the checkout action's http.extraheader, which is
+      # base64 of `x-access-token:<token>`. Both forms are scrubbed.
+      # ⚠️ Best-effort: this removes the token forms we know of, not anything else a model
+      # may have echoed. retention-days stays at the 1-day floor for that reason.
+      - name: Redact the execution transcript
+        if: failure()
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          f="$RUNNER_TEMP/claude-execution-output.json"
+          [ -f "$f" ] || exit 0
+          b64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" "$f" > "$f.tmp"
+          mv "$f.tmp" "$f"
+      - name: Upload the execution transcript
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-${{ github.job }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/claude-execution-output.json
+          # a job can fail BEFORE the model step writes the file (the exit-127 hook
+          # failures did); a missing-file error on top of the real one is noise
+          if-no-files-found: ignore
+          retention-days: 1
 
   # ── Tester ─────────────────────────────────────────────────────────────────────
   # Owns packages/e2e. The Implementor ships behaviour and writes Testing notes into its
@@ -840,6 +921,33 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         run: "$RUNNER_TEMP/agent-bin/finish-pr.sh"
+      # ⚠️ Redact before upload. Artifact BYTES ARE NOT MASKED — the `***` substitution
+      # applies to log output only. GH_TOKEN is in every model step's env and every role
+      # holds Bash(gh:*), so `gh auth token` prints it straight into a tool result, and
+      # `git config --list` exposes the checkout action's http.extraheader, which is
+      # base64 of `x-access-token:<token>`. Both forms are scrubbed.
+      # ⚠️ Best-effort: this removes the token forms we know of, not anything else a model
+      # may have echoed. retention-days stays at the 1-day floor for that reason.
+      - name: Redact the execution transcript
+        if: failure()
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          f="$RUNNER_TEMP/claude-execution-output.json"
+          [ -f "$f" ] || exit 0
+          b64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" "$f" > "$f.tmp"
+          mv "$f.tmp" "$f"
+      - name: Upload the execution transcript
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-${{ github.job }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/claude-execution-output.json
+          # a job can fail BEFORE the model step writes the file (the exit-127 hook
+          # failures did); a missing-file error on top of the real one is noise
+          if-no-files-found: ignore
+          retention-days: 1
 
   # ── Writer ─────────────────────────────────────────────────────────────────────
   # The tech writer. Owns documentation: every CLAUDE.md, the agent instruction files
@@ -972,6 +1080,33 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         run: "$RUNNER_TEMP/agent-bin/finish-pr.sh"
+      # ⚠️ Redact before upload. Artifact BYTES ARE NOT MASKED — the `***` substitution
+      # applies to log output only. GH_TOKEN is in every model step's env and every role
+      # holds Bash(gh:*), so `gh auth token` prints it straight into a tool result, and
+      # `git config --list` exposes the checkout action's http.extraheader, which is
+      # base64 of `x-access-token:<token>`. Both forms are scrubbed.
+      # ⚠️ Best-effort: this removes the token forms we know of, not anything else a model
+      # may have echoed. retention-days stays at the 1-day floor for that reason.
+      - name: Redact the execution transcript
+        if: failure()
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          f="$RUNNER_TEMP/claude-execution-output.json"
+          [ -f "$f" ] || exit 0
+          b64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" "$f" > "$f.tmp"
+          mv "$f.tmp" "$f"
+      - name: Upload the execution transcript
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-${{ github.job }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/claude-execution-output.json
+          # a job can fail BEFORE the model step writes the file (the exit-127 hook
+          # failures did); a missing-file error on top of the real one is noise
+          if-no-files-found: ignore
+          retention-days: 1
 
   # ── Security ───────────────────────────────────────────────────────────────────
   # Reviews what just landed on mainline and files issues for what it finds. Runs on
@@ -1047,6 +1182,33 @@ jobs:
             --model sonnet
             --allowedTools "Read,Bash(git:*),Bash(gh:*)"
             --max-turns 40
+      # ⚠️ Redact before upload. Artifact BYTES ARE NOT MASKED — the `***` substitution
+      # applies to log output only. GH_TOKEN is in every model step's env and every role
+      # holds Bash(gh:*), so `gh auth token` prints it straight into a tool result, and
+      # `git config --list` exposes the checkout action's http.extraheader, which is
+      # base64 of `x-access-token:<token>`. Both forms are scrubbed.
+      # ⚠️ Best-effort: this removes the token forms we know of, not anything else a model
+      # may have echoed. retention-days stays at the 1-day floor for that reason.
+      - name: Redact the execution transcript
+        if: failure()
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          f="$RUNNER_TEMP/claude-execution-output.json"
+          [ -f "$f" ] || exit 0
+          b64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" "$f" > "$f.tmp"
+          mv "$f.tmp" "$f"
+      - name: Upload the execution transcript
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-${{ github.job }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/claude-execution-output.json
+          # a job can fail BEFORE the model step writes the file (the exit-127 hook
+          # failures did); a missing-file error on top of the real one is noise
+          if-no-files-found: ignore
+          retention-days: 1
 
   # ── Merge housekeeping ─────────────────────────────────────────────────────────
   # Closes the issues a merged PR finished and files them on the board.

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -213,8 +213,13 @@ jobs:
         run: |
           f="$RUNNER_TEMP/claude-execution-output.json"
           [ -f "$f" ] || exit 0
+          drop() { echo "::warning::$1 — dropping the transcript"; rm -f "$f" "$f.tmp"; exit 0; }
+          [ -n "${TOKEN:-}" ] || drop "no token to redact against"
           b64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
-          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" "$f" > "$f.tmp"
+          raw=$(printf '%s' "$TOKEN" | base64 | tr -d '\n')
+          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" \
+              -e "s|$raw|***REDACTED***|g" "$f" > "$f.tmp" || drop "redaction failed"
+          grep -qF "$TOKEN" "$f.tmp" && drop "token survived redaction"
           mv "$f.tmp" "$f"
       - name: Upload the execution transcript
         if: failure()
@@ -402,8 +407,13 @@ jobs:
         run: |
           f="$RUNNER_TEMP/claude-execution-output.json"
           [ -f "$f" ] || exit 0
+          drop() { echo "::warning::$1 — dropping the transcript"; rm -f "$f" "$f.tmp"; exit 0; }
+          [ -n "${TOKEN:-}" ] || drop "no token to redact against"
           b64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
-          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" "$f" > "$f.tmp"
+          raw=$(printf '%s' "$TOKEN" | base64 | tr -d '\n')
+          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" \
+              -e "s|$raw|***REDACTED***|g" "$f" > "$f.tmp" || drop "redaction failed"
+          grep -qF "$TOKEN" "$f.tmp" && drop "token survived redaction"
           mv "$f.tmp" "$f"
       - name: Upload the execution transcript
         if: failure()
@@ -708,8 +718,13 @@ jobs:
         run: |
           f="$RUNNER_TEMP/claude-execution-output.json"
           [ -f "$f" ] || exit 0
+          drop() { echo "::warning::$1 — dropping the transcript"; rm -f "$f" "$f.tmp"; exit 0; }
+          [ -n "${TOKEN:-}" ] || drop "no token to redact against"
           b64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
-          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" "$f" > "$f.tmp"
+          raw=$(printf '%s' "$TOKEN" | base64 | tr -d '\n')
+          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" \
+              -e "s|$raw|***REDACTED***|g" "$f" > "$f.tmp" || drop "redaction failed"
+          grep -qF "$TOKEN" "$f.tmp" && drop "token survived redaction"
           mv "$f.tmp" "$f"
       - name: Upload the execution transcript
         if: failure()
@@ -935,8 +950,13 @@ jobs:
         run: |
           f="$RUNNER_TEMP/claude-execution-output.json"
           [ -f "$f" ] || exit 0
+          drop() { echo "::warning::$1 — dropping the transcript"; rm -f "$f" "$f.tmp"; exit 0; }
+          [ -n "${TOKEN:-}" ] || drop "no token to redact against"
           b64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
-          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" "$f" > "$f.tmp"
+          raw=$(printf '%s' "$TOKEN" | base64 | tr -d '\n')
+          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" \
+              -e "s|$raw|***REDACTED***|g" "$f" > "$f.tmp" || drop "redaction failed"
+          grep -qF "$TOKEN" "$f.tmp" && drop "token survived redaction"
           mv "$f.tmp" "$f"
       - name: Upload the execution transcript
         if: failure()
@@ -1094,8 +1114,13 @@ jobs:
         run: |
           f="$RUNNER_TEMP/claude-execution-output.json"
           [ -f "$f" ] || exit 0
+          drop() { echo "::warning::$1 — dropping the transcript"; rm -f "$f" "$f.tmp"; exit 0; }
+          [ -n "${TOKEN:-}" ] || drop "no token to redact against"
           b64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
-          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" "$f" > "$f.tmp"
+          raw=$(printf '%s' "$TOKEN" | base64 | tr -d '\n')
+          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" \
+              -e "s|$raw|***REDACTED***|g" "$f" > "$f.tmp" || drop "redaction failed"
+          grep -qF "$TOKEN" "$f.tmp" && drop "token survived redaction"
           mv "$f.tmp" "$f"
       - name: Upload the execution transcript
         if: failure()
@@ -1196,8 +1221,13 @@ jobs:
         run: |
           f="$RUNNER_TEMP/claude-execution-output.json"
           [ -f "$f" ] || exit 0
+          drop() { echo "::warning::$1 — dropping the transcript"; rm -f "$f" "$f.tmp"; exit 0; }
+          [ -n "${TOKEN:-}" ] || drop "no token to redact against"
           b64=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
-          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" "$f" > "$f.tmp"
+          raw=$(printf '%s' "$TOKEN" | base64 | tr -d '\n')
+          sed -e "s|$TOKEN|***REDACTED***|g" -e "s|$b64|***REDACTED***|g" \
+              -e "s|$raw|***REDACTED***|g" "$f" > "$f.tmp" || drop "redaction failed"
+          grep -qF "$TOKEN" "$f.tmp" && drop "token survived redaction"
           mv "$f.tmp" "$f"
       - name: Upload the execution transcript
         if: failure()


### PR DESCRIPTION
## Summary

A failed model step left nothing to debug with — the run log keeps only summary JSON, and the full transcript goes to `$RUNNER_TEMP/claude-execution-output.json` and dies with the runner. Two Tester failures on 2026-08-02 cost ~$8 between them and neither can be explained from what was retained.

Each of the six model-running jobs now redacts and uploads the transcript on failure. `merge_housekeeping` runs no model and gets nothing.

Closes #431

## ⚠️ Artifact bytes are not masked

The `***` substitution applies to **log output only**. `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` is in the env of all six model steps, and every role holds `Bash(gh:*)`. Two concrete paths put it in the transcript:

- `gh auth token` prints it verbatim into a tool result.
- `git config --list` exposes the checkout action's `http.extraheader` — base64 of `x-access-token:<token>`.

The redact step scrubs both forms before upload. This was **not** in the original issue: I wrote there that `PROJECTS_TOKEN` being confined to scripted steps meant the transcript should be clean, and I overlooked `GITHUB_TOKEN` entirely. The Implementor run on #431 caught it.

Redaction is **best-effort** — it removes the token forms we know about, not anything else a model may have echoed. That's why `retention-days` is at the **1-day floor** rather than the 14 originally proposed. (Sub-day retention isn't available; the input's minimum is 1.)

## Two deliberate deviations from the issue

**Placement at the end of each job, not beside the model step.** `failure()` is true if *any* earlier step failed, so end placement also captures a run where the model succeeded and a post-hook then failed — the exit-127 class fixed in #429 — and there the transcript is exactly what shows whether the model did its half. The post-hooks are `if: always()`, so they still run first and the ordering holds. This came from the Implementor's analysis and is better than what I specified.

**`sed` writes through a temp file instead of `sed -i`.** `-i` takes a mandatory backup suffix on BSD sed, so `sed -i -e …` is GNU-only. The runner is GNU so it would have worked, but the portable form is also what made the step testable off-runner.

## Verification

`npm test --ws` (eslint) ✓ · `tsc --noEmit` ✓ clean · `vite build` ✓ · workflow YAML parses ✓. No application code changed.

**Structural**, asserted per job — the two steps present, in order, as the final two:

```
manager             model=true  redact@ 5 upload@ 6  last two ✓
researcher          model=true  redact@ 6 upload@ 7  last two ✓
implementor         model=true  redact@ 9 upload@10  last two ✓
tester              model=true  redact@ 9 upload@10  last two ✓
writer              model=true  redact@ 5 upload@ 6  last two ✓
security            model=true  redact@ 2 upload@ 3  last two ✓
merge_housekeeping  model=false redact@-1 upload@-1  none ✓
```

`retention-days` is `1` on all six; six upload steps total.

**The redaction script was extracted from the workflow and run** — testing what ships, not a retype — against a fixture containing both token forms:

| check | result |
|---|---|
| raw token still present | **0** |
| base64 `x-access-token:` form still present | **0** |
| ordinary content survived | 1 |
| leftover `.tmp` file | 0 |
| missing-file path (job failed before the model ran) | exit 0, no error |

The first run of this test **failed** with `sed: -e: No such file or directory`, which is what surfaced the BSD/GNU `-i` issue above.

## Not verified before merge

`issue_comment` always runs the workflow from the default branch, so this PR's copy never fires. The first real evidence is the next failed role run — at which point the artifact should appear on the run, and #432 becomes workable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — the redaction failed open; now it fails closed

Raised in review: could the redact step itself leak? It could, and worse than that — **it failed open.**

Both steps are `if: failure()`, and `failure()` is true if *any earlier* step failed. So a redact step that died did **not** stop the upload — it shipped whatever was on disk, unredacted. Two ways in:

- an empty `$TOKEN` makes the pattern empty and `sed` exits 1 — verified: `sed: first RE may not be empty`
- any other `sed` failure aborts the step under `bash -e` before the `mv`, leaving the original file untouched

Every failure path now deletes the file instead, so there is nothing to upload:

| path | behaviour |
|---|---|
| empty or unset token | **drop** |
| `sed` fails for any reason | **drop** |
| token still present after redaction | **drop** |

The third is the belt-and-braces — a `grep -qF` over the output before the `mv`, so redaction is *verified* rather than assumed. Also added a third scrub form: bare base64 of the token, alongside the raw value and the base64 of `x-access-token:<token>`.

**Fail-closed matrix, exercised against the script extracted from the workflow:**

```
normal token     exit=0  kept | token-forms=0 | content-preserved=1
EMPTY token      exit=0  DROPPED — nothing to upload   ::warning::no token to redact against
sed-breaking     exit=0  DROPPED                       (token containing the | delimiter)
no input file    exit=0  clean no-op
```

All three token forms scrub to zero on the normal path, ordinary content survives, and every failure path exits 0 so it adds no noise to an already-failing job.

**On the step leaking directly:** it doesn't. The token arrives via step `env:` (masked as `***` in the log), and GitHub echoes the `run:` block as raw source — so the log shows the literal `$TOKEN`, never its value. That was the reason for using `env:` rather than interpolating `${{ secrets.GITHUB_TOKEN }}` into the script body.