### PR TITLE
Add e2e coverage for the recipe editor, including sibling-panel clobbering

### DIFF
--- a/packages/app/src/screen/recipe-edit/details/index.tsx
+++ b/packages/app/src/screen/recipe-edit/details/index.tsx
@@ -62,19 +62,19 @@ export default function RecipeEditDetails({ recipeId }: RecipeEditDetailsProps) 
 
             <DataGridRow zebra>
                 <DataGridLabel cols={3}>Name</DataGridLabel>
-                <DataGridInput colStart={1} cols={3} value={data.name} onChange={onChangeName} />
+                <DataGridInput colStart={1} cols={3} label="Name" value={data.name} onChange={onChangeName} />
             </DataGridRow>
             <DataGridRow zebra>
                 <DataGridLabel cols={3}>Brewer</DataGridLabel>
-                <DataGridInput colStart={1} cols={3} value={data.brewer} onChange={onChangeBrewer} />
+                <DataGridInput colStart={1} cols={3} label="Brewer" value={data.brewer} onChange={onChangeBrewer} />
             </DataGridRow>
             <DataGridRow zebra>
                 <DataGridLabel cols={3}>Type</DataGridLabel>
-                <DataGridInput colStart={1} cols={3} value={data.type} onChange={onChangeType} />
+                <DataGridInput colStart={1} cols={3} label="Type" value={data.type} onChange={onChangeType} />
             </DataGridRow>
             <DataGridRow zebra>
                 <DataGridLabel cols={3}>Description</DataGridLabel>
-                <DataGridInput colStart={1} cols={3} value={data.description} onChange={onChangeDescription} />
+                <DataGridInput colStart={1} cols={3} label="Description" value={data.description} onChange={onChangeDescription} />
             </DataGridRow>
 
             <DataGridSubheaderRow>Measurements</DataGridSubheaderRow>
@@ -83,6 +83,7 @@ export default function RecipeEditDetails({ recipeId }: RecipeEditDetailsProps) 
                 <DataGridInput
                     colStart={1}
                     cols={3}
+                    label="Batch Size"
                     value={data.batchSize.value}
                     onChange={onChangeBatchSizeValue}
                     onBlur={onBlurBatchSize}
@@ -93,6 +94,7 @@ export default function RecipeEditDetails({ recipeId }: RecipeEditDetailsProps) 
                 <DataGridInput
                     colStart={1}
                     cols={3}
+                    label="Boil Time"
                     value={data.boilTime.value}
                     onChange={onChangeBoilTimeValue}
                     onBlur={onBlurBoilTime}
@@ -103,6 +105,7 @@ export default function RecipeEditDetails({ recipeId }: RecipeEditDetailsProps) 
                 <DataGridInput
                     colStart={1}
                     cols={3}
+                    label="Efficiency"
                     value={data.efficiency.value}
                     onChange={onChangeEfficiencyValue}
                     onBlur={onBlurEfficiency}
@@ -115,6 +118,7 @@ export default function RecipeEditDetails({ recipeId }: RecipeEditDetailsProps) 
                 <DataGridInput
                     colStart={1}
                     cols={3}
+                    label="OG"
                     value={data.targets.og.value}
                     onChange={onChangeOgValue}
                     onBlur={onBlurOg}
@@ -125,6 +129,7 @@ export default function RecipeEditDetails({ recipeId }: RecipeEditDetailsProps) 
                 <DataGridInput
                     colStart={1}
                     cols={3}
+                    label="FG"
                     value={data.targets.fg.value}
                     onChange={onChangeFgValue}
                     onBlur={onBlurFg}
@@ -135,6 +140,7 @@ export default function RecipeEditDetails({ recipeId }: RecipeEditDetailsProps) 
                 <DataGridInput
                     colStart={1}
                     cols={3}
+                    label="ABV"
                     value={data.targets.abv.value}
                     onChange={onChangeAbvValue}
                     onBlur={onBlurAbv}
@@ -142,11 +148,11 @@ export default function RecipeEditDetails({ recipeId }: RecipeEditDetailsProps) 
             </DataGridRow>
             <DataGridRow zebra>
                 <DataGridLabel cols={3}>IBU</DataGridLabel>
-                <DataGridInput colStart={1} cols={3} value={data.targets.ibu} onChange={onChangeIbu} />
+                <DataGridInput colStart={1} cols={3} label="IBU" value={data.targets.ibu} onChange={onChangeIbu} />
             </DataGridRow>
             <DataGridRow zebra>
                 <DataGridLabel cols={3}>SRM</DataGridLabel>
-                <DataGridInput colStart={1} cols={3} value={data.targets.srm} onChange={onChangeSrm} />
+                <DataGridInput colStart={1} cols={3} label="SRM" value={data.targets.srm} onChange={onChangeSrm} />
             </DataGridRow>
         </DataGrid>
     );

--- a/packages/e2e/tests/recipe-edit.spec.ts
+++ b/packages/e2e/tests/recipe-edit.spec.ts
@@ -1,0 +1,154 @@
+import {expect, Page, test} from "@playwright/test";
+
+/**
+ * Persistence + sibling-panel-clobbering coverage for the recipe editor.
+ *
+ * The editor's four panels (Details, Ingredients, Equipment, Phases) all save
+ * through `patchRecipe`, a read-modify-write against the freshest stored recipe
+ * — specifically so one panel's edit can't clobber another's. That merge reads
+ * the store fresh on every call but nothing proved the two orderings are both
+ * safe, and a clobber looks identical on screen to a save that worked (saves
+ * are fire-and-forget, and text fields debounce 350ms), so every test here is
+ * edit -> reload -> assert. The clobber tests deliberately don't let the first
+ * field's debounce settle before switching panels and editing the second, since
+ * a settled first edit never exercises the race the sibling-panel merge exists
+ * to guard against.
+ */
+
+async function createRecipeFromTemplate(page: Page, name: string, template: string) {
+    await page.goto("/recipes");
+    await page.getByRole("tab", {name: "My Recipes"}).click();
+    await page.getByRole("button", {name: "Create"}).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel(/Recipe name/).fill(name);
+    await dialog.getByLabel(/Template/).selectOption(template);
+    await dialog.getByRole("button", {name: "Confirm"}).click();
+
+    await expect(page).toHaveURL(/\/recipe\/.+\/edit/);
+}
+
+async function settleSave(page: Page) {
+    await page.waitForTimeout(1000);
+}
+
+test("Details fields persist across a reload", async ({page}) => {
+    await createRecipeFromTemplate(page, "E2E Details Persist", "Empty");
+
+    await page.getByLabel("Brewer").fill("E2E Brewer");
+    await page.getByLabel("Type").fill("IPA");
+    await page.getByLabel("Description").fill("A test recipe for the editor.");
+
+    // batch size reformats on blur — a bare typed number keeps the field's
+    // previous unit rather than the typed string surviving verbatim
+    const batchSize = page.getByLabel("Batch Size");
+    await batchSize.fill("10");
+    await batchSize.blur();
+
+    const og = page.getByLabel("OG");
+    await og.fill("1.050");
+    await og.blur();
+
+    await settleSave(page);
+    await page.reload();
+
+    await expect(page.getByLabel("Brewer")).toHaveValue("E2E Brewer");
+    await expect(page.getByLabel("Type")).toHaveValue("IPA");
+    await expect(page.getByLabel("Description")).toHaveValue("A test recipe for the editor.");
+    await expect(page.getByLabel("Batch Size")).toHaveValue(/10gal/);
+    await expect(page.getByLabel("OG")).toHaveValue(/1\.050/);
+});
+
+test("reopening an existing recipe via the list shows its stored values", async ({page}) => {
+    await createRecipeFromTemplate(page, "E2E Reopen Recipe", "Empty");
+
+    await page.getByLabel("Brewer").fill("E2E Reopen Brewer");
+    await settleSave(page);
+
+    await page.goto("/recipes");
+    await page.getByRole("tab", {name: "My Recipes"}).click();
+    const row = page.getByRole("listitem").filter({hasText: "E2E Reopen Recipe"});
+    await row.getByRole("heading", {name: "E2E Reopen Recipe"}).click();
+
+    await expect(page).toHaveURL(/\/recipe\/[^/]+$/);
+    await page.getByRole("button", {name: "Edit"}).click();
+    await expect(page).toHaveURL(/\/recipe\/.+\/edit/);
+
+    await expect(page.getByRole("heading", {name: "E2E Reopen Recipe"})).toBeVisible();
+    await expect(page.getByLabel("Name")).toHaveValue("E2E Reopen Recipe");
+    await expect(page.getByLabel("Brewer")).toHaveValue("E2E Reopen Brewer");
+});
+
+test("a Details edit and an Ingredients edit in the same session both survive — Details first", async ({page}) => {
+    await createRecipeFromTemplate(page, "E2E Clobber Details First", "Empty");
+
+    // Details is the default tab — start its debounce, then switch away before
+    // it has any chance to settle
+    await page.getByLabel("Brewer").fill("E2E Clobber Brewer 1");
+
+    await page.getByRole("tab", {name: "Ingredients", exact: true}).click();
+    await page.getByLabel("Ingredient for 2. Boil").selectOption("hop:Cascade");
+    await page.getByRole("button", {name: "Add ingredient to 2. Boil"}).click();
+    // the new row's own weight edit debounces too, so start it right away
+    await page.getByLabel("Cascade weight").fill("1.5");
+
+    await settleSave(page);
+    await page.reload();
+
+    // the last-active tab (Ingredients) is what the query-param-backed
+    // PanelSwitcher restores on reload — only the active panel is mounted,
+    // so Details has to be reselected before its fields exist to assert on
+    await page.getByRole("tab", {name: "Ingredients", exact: true}).click();
+    await expect(page.getByLabel("Cascade weight")).toHaveValue(/1\.5/);
+    await page.getByRole("tab", {name: "Details", exact: true}).click();
+    await expect(page.getByLabel("Brewer")).toHaveValue("E2E Clobber Brewer 1");
+});
+
+test("a Details edit and an Ingredients edit in the same session both survive — Ingredients first", async ({page}) => {
+    await createRecipeFromTemplate(page, "E2E Clobber Ingredients First", "Empty");
+
+    await page.getByRole("tab", {name: "Ingredients", exact: true}).click();
+    await page.getByLabel("Ingredient for 2. Boil").selectOption("hop:Cascade");
+    await page.getByRole("button", {name: "Add ingredient to 2. Boil"}).click();
+    await page.getByLabel("Cascade weight").fill("1.5");
+
+    await page.getByRole("tab", {name: "Details", exact: true}).click();
+    await page.getByLabel("Brewer").fill("E2E Clobber Brewer 2");
+
+    await settleSave(page);
+    await page.reload();
+
+    await expect(page.getByLabel("Brewer")).toHaveValue("E2E Clobber Brewer 2");
+    await page.getByRole("tab", {name: "Ingredients", exact: true}).click();
+    await expect(page.getByLabel("Cascade weight")).toHaveValue(/1\.5/);
+});
+
+test("adds an ingredient, equipment, and a phase from the recipe side, and all persist across a reload", async ({page}) => {
+    await createRecipeFromTemplate(page, "E2E Brewable Persist", "Empty");
+
+    await page.getByRole("tab", {name: "Ingredients", exact: true}).click();
+    await page.getByLabel("Ingredient for 2. Boil").selectOption("hop:Cascade");
+    await page.getByRole("button", {name: "Add ingredient to 2. Boil"}).click();
+
+    await page.getByRole("tab", {name: "Equipment", exact: true}).click();
+    const mashEquipment = page.locator(".data-grid").filter({has: page.getByRole("button", {name: "Add equipment to 1. Mash"})});
+    await mashEquipment.getByRole("combobox").selectOption("Mash Tun - 10gal");
+    await mashEquipment.getByRole("button", {name: "Add equipment to 1. Mash"}).click();
+
+    await page.getByRole("tab", {name: "Phases", exact: true}).click();
+    await page.getByLabel("Phase type to add").selectOption("conditioning");
+    await page.getByRole("button", {name: "Add phase"}).click();
+
+    await settleSave(page);
+    await page.reload();
+
+    await page.getByRole("tab", {name: "Ingredients", exact: true}).click();
+    await expect(page.getByLabel("Cascade weight")).toBeVisible();
+
+    await page.getByRole("tab", {name: "Equipment", exact: true}).click();
+    await expect(mashEquipment.getByRole("combobox").first()).toHaveValue("Mash Tun - 10gal");
+
+    await page.getByRole("tab", {name: "Phases", exact: true}).click();
+    await expect(page.getByText("4. Conditioning")).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Adds `packages/e2e/tests/recipe-edit.spec.ts`: Details persistence, sibling-panel clobbering in both orders, brewable panel persistence, and reopening an existing recipe via the list.
- Adds missing `aria-label`s to the Details panel's grid inputs via `DataGridInput`'s existing `label` prop, so the new specs can locate them.
- No clobber bug found — `patchRecipe`'s read-modify-write held up in both orderings across repeated runs.

Closes #414

## Verification
- `npm run test:e2e -w packages/e2e` — 60 passed, including the 5 new specs; also repeated the new file 3× with no flakes.
- `npm test --ws` — clean (0 errors).

Generated with [Claude Code](https://claude.ai/code)