### PR TITLE
Give every role one standardized maintainer callout section

### DIFF
--- a/packages/claude-team/prompts/_shared.md
+++ b/packages/claude-team/prompts/_shared.md
@@ -41,3 +41,27 @@ Manager creating it is what keeps one story to one branch.
 - Ask when a change is ambiguous, irreversible, or reaches outside the PR.
 - Create issues and PRs **unlabeled**. A role labels only the PR it opens, and a scripted
   hook does even that.
+
+## Talking to the maintainer
+
+When you have a question, or made a call the maintainer would want to know about, put it in
+one standardized section at the **very bottom** of your comment — below a handoff, below
+everything:
+
+```markdown
+---
+### 🔔 Maintainer
+
+- ❓ **Blocked** — <the question>. Proceeding by <what you did instead>, or stopped.
+- ⚠️ **Heads up** — <what you decided that they would want to know>.
+```
+
+- ⚠️ **Omit the whole section when there is nothing.** Its value is that it is rare. A
+  section that shows up every time gets skimmed, and then the one that mattered is missed.
+- **Keep the two kinds apart.** `❓ Blocked` is a question you need answered. `⚠️ Heads up`
+  is a decision already made. Merging them means the maintainer cannot triage at a glance.
+- ⚠️ **A blocked item still says what you did.** Default and announce rather than stopping
+  silently — and if you genuinely could not proceed, write "stopped" and why. Silence is
+  never the answer.
+- **One line each.** If it needs a paragraph, the paragraph goes in the body above and the
+  line points at it.

--- a/packages/claude-team/prompts/implementor.md
+++ b/packages/claude-team/prompts/implementor.md
@@ -28,7 +28,8 @@ Code, and only code.
 - Push to the story branch.
 - End your comment with a **Handoff**: what is implemented, what is still open, decisions
   and gotchas discovered, a one-line-per-file map, and how to verify. Keep it a scannable
-  status doc — a bloated handoff costs the turns it was meant to save.
+  status doc — a bloated handoff costs the turns it was meant to save. A **🔔 Maintainer**
+  section, if you have one, goes below it.
 - Add **Testing notes** for the Tester, and **docs candidates** for the Writer, when either
   is warranted.
 


### PR DESCRIPTION
## Summary

Every role now ends with one standardized section, at the very bottom, when it has something for the maintainer:

```markdown
---
### 🔔 Maintainer

- ❓ **Blocked** — <the question>. Proceeding by <what you did instead>, or stopped.
- ⚠️ **Heads up** — <what you decided that they would want to know>.
```

Today a question or a caveat is buried in prose. On a long handoff it's easy to miss, and the cost of missing "I assumed X" is that X ships.

Closes #470

## The three rules that make it work

- ⚠️ **Omitted entirely when there is nothing.** Its value is being rare — a section that appears every time gets skimmed, which is exactly how the `docsCandidates` convention decayed into something nobody trusted.
- **The two kinds stay apart.** `❓ Blocked` needs an answer; `⚠️ Heads up` is already decided. Merged, the maintainer can't triage at a glance.
- ⚠️ **A blocked item still says what the agent did.** Default and announce rather than stopping silently, with "stopped" a valid answer and silence never one — the same principle as `open-story-pr.sh` warning instead of exiting quietly, and the delegator's loud fallback in #466.

## Where it lives

`packages/claude-team/prompts/_shared.md`, so all six roles inherit it. **Entirely package-side** — grepped for `brewdocs`, `mainline`, the package names, `npm`, `vite`, `tsc`: clean.

The Implementor's handoff instruction gained one line saying the callout goes below it, since both otherwise claim "the bottom of the comment".

## Verification

`npm test --ws` (eslint) ✓ · `tsc --noEmit` ✓ clean · `vite build` ✓. Prompt-only; no application code.

Prompt assembly re-simulated for all six roles — each still resolves base + overlay, and each carries the section and its omit rule exactly once:

```
manager      134 lines  callout=1  omit-rule=1
researcher   148 lines  callout=1  omit-rule=1
implementor  147 lines  callout=2  omit-rule=1   (2 = the section + the handoff cross-reference)
tester       141 lines  callout=1  omit-rule=1
writer       148 lines  callout=1  omit-rule=1
security     139 lines  callout=1  omit-rule=1
```

## Note

This is a **prompt convention**, so it's model-dependent — normally what this repo removes. It has to be: the model is what decides it has a question. Once #468 lands the `--json-schema` handoffs, this could become a `maintainer` array in the schema that a hook renders, making it deterministic rather than remembered. Recorded as out of scope on #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
