### PR TITLE
Teach the Security role to look for guards that fail open

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -1012,7 +1012,16 @@ jobs:
             - **Secrets and tokens** — anything committed, logged, or placed where a model or
               a comment could echo it. A workflow that puts a long-lived credential within
               reach of a prompt is a real finding; the built-in `GITHUB_TOKEN` scoped to one
-              run is not.
+              run is not. ⚠️ Secret masking covers **log output only** — a secret written
+              into an uploaded artifact, a committed file or an API payload is published
+              verbatim, `***` notwithstanding.
+            - **Guards that fail open** — a control counts only if its failure stops what it
+              protects. Trace the failure path, not the happy path: when the redact /
+              validate / sanitise step dies, does the upload / write / send still happen?
+              ⚠️ In a workflow `if: always()` and `if: failure()` evaluate the **job**
+              status, not the previous step's, so a guard exiting non-zero does not stop the
+              step after it. This shipped once — a redaction step that died left the raw
+              file in place for the upload step to publish.
             - **Workflow and supply chain** — a permission widened past what a job needs, an
               allowlist loosened to a wildcard, an unpinned or newly-added action, a script
               that interpolates untrusted input into a shell command.

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -1020,8 +1020,10 @@ jobs:
               validate / sanitise step dies, does the upload / write / send still happen?
               ⚠️ In a workflow `if: always()` and `if: failure()` evaluate the **job**
               status, not the previous step's, so a guard exiting non-zero does not stop the
-              step after it. This shipped once — a redaction step that died left the raw
-              file in place for the upload step to publish.
+              step after it. This reached review once — a redaction step that died would
+              have left the raw file in place for the upload step to publish. It was caught
+              by a reviewer asking what happens when the guard fails, which is the question
+              to ask, and the reason the happy path passing proves nothing.
             - **Workflow and supply chain** — a permission widened past what a job needs, an
               allowlist loosened to a wildcard, an unpinned or newly-added action, a script
               that interpolates untrusted input into a shell command.


### PR DESCRIPTION
## Summary

The redaction bug caught in review on #433 was a class the Security prompt had no instruction for: **a control that only works on its happy path.**

The redact step and the upload step were both `if: failure()`. `failure()` evaluates the **job** status, not the previous step's — so when the redact step died, the upload step still ran and would have published the unredacted transcript. Redaction was tested and worked; nothing tested what happened when it didn't.

Closes #434

## What changed

Two bullets in the `security` job's *What matters here* list, +10 lines total.

**New — Guards that fail open:**

> A control counts only if its failure stops what it protects. Trace the failure path, not the happy path: when the redact / validate / sanitise step dies, does the upload / write / send still happen? ⚠️ In a workflow `if: always()` and `if: failure()` evaluate the **job** status, not the previous step's, so a guard exiting non-zero does not stop the step after it. This shipped once — a redaction step that died left the raw file in place for the upload step to publish.

Phrased to be *traced* rather than agreed with — it names what to look at. And it names the Actions specific deliberately: `if: always()` reading like a per-step guard is what made this non-obvious in the first place.

**Extended — Secrets and tokens**, with the second lesson from the same bug:

> ⚠️ Secret masking covers **log output only** — a secret written into an uploaded artifact, a committed file or an API payload is published verbatim, `***` notwithstanding.

## Verification

`npm test --ws` (eslint) ✓ · `tsc --noEmit` ✓ clean · `vite build` ✓ · workflow YAML parses ✓. No application code changed.

Prompt grows from 43 to 53 lines; the bullet list goes from 3 to 5. The Security role runs on **every** merge to `mainline` on a 40-turn budget, so this is deliberately two bullets rather than a section — a longer checklist costs turns on every run.

## Scope

Only the Security prompt. The same lesson arguably belongs with the Implementor — "test the failure path of anything you write as a guard" — but that's a separate call and a separate budget, so I left it out rather than widening this unasked.

## Note

Independent of #433, which is still open and touches the end of the same job (the redact/upload steps). Different regions of the file; no conflict either way round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — corrected the example

The bullet said *"This shipped once."* It didn't. [PR #433](https://github.com/matt-whitaker/brewdocs.beer/pull/433) — the redaction change this was drawn from — is now **parked unmerged**, so the claim became false the moment it closed.

Reworded to what actually happened:

> This reached review once — a redaction step that died would have left the raw file in place for the upload step to publish. It was caught by a reviewer asking what happens when the guard fails, which is the question to ask, and the reason the happy path passing proves nothing.

The correction also makes it a better instruction: it now names the *move* that found the bug rather than just asserting something once went wrong. A prompt whose job is teaching a reviewer to check claims against reality is the wrong place to carry an unchecked claim.

Gate re-run: eslint ✓, `tsc --noEmit` ✓, `vite build` ✓, YAML parses ✓. Prompt is 55 lines.
