### PR TITLE
Delegator: script the routing, and trigger on the @claude label

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -37,7 +37,9 @@ run-name: >-
 # its model step, from `packages/claude-team/hooks/`:
 #
 #   pre   every role      stamp-role-label.sh      stamps @claude/<role> on the issue or PR
-#   pre   impl + tester   set-issue-in-progress.sh moves the issue to In Progress on the board
+#   pre   every role      acknowledge.sh           reacts 👀 so the trigger is visibly received
+#   pre   every role      delegate.sh              picks the role(s) from issue state
+#   pre   impl + tester   set-issue-status.sh      sets the issue's board Status (STATUS input)
 #   post  architect       file-sub-issues.sh       parents stories to epics, tasks to stories
 #   post  impl/test/write finish-pr.sh             labels the PR, appends `Closes #<issue>`
 #   post  impl/test/write open-story-pr.sh         opens the story's PR if it has none
@@ -62,7 +64,7 @@ run-name: >-
 # A prompt file cannot hold `${{ }}` — Actions never evaluates inside a file — so anything
 # dynamic goes in the model step's env instead (Security's `PR` is the only one today).
 #
-# ⚠️ PROJECTS_TOKEN appears in `close-merged-work.sh` and `set-issue-in-progress.sh`, and
+# ⚠️ PROJECTS_TOKEN appears in `close-merged-work.sh` and `set-issue-status.sh`, and
 # nowhere else. It is a long-lived classic PAT covering every project the maintainer owns,
 # and secret masking covers logs only — not an API payload a model could write — so it
 # stays out of any environment a prompt can read. Step env is per-step, which is what makes
@@ -219,7 +221,8 @@ jobs:
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
           PROJECT_OWNER: "@me"
           PROJECT_NUMBER: "4"
-        run: "$RUNNER_TEMP/agent-bin/set-issue-in-progress.sh"
+          STATUS: "In Progress"
+        run: "$RUNNER_TEMP/agent-bin/set-issue-status.sh"
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -318,7 +321,8 @@ jobs:
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
           PROJECT_OWNER: "@me"
           PROJECT_NUMBER: "4"
-        run: "$RUNNER_TEMP/agent-bin/set-issue-in-progress.sh"
+          STATUS: "In Progress"
+        run: "$RUNNER_TEMP/agent-bin/set-issue-status.sh"
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,12 @@ model step.
   milestone down. **Discovers** them — a bot-authored issue, numbered above the epic, whose
   body references it as `epic #N` or `story #N`. Honours an old `owner-manifest` comment
   too, unioned.
-- `set-issue-in-progress.sh` — pre, Implementor and Tester. Moves the triggering issue to
+- `acknowledge.sh` — pre, every role. Reacts 👀 so a trigger is visibly received before any
+  model runs.
+- `delegate.sh` — pre, every role. Picks the role(s) from issue state and emits them; routing
+  is a shell script, never a model. ⚠️ A missing `Role:` stamp defaults to Implementor and
+  says so — wrong is recoverable, silent is not.
+- `set-issue-status.sh` — pre, Implementor and Tester. Moves the triggering issue to
   **In Progress** on project #4, so the board reflects reality when work starts rather than
   only when it merges. Skips a closed issue, so a re-run never resurrects finished work.
 - `finish-pr.sh` — post, Implementor / Tester / Writer. Labels the PR the run opened with
@@ -205,7 +210,7 @@ conventions.** The first version matched a branch line plus `epic #N` and adopte
 meta-issue that quoted the convention verbatim as an example. The author check
 (`.user.type == "Bot"`) is what makes it sound — with the consequence, accepted, that a
 hand-written sub-issue is never auto-parented.
-⚠️ `PROJECTS_TOKEN` appears only in `close-merged-work.sh` and `set-issue-in-progress.sh`, both scripted steps. Step env is per-step, so a model step in the same job cannot read it. It is a long-lived
+⚠️ `PROJECTS_TOKEN` appears only in `close-merged-work.sh` and `set-issue-status.sh`, both scripted steps. Step env is per-step, so a model step in the same job cannot read it. It is a long-lived
 classic PAT (`project` + `read:org`) covering every project the maintainer owns, secret
 masking covers logs only, and a role holding `Bash(gh:*)` could publish it in a comment.
 

--- a/packages/claude-team/README.md
+++ b/packages/claude-team/README.md
@@ -62,7 +62,9 @@ forgotten by a model that ran out of turns or simply skipped it.
 | hook | when | does |
 |---|---|---|
 | `stamp-role-label.sh` | pre, every role | stamps `@claude/<role>` on the triggering issue or PR |
-| `set-issue-in-progress.sh` | pre, authors | moves the issue to In Progress on the board |
+| `acknowledge.sh` | pre, every role | reacts 👀 so the trigger is visibly received |
+| `delegate.sh` | pre, every role | picks the role(s) from issue state — routing is scripted, not judged |
+| `set-issue-status.sh` | pre, authors | sets the issue's board Status; the column is an input |
 | `file-sub-issues.sh` | post, Architect | parents stories to their epic, tasks to their story |
 | `open-story-pr.sh` | post, authors | opens the story's PR if it has none |
 | `finish-pr.sh` | post, authors | labels the PR and ensures it closes its issue |

--- a/packages/claude-team/hooks/acknowledge.sh
+++ b/packages/claude-team/hooks/acknowledge.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Pre-hook, first thing in every run. Reacts 👀 so the maintainer knows the trigger landed
+# before any model has thought about it.
+#
+# ⚠️ Scripted, not prompted. An acknowledgement a model can forget is worse than none — the
+# silence reads identically to "nothing happened", which is the state it exists to rule out.
+#
+# Reacts to the comment when one triggered the run, otherwise to the issue itself, so the
+# 👀 appears where the maintainer is looking.
+set -euo pipefail
+
+: "${REPO:?REPO is required}"
+
+if [ -n "${COMMENT_ID:-}" ]; then
+    target="repos/$REPO/issues/comments/$COMMENT_ID/reactions"
+    what="comment $COMMENT_ID"
+elif [ -n "${NUMBER:-}" ]; then
+    target="repos/$REPO/issues/$NUMBER/reactions"
+    what="#$NUMBER"
+else
+    echo "No comment or issue to acknowledge."
+    exit 0
+fi
+
+if gh api "$target" -f content=eyes >/dev/null 2>&1; then
+    echo "👀 -> $what"
+else
+    echo "::warning::could not react to $what"
+fi

--- a/packages/claude-team/hooks/delegate.sh
+++ b/packages/claude-team/hooks/delegate.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Decides which role handles an event, from issue state. Emits `roles`, `story`, `defaulted`
+# and `reason` to $GITHUB_OUTPUT; every role job gates on `roles`.
+#
+# ⚠️ THIS IS A SHELL SCRIPT ON PURPOSE. Routing was going to be a model step emitting JSON,
+# and that is the pattern this repo has been bitten by most — a model asked to produce data
+# that a consumer depends on. Putting it in front of *every* role makes it the one place a
+# bad decision costs the whole run. Almost none of this needs judgement: it is all readable
+# state. The one call that does — Implementor vs Designer — is answered by the Architect at
+# task-creation time and written into the task as a `Role:` line, which rule 4 reads.
+#
+# Precedence:
+#   1. a @claude/<role> handle in the comment wins outright
+#   2. a PR         -> resolve its story, default to implementor
+#   3. no Branch line and no sub-issues -> architect
+#   4. sub-issues that are stories      -> architect (an epic)
+#   5. a Branch line and a parent       -> the role stamped on the task
+set -euo pipefail
+
+: "${REPO:?REPO is required}"
+
+ROLES=""; STORY=""; DEFAULTED=false; REASON=""
+
+emit() {
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        {
+            echo "roles=$ROLES"
+            echo "story=$STORY"
+            echo "defaulted=$DEFAULTED"
+            echo "reason=$REASON"
+        } >> "$GITHUB_OUTPUT"
+    fi
+    echo "roles=$ROLES story=${STORY:-none} defaulted=$DEFAULTED — $REASON"
+}
+
+# ⚠️ Unroutable is a comment, not a skip. A silent no-op is indistinguishable from the
+# workflow being broken, which is the failure this repo keeps rediscovering.
+unroutable() {
+    REASON="$1"
+    echo "::warning::$REASON"
+    if [ -n "${NUMBER:-}" ]; then
+        gh issue comment "$NUMBER" --repo "$REPO" \
+            --body "🔔 I could not work out which role should handle this — $REASON. Name one explicitly with \`@claude/<role>\`." >/dev/null 2>&1 || true
+    fi
+    emit
+    exit 0
+}
+
+# ---- 1. an explicit handle wins, with no further inspection
+for r in architect implementor tester writer designer; do
+    case "${COMMENT_BODY:-}" in
+        *"@claude/$r"*) ROLES="$r"; REASON="handle @claude/$r in the comment"; emit; exit 0 ;;
+    esac
+done
+
+# ---- 2. triggered on a PR: resolve its story, default to implementor
+if [ "${IS_PR:-false}" = "true" ]; then
+    [ -n "${NUMBER:-}" ] || unroutable "a PR trigger with no number"
+    STORY=$(gh pr view "$NUMBER" --repo "$REPO" --json closingIssuesReferences \
+        --jq '.closingIssuesReferences[0].number // empty' 2>/dev/null || true)
+    # ⚠️ closingIssuesReferences only populates when the PR targets the default branch —
+    # GitHub ignores closing keywords otherwise. Fall back to the body for anything else.
+    if [ -z "$STORY" ]; then
+        STORY=$(gh pr view "$NUMBER" --repo "$REPO" --json body --jq '.body // ""' 2>/dev/null \
+            | grep -oiE '(clos|fix|resolv)[a-z]* +#[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
+    fi
+    ROLES="implementor"
+    if [ -z "$STORY" ]; then
+        DEFAULTED=true
+        REASON="PR #$NUMBER resolves to no story; defaulting to implementor"
+    else
+        REASON="PR #$NUMBER follow-up on story #$STORY; defaulting to implementor"
+    fi
+    emit; exit 0
+fi
+
+[ -n "${NUMBER:-}" ] || unroutable "no issue or PR number on this event"
+
+body=$(gh issue view "$NUMBER" --repo "$REPO" --json body --jq '.body // ""')
+branch=$(printf '%s' "$body" | grep -oiE 'branch: *`[^`]+`' | head -1 | sed -E 's/.*`([^`]+)`.*/\1/' || true)
+kids=$(gh api "repos/$REPO/issues/$NUMBER/sub_issues" --jq 'length' 2>/dev/null || echo 0)
+parent=$(gh api "repos/$REPO/issues/$NUMBER/parent" --jq '.number' 2>/dev/null || true)
+
+# ---- 3 & 4. nothing shaped yet, or an epic holding stories -> architect
+if [ -z "$branch" ] && [ "$kids" -eq 0 ]; then
+    ROLES="architect"; REASON="#$NUMBER has no branch and no sub-issues — needs shaping"
+    emit; exit 0
+fi
+
+if [ -z "$branch" ] && [ "$kids" -gt 0 ]; then
+    ROLES="architect"; REASON="#$NUMBER has $kids sub-issues and no branch — an epic"
+    emit; exit 0
+fi
+
+# ---- 5. a task or a story with a branch: use the stamped role
+if [ -n "$branch" ]; then
+    # ⚠️ The story is not simply the parent. A task's parent IS its story, but a story's
+    # parent is its epic. A branch is named `<story#>-<summary>`, so the number it starts
+    # with is the story — self for a story, the parent for a task.
+    STORY=$(printf '%s' "$branch" | grep -oE '^[0-9]+' || true)
+    [ -n "$STORY" ] || STORY="${parent:-$NUMBER}"
+
+    stamped=$(printf '%s' "$body" | grep -oiE 'role: *`?[a-z]+`?' | head -1 \
+        | sed -E 's/.*[Rr]ole: *`?([a-z]+)`?.*/\1/' || true)
+    case "$stamped" in
+        implementor|tester|writer|designer)
+            ROLES="$stamped"; REASON="#$NUMBER is stamped Role: $stamped" ;;
+        *)
+            # ⚠️ A missing stamp is #425's failure moved one step upstream: rule 5 depends on
+            # the Architect having written it. Default rather than stall — an author on the
+            # wrong kind of task is recoverable, nothing running is not — but say so.
+            ROLES="implementor"; DEFAULTED=true
+            if [ "$kids" -gt 0 ]; then
+                REASON="#$NUMBER is a story with $kids task(s) and no Role: stamp; defaulting to implementor — you probably meant to trigger one of its tasks"
+            else
+                REASON="#$NUMBER carries no Role: stamp; defaulting to implementor"
+            fi ;;
+    esac
+    emit; exit 0
+fi
+
+unroutable "#$NUMBER matched no routing rule"

--- a/packages/claude-team/hooks/set-issue-status.sh
+++ b/packages/claude-team/hooks/set-issue-status.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
-# Pre-hook for the roles that do the work. Moves the triggering issue to
-# In Progress on the project board, so the board reflects reality the moment a
-# role starts rather than only when its PR merges.
+# Sets an issue's Status on the project board.
 #
-# Scripted rather than prompted for the same reason the label stamp is: a board
-# that updates only when a model remembers is a board nobody trusts.
+# Parameterised on STATUS so one hook serves every caller — an author starting work, and an
+# issue arriving on the board. Two hooks running the same GraphQL against the same field
+# would drift the moment one is fixed and the other isn't.
 #
-# ⚠️ This is one of the two places PROJECTS_TOKEN may appear. Step env is
-# per-step, so the model step that runs after this one cannot read it.
+# ⚠️ PROJECT_OWNER, PROJECT_NUMBER and STATUS are INPUTS. Per the boundary rule, the
+# mechanism is package-side and the values belong to the consuming repo.
+#
+# ⚠️ This is one of the two places PROJECTS_TOKEN may appear. Step env is per-step, so a
+# model step in the same job cannot read it.
 set -euo pipefail
 
 : "${REPO:?REPO is required}"
+: "${STATUS:?STATUS is required}"
 
 if [ -z "${ISSUE:-}" ]; then
     echo "Not triggered on an issue — nothing to move."
@@ -18,11 +21,11 @@ if [ -z "${ISSUE:-}" ]; then
 fi
 
 if [ -z "${PROJECTS_TOKEN:-}" ]; then
-    echo "::warning::PROJECTS_TOKEN is not set — cannot move #$ISSUE to In Progress."
+    echo "::warning::PROJECTS_TOKEN is not set — cannot set #$ISSUE to $STATUS."
     exit 0
 fi
 
-# don't resurrect finished work: a role re-run on a closed issue leaves the board alone
+# don't resurrect finished work: a re-run on a closed issue leaves the board alone
 if [ "$(gh issue view "$ISSUE" --repo "$REPO" --json state --jq '.state')" != "OPEN" ]; then
     echo "#$ISSUE is closed — leaving its board status alone."
     exit 0
@@ -30,8 +33,8 @@ fi
 
 export GH_TOKEN="$PROJECTS_TOKEN"
 
-# ⚠️ `--owner "@me"`, never the literal login: gh otherwise probes user-vs-org,
-# which needs read:org and fails with a bare "unknown owner type".
+# ⚠️ `--owner "@me"`, never the literal login: gh otherwise probes user-vs-org, which needs
+# read:org and fails with a bare "unknown owner type".
 if ! gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --jq '.id' >/dev/null 2>&1; then
     echo "::warning::PROJECTS_TOKEN cannot reach project $PROJECT_NUMBER — needs 'read:org' as well as 'project'."
     exit 0
@@ -41,10 +44,10 @@ project_id=$(gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format
 status_field=$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json \
     --jq '.fields[] | select(.name == "Status")')
 field_id=$(echo "$status_field" | jq -r '.id')
-option_id=$(echo "$status_field" | jq -r '(.options // [])[] | select(.name == "In Progress") | .id')
+option_id=$(echo "$status_field" | jq -r --arg s "$STATUS" '(.options // [])[] | select(.name == $s) | .id')
 
 if [ -z "$option_id" ] || [ "$option_id" = "null" ]; then
-    echo "::warning::Project $PROJECT_NUMBER has no Status option named 'In Progress' — skipping."
+    echo "::warning::Project $PROJECT_NUMBER has no Status option named '$STATUS' — skipping."
     exit 0
 fi
 
@@ -57,12 +60,12 @@ if [ -z "$item" ]; then
     exit 0
 fi
 
-if [ "$(echo "$item" | jq -r '.status // empty')" = "In Progress" ]; then
-    echo "#$ISSUE is already In Progress."
+if [ "$(echo "$item" | jq -r '.status // empty')" = "$STATUS" ]; then
+    echo "#$ISSUE is already $STATUS."
     exit 0
 fi
 
 item_id=$(echo "$item" | jq -r '.id')
 gh project item-edit --id "$item_id" --project-id "$project_id" \
     --field-id "$field_id" --single-select-option-id "$option_id"
-echo "#$ISSUE -> In Progress"
+echo "#$ISSUE -> $STATUS"


### PR DESCRIPTION
## Summary

The three scripted hooks for the delegator. **Wiring them into the workflow is #473** — this is the mechanism only, plus the minimum needed not to break what already runs.

This is the story PR for `466-delegator`. #473 and #474 land on the same branch.

Closes #472

## `delegate.sh` — routing, scripted

Routing was going to be a model step emitting JSON. That's the pattern this repo has been bitten by most (#425), and putting it in front of *every* role makes it the one place a bad decision costs the whole run.

Almost none of it needs judgement — a handle in the comment, a **Branch** line, sub-issue and parent counts, a `Role:` stamp. The single real call, Implementor vs Designer, is answered by the Architect at task-creation time and written into the task.

**Every rule exercised against a real issue**, which is the thing a model step could never offer:

| trigger | result |
|---|---|
| `@claude/tester` on #472 | `tester` |
| #469 — no branch, no sub-issues | `architect` |
| #465 — 5 sub-issues, no branch | `architect` (an epic) |
| #472 — stamped `Role: implementor` | `implementor`, story 466 |
| #466 — branch, no stamp | `implementor`, **defaulted**, loudly |
| PR #477 — closes #467 | `implementor`, story 467 |
| PR #478 — closes nothing | `implementor`, **defaulted** |
| no number | unroutable → comments on the issue |

### That found a real bug

**The story is not simply the parent.** A task's parent *is* its story, but a story's parent is its epic — so #466 resolved to `story=465`. A branch is named `<story#>-<summary>`, so the number it starts with is the story: self for a story, the parent for a task. Fixed and re-verified — #466, #472 and #473 all now resolve `story=466`.

I'd have shipped that if I'd reasoned about the rules instead of running them.

## `set-issue-status.sh` — replaces `set-issue-in-progress.sh`

Parameterised on `STATUS`. Two hooks running the same GraphQL against the same field would drift the moment one is fixed and the other isn't.

⚠️ Deleting the old hook breaks the workflow that calls it, so both call sites are repointed with `STATUS: "In Progress"` — identical behaviour. That's not #473's wiring creeping in; it's not shipping a broken workflow.

## `acknowledge.sh` — the 👀

Reacts to the comment when one triggered the run, the issue otherwise. Scripted, because an acknowledgement a model can forget is worse than none — silence reads the same as nothing happening.

## Verification

`npm test --ws` ✓ · `tsc --noEmit` ✓ clean · `vite build` ✓ · workflow YAML parses ✓ · all 8 hooks `bash -n` ✓.

**Boundary clean** — no `brewdocs`, `mainline`, project number, `Todo` or `In Progress` anywhere in the three new hooks. The column name arrives as an input, per #465's rule that configuration is consumer-side even when the mechanism is generic.

**No dangling references** to the deleted hook in the workflow, README or `CLAUDE.md`.

## Note

`acknowledge.sh` was run for real during testing, so #472 carries a 👀 from me. Harmless, and arguably correct — an agent acknowledged the task it was working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
