### PR TITLE
Add e2e coverage for adding a hop to a phase with additives

### DIFF
--- a/packages/e2e/tests/batch-edit.spec.ts
+++ b/packages/e2e/tests/batch-edit.spec.ts
@@ -231,6 +231,35 @@ test("a second phase of the same type gets its own tab and its own ingredients",
     await expect(page.getByLabel("Cascade weight")).toHaveCount(0);
 });
 
+/**
+ * The add-row is scoped to its phase, not its subsection — a phase with more
+ * than one subsection (2. Boil ships both Hops and Additives) has only one add
+ * row, rendered after the last one. Scoping the assertion to the Hops group
+ * (phase-section.tsx wraps each resourceType in its own DOM group) is what
+ * actually proves the new hop joined Hops rather than merely existing
+ * somewhere on the page.
+ */
+test("adds a hop to a phase that also has additives, and it persists under Hops", async ({page}) => {
+    await brewBatchFromKbRecipe(page, "E2E Hops Subsection Batch");
+
+    await page.getByRole("tab", {name: "Planning", exact: true}).click();
+    await page.getByRole("tab", {name: "Ingredients", exact: true}).click();
+
+    await page.getByLabel("Ingredient for 2. Boil").selectOption("hop:Cascade");
+    await page.getByRole("button", {name: "Add ingredient to 2. Boil"}).click();
+    await expect(page.getByLabel("Cascade weight")).toBeVisible();
+
+    await settleSave(page);
+    await page.reload();
+    await page.getByRole("tab", {name: "Planning", exact: true}).click();
+    await page.getByRole("tab", {name: "Ingredients", exact: true}).click();
+
+    const hopsGroup = page.getByText("Hops", {exact: true}).locator("xpath=..");
+    await expect(hopsGroup.getByLabel("Cascade weight")).toBeVisible();
+    await expect(hopsGroup.getByLabel("Northern Brewer weight")).toHaveCount(3);
+    await expect(hopsGroup.getByText("Irish Moss")).toHaveCount(0);
+});
+
 test("adds a water sample on the Mash phase and persists bundled parameters", async ({page}) => {
     await brewBatchFromKbRecipe(page, "E2E Water Batch");
     await openSchedulePhase(page, "1. Mash");


### PR DESCRIPTION
## Summary

Adds Playwright coverage for #445 / #446: adding a hop to a phase that also has Additives (`2. Boil`), reloading, and asserting it persisted under the **Hops** DOM group specifically, not just anywhere on the page.

### Why it passes on unfixed `mainline` too

Verified both ways: against #446's diff (applied locally) it passes; reverted to today's `mainline` it still passes. The bug in #445 is about which control you click, not where a saved assignment ends up — assignments have always grouped by `resourceType` on render, independent of add-row placement. Matches #446's own Testing notes: this is a placement guard for the panel, not a regression test for that diff. It doesn't need #446 merged first.

Closes #445

## Verification

- `npx playwright test tests/batch-edit.spec.ts` — 16/16 passed
- `npm test --ws` (eslint) — 0 errors, only the 6 pre-existing `design` warnings

🤖 Generated with [Claude Code](https://claude.ai/code)