### PR TITLE
Document that role allowlists union with the action's base set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,24 @@ keyword — its own — since it does target `mainline`; a sub-PR index written 
 role whose output the maintainer must review line by line. Manager 40 turns, Writer 60,
 Security 40, the rest 80. Implementor and Tester run `npm ci` as a step; nobody else builds.
 
+**Allowlists union, they don't replace.** A role's `claude_args --allowedTools` is merged with
+the action's own base set, not substituted for it — `mergedAllowedTools = [...new Set([...
+extraArgsAllowedTools, ...directAllowedTools])]` in `anthropics/claude-code-action`,
+`base-action/src/parse-sdk-options.ts`. So every role also has the base grant:
+
+```
+Glob, Grep, LS, Read, mcp__github_comment__update_claude_comment,
+Bash(git add:*), Bash(git commit:*), Bash(git rm:*), Bash(git-push.sh:*)
+```
+
+- This is why `implementor` and `tester` still read files despite neither listing `Read`.
+- What is granted is the union of the two lists and **nothing else** — every other binary
+  (`python3`, `node`, `mkdir`, `mv`, `cp`, `cat`, `chmod`, `sed`) is denied, as is any
+  `&&`-chained command. That is the usual source of a run's permission denials.
+- ⚠️ Denials cost turns. A Tester run hit its 80-turn cap with 11 of them and produced no PR.
+- ⚠️ Widen a role's list only against a denial you have actually seen. The transcript that
+  would show them is not retained (issue #431, parked), so until it is, a denial is a guess.
+
 ⚠️ Keep task checklists to 3–5 outcome-level items. The action narrates each one back to the
 PR, so a 10-item list spends most of the budget before any code is written.
 ⚠️ `trigger_phrase` must match the handle per job. `track_progress: true` forces the action's


### PR DESCRIPTION
## Summary

#432 was built around one unknown: whether `claude_args --allowedTools` **replaces** or **unions with** the action's own `ALLOWED_TOOLS`. If it replaced, `implementor` and `tester` had no `Read`/`Glob`/`Grep`/`LS` at all — a serious finding on its own, and one that would have explained a lot of turn-burn.

**It unions.** From `anthropics/claude-code-action`, `base-action/src/parse-sdk-options.ts`:

```js
// Extract and merge allowedTools from all sources:
// 1. From extraArgs (parsed from claudeArgs - contains tag mode's tools)
// 2. From options.allowedTools (direct input - may be undefined)
// This prevents duplicate flags being overwritten when claudeArgs contains --allowedTools
const mergedAllowedTools = [
  ...new Set([...extraArgsAllowedTools, ...directAllowedTools]),
];
```

Closes #432

## What this settles

- Every role also carries the base grant — `Glob, Grep, LS, Read, mcp__github_comment__update_claude_comment, Bash(git add:*), Bash(git commit:*), Bash(git rm:*), Bash(git-push.sh:*)`. That's why `implementor` and `tester` read files despite neither listing `Read`.
- The grant is the union of the two lists and **nothing else**. Every other binary — `python3`, `node`, `mkdir`, `mv`, `cp`, `cat`, `chmod`, `sed` — is denied, as is any `&&`-chained command. That's the ordinary source of a run's denials, and the Implementor run on #431 reported exactly this about `python3`/`node`.

## What it does not settle

Which specific calls the Tester was denied on run `30730807259` is **still unknown**. That needs the transcript, which is #431 — closed unmerged and parked. So the issue's remaining acceptance criteria ("list the actual denied calls", "justify any allowlist change by a denial that occurred") can't be met right now, and I've deliberately **not** widened any allowlist. Doing so on a guess is the thing #432 itself warned against.

The standing rule is captured in the docs instead: widen a role's list only against a denial actually observed.

## Why this closes #432 rather than staying open

The pivotal question is answered and the answer is benign — there's no lurking problem to keep an issue open for. The residual question is small, blocked on parked work, and #431 is already the trigger if Tester failures recur. Leaving #432 open would mostly mislead the next reader into re-running an investigation that's finished.

## Verification

`npm test --ws` (eslint) ✓ · `tsc --noEmit` ✓ clean · `vite build` ✓. Docs-only, 18 lines added to the root `CLAUDE.md` under *Budgets*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
