### PR TITLE
Claude Team: delegator routing, the author chain, JSON handoffs and the Designer

### DIFF
--- a/.github/agent-prompts/designer.md
+++ b/.github/agent-prompts/designer.md
@@ -1,0 +1,34 @@
+Your package is **`packages/design`** — the React UI primitives that emit Tailwind/DaisyUI
+class strings. `packages/app` and `packages/www` are the *consumers*, and belong to the
+Implementor.
+
+Read [`packages/design/CLAUDE.md`](packages/design/CLAUDE.md) before you touch anything, and
+[`DESIGN.md`](packages/design/DESIGN.md) for the long-form system (color, typography,
+spacing, radii, components).
+
+Run the gate before you finish: `npm test --ws`, then `tsc --noEmit`, then
+`npm run build -w packages/app`. Report each in the PR — the PR body is the only record it
+ran. For a visual change also run `npm run build -w packages/design` (the Storybook build),
+and attach a screenshot of the story.
+
+⚠️ **`packages/design` ships raw TypeScript** — no build step, `main: src/index.ts`. Every
+consumer's bundler compiles it, so your code must compile under *both* the app's and www's
+tsconfig.
+
+⚠️ **Tailwind v4 does not scan symlinked workspace deps.** `app/src/styles.css` and www's
+each carry a load-bearing `@source "../../design/src";`. If styling vanishes wholesale, that
+is why — but those files are the Implementor's, so report it rather than editing them.
+
+⚠️ **Don't check tailwind/daisyui behaviour by reading `node_modules` at the repo root** —
+daisyui is nested per-consumer and the root has no copy. The built CSS in
+`packages/app/dist/assets/*.css` is the only reliable answer to "what does this class do".
+
+⚠️ **The _Surface_ list in `packages/design/CLAUDE.md` is one bullet per component, and must
+stay that way** — it was a single paragraph and collided in four consecutive merges because
+every design-touching branch appended to the same line. That file is the Writer's to edit;
+a new primitive gets its own bullet, never an append to an existing one. Put it in
+`docsCandidates` and say which bullet.
+
+A `docsCandidates` entry names `packages/design/CLAUDE.md` or `packages/design/DESIGN.md`.
+⚠️ Never propose an inline code comment: this repo's default is none, and the *why* belongs
+in a `CLAUDE.md` where it is discoverable and maintained.

--- a/.github/agent-prompts/implementor.md
+++ b/.github/agent-prompts/implementor.md
@@ -4,11 +4,7 @@ ran.
 
 For a UI change, check the screen in a browser and attach a screenshot.
 
-Docs candidates go in a fenced `json` block at the end of your handoff:
-
-```json
-{"docsCandidates": [{"file": "packages/app/CLAUDE.md", "note": "…", "why": "…"}]}
-```
-
-`why` is the field that decides it — a note without a real cost behind it usually isn't one.
-Omit the block entirely when nothing cost you time.
+Docs in this repo live in a `CLAUDE.md` per package — root for universal rules,
+`packages/<name>/CLAUDE.md` for the rest — so a `docsCandidates` entry names one of those
+as its `file`. ⚠️ Never propose an inline code comment: this repo's default is none, and
+the *why* belongs in a `CLAUDE.md` where it is discoverable and maintained.

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -348,6 +348,25 @@ jobs:
           cp packages/claude-team/hooks/*.sh "$RUNNER_TEMP/agent-bin/"
           chmod +x "$RUNNER_TEMP/agent-bin"/*.sh
 
+      # The handoff contract lives in packages/claude-team so a second repo gets it
+      # unchanged, but `--json-schema` takes INLINE JSON, not a path — so the file is
+      # compacted to one line here and injected into claude_args below. Same shape as
+      # load-prompt: the file is the source of truth, the workflow only carries it.
+      # ⚠️ Loaded here, before any model step, for the usual reason — a `run:` reads the
+      # working tree and the model switches branches partway through.
+      - id: schema
+        name: Load the handoff schema
+        run: |
+          # ⚠️ claude_args is line-parsed, so the schema must be ONE line; and it is wrapped
+          # in single quotes there, so it must contain none. Fail loudly rather than emit a
+          # value that would mangle every flag after it.
+          body=$(jq -c . packages/claude-team/schemas/handoff.json)
+          case "$body" in
+            *"'"*) echo "::error::handoff.json contains a single quote; it cannot be inlined into claude_args"; exit 1 ;;
+          esac
+          echo "body=$body" >> "$GITHUB_OUTPUT"
+          echo "handoff schema loaded (${#body} chars)"
+
       # Resolved once, read by every gate below — otherwise the same condition appears
       # nine times and drifts.
       # ⚠️ The comment body arrives as ENV and is never interpolated into the script. A
@@ -415,6 +434,7 @@ jobs:
           NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: "$RUNNER_TEMP/agent-bin/stamp-role-label.sh"
       - name: Implementor
+        id: implementor
         if: contains(steps.roles.outputs.list, 'implementor')
         uses: anthropics/claude-code-action@v1
         env:
@@ -428,10 +448,15 @@ jobs:
           # Allowlist by *family*, not per-subcommand. Deliberately NOT bare `Bash`: this
           # runner carries GH_TOKEN and the Claude OAuth token in env, and arbitrary shell
           # could exfiltrate them. Only write-access actors can trigger a run.
+          # ⚠️ --json-schema makes the Implementor's final message the handoff contract, and
+          # the action exposes it as `structured_output` for the two steps below. Prose
+          # sections a later role has to find and parse are the shape that failed for
+          # sub-issue filing: a consumer cannot tell "nothing to report" from "forgot".
           claude_args: |
             --model opus
             --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*)"
             --max-turns 80
+            --json-schema '${{ steps.schema.outputs.body }}'
 
       # ── Tester ──
       # Owns packages/e2e. The Implementor ships behaviour and reports Testing notes; the
@@ -458,7 +483,18 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
           track_progress: true
-          prompt: ${{ steps.p_tester.outputs.body }}
+          # ⚠️ The handoff arrives as prompt CONTEXT, not as something to go and find. It is
+          # empty when the Implementor did not run in this job (a Tester-only trigger) or
+          # when its step failed — which is exactly why `testingNotes: []` and an absent
+          # block have to read differently. The prompt says how to tell them apart.
+          prompt: |
+            ${{ steps.p_tester.outputs.body }}
+
+            ## Handoff from the Implementor
+
+            ```json
+            ${{ steps.implementor.outputs.structured_output }}
+            ```
           claude_args: |
             --model sonnet
             --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
@@ -490,7 +526,17 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
           track_progress: true
-          prompt: ${{ steps.p_writer.outputs.body }}
+          # The Writer sees the Implementor's candidates directly. ⚠️ Still a proposal, not
+          # an order — a schema must not imply obligation, and rejecting every candidate
+          # stays a correct outcome. writer.md carries that.
+          prompt: |
+            ${{ steps.p_writer.outputs.body }}
+
+            ## Handoff from the Implementor
+
+            ```json
+            ${{ steps.implementor.outputs.structured_output }}
+            ```
           claude_args: |
             --model sonnet
             --allowedTools "Read,Edit,Write,Bash(git:*),Bash(gh:*)"

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -72,6 +72,7 @@ run-name: >-
 #   post  architect       file-sub-issues.sh       parents stories to epics, tasks to stories
 #   post  authors job     finish-pr.sh             labels the PR, appends `Closes #<issue>`
 #   post  authors job     open-story-pr.sh         opens the story's PR if it has none
+#   post  authors job     log-to-epic.sh           rewrites the epic's rolling work log
 #   merge (no role)       close-merged-work.sh     closes the PR's issues, files them on the board
 #
 # ⚠️ The authors job's post-hooks run ONCE at the end of the job, not once per role — three
@@ -513,6 +514,14 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         run: "$RUNNER_TEMP/agent-bin/open-story-pr.sh"
+      - name: Update the epic's work log
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          ROLES: ${{ steps.roles.outputs.list }}
+        run: "$RUNNER_TEMP/agent-bin/log-to-epic.sh"
 
   # ── Security ───────────────────────────────────────────────────────────────────
   # Reviews what just landed on mainline and files issues for what it finds. Runs on

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -324,6 +324,11 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the story this run belongs to, resolved by the delegator from the PR's head
+          # branch. Same pattern as Security's PR: a prompt file can't hold `${{ }}`, so
+          # anything dynamic arrives as env and the model's own shell expands it. Empty when
+          # the trigger resolves to no story — the prompt says to carry on without it.
+          STORY: ${{ needs.delegate.outputs.story }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # ⚠️ track_progress forces the action's TAG MODE. That mode re-checks the
@@ -428,6 +433,11 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the story this run belongs to, resolved by the delegator from the PR's head
+          # branch. Same pattern as Security's PR: a prompt file can't hold `${{ }}`, so
+          # anything dynamic arrives as env and the model's own shell expands it. Empty when
+          # the trigger resolves to no story — the prompt says to carry on without it.
+          STORY: ${{ needs.delegate.outputs.story }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # ⚠️ track_progress forces the action's TAG MODE. That mode re-checks the
@@ -507,6 +517,11 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the story this run belongs to, resolved by the delegator from the PR's head
+          # branch. Same pattern as Security's PR: a prompt file can't hold `${{ }}`, so
+          # anything dynamic arrives as env and the model's own shell expands it. Empty when
+          # the trigger resolves to no story — the prompt says to carry on without it.
+          STORY: ${{ needs.delegate.outputs.story }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -12,9 +12,11 @@ run-name: >-
   ${{ github.event_name == 'pull_request'
   && (github.event.pull_request.merged && 'Post-merge' || 'PR closed')
   || contains(github.event.comment.body || github.event.review.body, '@claude/architect') && 'Architect'
+  || contains(github.event.comment.body || github.event.review.body, '@claude/implementor') && 'Implementor'
   || contains(github.event.comment.body || github.event.review.body, '@claude/tester') && 'Tester'
   || contains(github.event.comment.body || github.event.review.body, '@claude/writer') && 'Writer'
-  || 'Implementor' }}
+  || contains(github.event.comment.body || github.event.review.body, '@claude/designer') && 'Designer'
+  || 'Delegate' }}
   · #${{ github.event.issue.number || github.event.pull_request.number }}
   ${{ github.event.issue.title || github.event.pull_request.title }}
 
@@ -23,22 +25,41 @@ run-name: >-
 # by a job-level `if:`, so it is one run per comment with the unselected roles skipping
 # inside it. Security is the sixth and runs on merge, not on a comment.
 #
-# ⚠️ THE HANDLE IN THE COMMENT ROUTES. Not labels.
+# ⚠️ THE DELEGATOR ROUTES. Two ways in, one router:
 #
-#   "@claude/architect ..."    -> Architect    (issues only — it shapes work and cuts tasks)
-#   "@claude/implementor ..."  -> Implementor  (issue or PR)
-#   "@claude/tester ..."       -> Tester       (issue or PR)
-#   "@claude/writer ..."       -> Writer       (issue or PR)
+#   label "@claude" on an issue  -> delegate.sh reads issue state and picks the role
+#   "@claude" in a comment       -> same
+#   "@claude/<role>" in a comment-> delegate.sh rule 1 returns that role outright
 #
-# ⚠️ A BARE "@claude" DOES NOTHING, deliberately, so a half-typed handle cannot start the
-# wrong agent. Labels trigger nothing either — `on.issues` is not subscribed.
+# Every model job carries `needs: delegate` and gates on `needs.delegate.outputs.roles`.
+# A job cannot gate on a step inside itself, which is why the router is its own job.
+#
+# ⚠️ THIS IS NOT THE `needs:` SHAPE #430 REVERTED. There, roles needed `implementor`, which
+# itself skipped most runs — and a job needing a skipped job reports cancelled, which was
+# the noise. `delegate` always RUNS whenever the workflow triggers, so dependents reach
+# their own `if:` and skip cleanly. The alternative (delegate as a step in all six jobs)
+# spins six runners to check out a repo and then do nothing.
+#
+# ⚠️ A HANDLE MUST NEVER BE BLOCKED BY THE ROUTER. Each role's `if:` is
+# `always() && (router picked me || the comment names me)`, so an explicit handle still
+# routes when delegate.sh fails outright. Only a *skipped* delegate skips the roles.
+#
+# ⚠️ THE LOOP GUARD IS THE EXACT LABEL NAME. Roles stamp "@claude/<role>", and every stamp
+# is another `issues: labeled` event. The delegate job requires
+# `github.event.label.name == '@claude'` — an exact match, so no "@claude/..." stamp can
+# re-enter — backed by the bot-actor guard, since the stamp is applied as a bot. Both must
+# hold; either alone is one edit away from an infinite loop rather than a visible failure.
+#
+# ⚠️ RE-ADDING "@claude" IS THE "RUN AGAIN" GESTURE, deliberately. `labeled` fires on every
+# add, so removing and re-adding re-runs the delegator on current issue state — which is
+# what you want after editing the issue. Concurrency queues it behind any run in flight.
 #
 # ⚠️ BACKLOG WORK IS SCRIPTED, NOT PROMPTED. Every role carries hard-coded hooks around
 # its model step, from `packages/claude-team/hooks/`:
 #
+#   delegate job          acknowledge.sh           reacts 👀 so the trigger is visibly received
+#   delegate job          delegate.sh              picks the role(s) from issue state
 #   pre   every role      stamp-role-label.sh      stamps @claude/<role> on the issue or PR
-#   pre   every role      acknowledge.sh           reacts 👀 so the trigger is visibly received
-#   pre   every role      delegate.sh              picks the role(s) from issue state
 #   pre   impl + tester   set-issue-status.sh      sets the issue's board Status (STATUS input)
 #   post  architect       file-sub-issues.sh       parents stories to epics, tasks to stories
 #   post  impl/test/write finish-pr.sh             labels the PR, appends `Closes #<issue>`
@@ -70,6 +91,9 @@ run-name: >-
 # stays out of any environment a prompt can read. Step env is per-step, which is what makes
 # these two safe: the model step in the same job cannot see it.
 on:
+  # the primary trigger. Gated to the label being exactly "@claude" — see the loop guard.
+  issues:
+    types: [labeled]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -92,6 +116,67 @@ env:
   NODE_VERSION: 22
 
 jobs:
+  # ── Delegate ───────────────────────────────────────────────────────────────────
+  # The router. Acknowledges the trigger, then decides which role handles it. Every model
+  # job below hangs off this one.
+  #
+  # ⚠️ NO MODEL, on purpose. Routing was going to be a model step emitting JSON, and "a
+  # model producing data a consumer depends on" is the pattern this repo has been bitten by
+  # most. Sitting in front of every role makes a bad decision here cost the whole run;
+  # almost none of it needs judgement. See the header for the loop guard and the `needs:`
+  # note, and delegate.sh for the precedence rules.
+  delegate:
+    if: |
+      github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
+        (github.event_name == 'issues' && github.event.label.name == '@claude') ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # write so the unroutable path can leave a comment rather than skipping silently
+      issues: write
+      pull-requests: read
+    outputs:
+      roles: ${{ steps.route.outputs.roles }}
+      story: ${{ steps.route.outputs.story }}
+      defaulted: ${{ steps.route.outputs.defaulted }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Stash the agent hooks
+        run: |
+          mkdir -p "$RUNNER_TEMP/agent-bin"
+          cp packages/claude-team/hooks/*.sh "$RUNNER_TEMP/agent-bin/"
+          chmod +x "$RUNNER_TEMP/agent-bin"/*.sh
+      # First real step of every run: the 👀 lands before anything has thought about it.
+      - name: Acknowledge the trigger
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          # ⚠️ issue_comment only. A review comment's id belongs to the *pulls* comments
+          # collection, and acknowledge.sh reacts via `issues/comments/<id>` — passing one
+          # here reacts to an unrelated comment or 404s. Empty falls back to the PR itself,
+          # which is an issue as far as the reactions API is concerned.
+          COMMENT_ID: ${{ github.event_name == 'issue_comment' && github.event.comment.id || '' }}
+        run: "$RUNNER_TEMP/agent-bin/acknowledge.sh"
+      - id: route
+        name: Pick the role
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          # empty on a label trigger — that is what sends delegate.sh past rule 1 into
+          # reading issue state, which is the whole point of the label path
+          COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
+          # `issues` never fires for a PR (labelling one is a `pull_request` event), so the
+          # only PR path in is a comment or review.
+          IS_PR: ${{ (github.event.issue.pull_request || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review') && 'true' || 'false' }}
+        run: "$RUNNER_TEMP/agent-bin/delegate.sh"
+
   # ── Architect ────────────────────────────────────────────────────────────────
   # Shapes work so the others can act on it. On an epic it defines the goal and cuts
   # stories; on a story it researches, rewrites the issue, cuts the branch and creates
@@ -99,11 +184,15 @@ jobs:
   # cold starts that each re-read the same issue.
   # ⚠️ It stops at task creation. It never hands to an author, and never opens a PR.
   architect:
+    needs: delegate
+    # ⚠️ The `!github.event.issue.pull_request` guard rides the handle arm only. The router
+    # can never pick architect on a PR (rule 2 sends every PR to implementor), but a handle
+    # typed into a PR comment would otherwise start a role written for an epic issue.
     if: |
-      github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]'
-      && github.event_name == 'issue_comment'
-      && !github.event.issue.pull_request
-      && contains(github.event.comment.body, '@claude/architect')
+      always() && needs.delegate.result != 'skipped' && (
+        contains(needs.delegate.outputs.roles, 'architect')
+        || (!github.event.issue.pull_request && contains(github.event.comment.body, '@claude/architect'))
+      )
     runs-on: ubuntu-latest
     permissions:
       # write purely to push the epic's (empty) integration branch — the prompt
@@ -140,11 +229,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # ⚠️ track_progress forces the action's TAG MODE, which gates on this phrase
-          # independently of our own `if:`. Leave it at the default "@claude" and the
-          # action skips in 0s with a placeholder comment, because "@claude/architect"
-          # is not a match for "@claude".
-          trigger_phrase: "@claude/architect"
+          # ⚠️ track_progress forces the action's TAG MODE. That mode re-checks the
+          # trigger phrase independently of our `if:` — but checkContainsTrigger() returns
+          # early on `if (prompt) return true`, and we always pass a prompt, so the phrase
+          # is inert at v1 (verified at v1.0.183). It is "@claude" rather than
+          # "@claude/architect" because a LABEL trigger carries no comment for a per-role
+          # phrase to match: if that short-circuit ever goes away, "@claude" still matches
+          # the comment path and a per-role phrase would fail every role at once.
+          trigger_phrase: "@claude"
           track_progress: true
           prompt: ${{ steps.prompt.outputs.body }}
           # Read-and-write-issues only; no build tools needed for shaping an epic.
@@ -154,7 +246,14 @@ jobs:
             --max-turns 100
 
       - name: File the story's sub-issues
-        if: always() && github.event_name == 'issue_comment' && !github.event.issue.pull_request
+        # ⚠️ `issues` must be here as well as `issue_comment`. The label is now the primary
+        # way an Architect run starts, and keyed to comments alone this hook — the thing that
+        # parents the tasks it just created — never fired on the path that will be used most.
+        if: |
+          always() && (
+            github.event_name == 'issues'
+            || (github.event_name == 'issue_comment' && !github.event.issue.pull_request)
+          )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -166,13 +265,12 @@ jobs:
   # on a PR, the description + current comments) for context before touching code.
   # Deliverable is code + a PR against mainline. The only role that answers @claude.
   implementor:
-    # Per-event trigger check. The actor guard stops a self-trigger loop: track_progress
-    # posts as github-actions[bot], and a comment quoting "@claude" would re-enter here.
+    needs: delegate
     if: |
-      github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude/implementor')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude/implementor')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/implementor'))
+      always() && needs.delegate.result != 'skipped' && (
+        contains(needs.delegate.outputs.roles, 'implementor')
+        || contains(github.event.comment.body, '@claude/implementor')
+        || contains(github.event.review.body, '@claude/implementor')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -228,11 +326,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # ⚠️ track_progress forces the action's TAG MODE, which gates on this phrase
-          # independently of our own `if:`. Leave it at the default "@claude" and the
-          # action skips in 0s with a placeholder comment, because "@claude/implementor"
-          # is not a match for "@claude".
-          trigger_phrase: "@claude/implementor"
+          # ⚠️ track_progress forces the action's TAG MODE. That mode re-checks the
+          # trigger phrase independently of our `if:` — but checkContainsTrigger() returns
+          # early on `if (prompt) return true`, and we always pass a prompt, so the phrase
+          # is inert at v1 (verified at v1.0.183). It is "@claude" rather than
+          # "@claude/implementor" because a LABEL trigger carries no comment for a per-role
+          # phrase to match: if that short-circuit ever goes away, "@claude" still matches
+          # the comment path and a per-role phrase would fail every role at once.
+          trigger_phrase: "@claude"
           track_progress: true
           prompt: ${{ steps.prompt.outputs.body }}
           # Allowlist by *family*, not per-subcommand. Deliberately NOT bare `Bash`: this
@@ -270,11 +371,12 @@ jobs:
   # fire-and-forget call while lint/tsc/build stay green) is only caught by a test written
   # to distrust the change.
   tester:
+    needs: delegate
     if: |
-      github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude/tester')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude/tester')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/tester'))
+      always() && needs.delegate.result != 'skipped' && (
+        contains(needs.delegate.outputs.roles, 'tester')
+        || contains(github.event.comment.body, '@claude/tester')
+        || contains(github.event.review.body, '@claude/tester')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -328,11 +430,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # ⚠️ track_progress forces the action's TAG MODE, which gates on this phrase
-          # independently of our own `if:`. Leave it at the default "@claude" and the
-          # action skips in 0s with a placeholder comment, because "@claude/tester"
-          # is not a match for "@claude".
-          trigger_phrase: "@claude/tester"
+          # ⚠️ track_progress forces the action's TAG MODE. That mode re-checks the
+          # trigger phrase independently of our `if:` — but checkContainsTrigger() returns
+          # early on `if (prompt) return true`, and we always pass a prompt, so the phrase
+          # is inert at v1 (verified at v1.0.183). It is "@claude" rather than
+          # "@claude/tester" because a LABEL trigger carries no comment for a per-role
+          # phrase to match: if that short-circuit ever goes away, "@claude" still matches
+          # the comment path and a per-role phrase would fail every role at once.
+          trigger_phrase: "@claude"
           track_progress: true
           prompt: ${{ steps.prompt.outputs.body }}
           claude_args: |
@@ -366,11 +471,12 @@ jobs:
   # neither of them was really working on. Implementor and Tester now report what needs
   # documenting in their handoff and change no docs themselves.
   writer:
+    needs: delegate
     if: |
-      github.actor != 'claude[bot]' && github.actor != 'github-actions[bot]' && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude/writer')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude/writer')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude/writer'))
+      always() && needs.delegate.result != 'skipped' && (
+        contains(needs.delegate.outputs.roles, 'writer')
+        || contains(github.event.comment.body, '@claude/writer')
+        || contains(github.event.review.body, '@claude/writer')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -404,7 +510,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
-          trigger_phrase: "@claude/writer"
+          # ⚠️ track_progress forces the action's TAG MODE. That mode re-checks the
+          # trigger phrase independently of our `if:` — but checkContainsTrigger() returns
+          # early on `if (prompt) return true`, and we always pass a prompt, so the phrase
+          # is inert at v1 (verified at v1.0.183). It is "@claude" rather than
+          # "@claude/writer" because a LABEL trigger carries no comment for a per-role
+          # phrase to match: if that short-circuit ever goes away, "@claude" still matches
+          # the comment path and a per-role phrase would fail every role at once.
+          trigger_phrase: "@claude"
           prompt: ${{ steps.prompt.outputs.body }}
           claude_args: |
             --model sonnet

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -20,18 +20,19 @@ run-name: >-
   · #${{ github.event.issue.number || github.event.pull_request.number }}
   ${{ github.event.issue.title || github.event.pull_request.title }}
 
-# ONE WORKFLOW, FIVE JOBS, SIX ROLES. Kept in one file so the Actions history stays
+# ONE WORKFLOW, FIVE JOBS, SEVEN ROLES. Kept in one file so the Actions history stays
 # readable: one run per trigger, with whatever was not selected skipping inside it rather
 # than filling the list with skipped runs.
 #
 #   delegate            routes — no model
 #   architect           shapes work and cuts tasks
-#   authors             Implementor -> Tester -> Writer, as sequential STEPS in one job
+#   authors             Implementor|Designer -> Tester -> Writer, sequential STEPS in one job
 #   security            on merge, not on a trigger
 #   merge_housekeeping  on merge — no model
 #
-# The three authoring roles share a job so one `@claude` runs the whole chain. See that
-# job's header for why they are steps and not `needs:`.
+# The authoring roles share a job so one `@claude` runs the whole chain. Implementor and
+# Designer are alternatives — a task is one or the other, split on the package it touches.
+# See that job's header for why they are steps and not `needs:`.
 #
 # ⚠️ THE DELEGATOR ROUTES. Two ways in, one router:
 #
@@ -273,9 +274,10 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
         run: "$RUNNER_TEMP/agent-bin/file-sub-issues.sh"
-  # ── Authors: Implementor → Tester → Writer ─────────────────────────────────────
-  # The three authoring roles as sequential STEPS in one job, so a single `@claude` on a
-  # task runs all three with no further input from the maintainer.
+  # ── Authors: Implementor | Designer → Tester → Writer ──────────────────────────
+  # The authoring roles as sequential STEPS in one job, so a single `@claude` on a task
+  # runs the whole chain with no further input from the maintainer. Implementor and Designer
+  # are alternatives — a task is one or the other, split on the package it touches.
   #
   # ⚠️ STEPS, NOT `needs:`. #430 reverted role chaining because `needs:` ACROSS JOBS left
   # the followers queued behind every run, and a job that skips after waiting reports as
@@ -284,10 +286,11 @@ jobs:
   # failed. (The one `needs:` in this file, on `delegate`, is a different case — see the
   # header.)
   #
-  # ⚠️ BUDGET. Three model runs back to back: opus at 80 turns, then sonnet at 80, then
-  # sonnet at 60 — 220 turns on one runner, plus `npm ci` and a browser install. By a wide
-  # margin the longest job here. A single-role run is unaffected: the other two model steps
-  # skip and their setup skips with them.
+  # ⚠️ BUDGET. Three model runs back to back — an author at opus 80 turns, then sonnet 80,
+  # then sonnet 60: 220 turns on one runner, plus `npm ci` and a browser install. By a wide
+  # margin the longest job here. Implementor and Designer never both run, so 220 is the
+  # ceiling, not 300. A single-role run is unaffected: the other model steps skip and their
+  # setup skips with them.
   #
   # ⚠️ EACH ROLE GETS ITS OWN TRACKING COMMENT, because `use_sticky_comment` is not set —
   # the action reuses a comment only when it is. That is what keeps the Implementor's
@@ -305,12 +308,15 @@ jobs:
     if: |
       always() && needs.delegate.result != 'skipped' && (
         contains(needs.delegate.outputs.roles, 'implementor')
+        || contains(needs.delegate.outputs.roles, 'designer')
         || contains(needs.delegate.outputs.roles, 'tester')
         || contains(needs.delegate.outputs.roles, 'writer')
         || contains(github.event.comment.body, '@claude/implementor')
+        || contains(github.event.comment.body, '@claude/designer')
         || contains(github.event.comment.body, '@claude/tester')
         || contains(github.event.comment.body, '@claude/writer')
         || contains(github.event.review.body, '@claude/implementor')
+        || contains(github.event.review.body, '@claude/designer')
         || contains(github.event.review.body, '@claude/tester')
         || contains(github.event.review.body, '@claude/writer')
       )
@@ -334,6 +340,10 @@ jobs:
         uses: ./.github/actions/load-prompt
         with:
           role: implementor
+      - id: p_designer
+        uses: ./.github/actions/load-prompt
+        with:
+          role: designer
       - id: p_tester
         uses: ./.github/actions/load-prompt
         with:
@@ -379,7 +389,7 @@ jobs:
           COMMENT: ${{ github.event.comment.body || github.event.review.body }}
         run: |
           list=""
-          for r in implementor tester writer; do
+          for r in implementor designer tester writer; do
             case " $ROUTED " in
               *"$r"*) list="$list $r"; continue ;;
             esac
@@ -394,12 +404,12 @@ jobs:
       # without it `tsc` resolves to the runner image's global TypeScript (a different
       # major) and fails on config this repo pins as valid. The Writer builds nothing, so a
       # Writer-only run skips all of it.
-      - if: contains(steps.roles.outputs.list, 'implementor') || contains(steps.roles.outputs.list, 'tester')
+      - if: contains(steps.roles.outputs.list, 'implementor') || contains(steps.roles.outputs.list, 'designer') || contains(steps.roles.outputs.list, 'tester')
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
-      - if: contains(steps.roles.outputs.list, 'implementor') || contains(steps.roles.outputs.list, 'tester')
+      - if: contains(steps.roles.outputs.list, 'implementor') || contains(steps.roles.outputs.list, 'designer') || contains(steps.roles.outputs.list, 'tester')
         run: npm ci
       # Browser install as a workflow step, not a Claude turn. Without it the Tester can
       # write specs but never run them, and an unrun test is worse than no test.
@@ -407,7 +417,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Move the issue to In Progress
-        if: contains(steps.roles.outputs.list, 'implementor') || contains(steps.roles.outputs.list, 'tester')
+        if: contains(steps.roles.outputs.list, 'implementor') || contains(steps.roles.outputs.list, 'designer') || contains(steps.roles.outputs.list, 'tester')
         env:
           # ⚠️ PROJECTS_TOKEN is safe here and only here: step env is per-step, so the model
           # steps below cannot read it. See the Owner post-mortem in CLAUDE.md.
@@ -458,6 +468,44 @@ jobs:
             --max-turns 80
             --json-schema '${{ steps.schema.outputs.body }}'
 
+      # ── Designer ──
+      # The Implementor of the design system. Same shape — branch, PR, gate, handoff — with
+      # the design package as its subject instead of the code that consumes it.
+      #
+      # ⚠️ The boundary is the PACKAGE, not a judgement call, so it can be checked rather
+      # than negotiated. A task that changes a primitive *and* its call sites is two tasks,
+      # and the Architect cuts it in two; the prompt tells the Designer to say so and stop
+      # rather than reach across.
+      #
+      # ⚠️ Implementor and Designer are alternatives, not a sequence — a task is one or the
+      # other. Both emit the same handoff schema, so whichever ran feeds the Tester and
+      # Writer below.
+      - name: Stamp the Designer label
+        if: contains(steps.roles.outputs.list, 'designer')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLE: designer
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: "$RUNNER_TEMP/agent-bin/stamp-role-label.sh"
+      - name: Designer
+        id: designer
+        if: contains(steps.roles.outputs.list, 'designer')
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STORY: ${{ needs.delegate.outputs.story }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          trigger_phrase: "@claude"
+          track_progress: true
+          prompt: ${{ steps.p_designer.outputs.body }}
+          claude_args: |
+            --model opus
+            --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*)"
+            --max-turns 80
+            --json-schema '${{ steps.schema.outputs.body }}'
+
       # ── Tester ──
       # Owns packages/e2e. The Implementor ships behaviour and reports Testing notes; the
       # Tester turns those into Playwright specs. Split because the two pull in opposite
@@ -483,17 +531,19 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
           track_progress: true
-          # ⚠️ The handoff arrives as prompt CONTEXT, not as something to go and find. It is
-          # empty when the Implementor did not run in this job (a Tester-only trigger) or
-          # when its step failed — which is exactly why `testingNotes: []` and an absent
-          # block have to read differently. The prompt says how to tell them apart.
+          # ⚠️ The handoff arrives as prompt CONTEXT, not as something to go and find.
+          # Implementor OR Designer, whichever authored — they are alternatives and emit the
+          # same schema, so `||` takes the one that ran (an unrun step's output is empty,
+          # which is falsy). Empty when neither ran (a Tester-only trigger) or when the
+          # author's step failed — exactly why `testingNotes: []` and an absent block have
+          # to read differently. The prompt says how to tell them apart.
           prompt: |
             ${{ steps.p_tester.outputs.body }}
 
             ## Handoff from the Implementor
 
             ```json
-            ${{ steps.implementor.outputs.structured_output }}
+            ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output }}
             ```
           claude_args: |
             --model sonnet
@@ -526,7 +576,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
           track_progress: true
-          # The Writer sees the Implementor's candidates directly. ⚠️ Still a proposal, not
+          # The Writer sees the author's candidates directly — Implementor or Designer,
+          # whichever ran. ⚠️ Still a proposal, not
           # an order — a schema must not imply obligation, and rejecting every candidate
           # stays a correct outcome. writer.md carries that.
           prompt: |
@@ -535,7 +586,7 @@ jobs:
             ## Handoff from the Implementor
 
             ```json
-            ${{ steps.implementor.outputs.structured_output }}
+            ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output }}
             ```
           claude_args: |
             --model sonnet

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -20,10 +20,18 @@ run-name: >-
   · #${{ github.event.issue.number || github.event.pull_request.number }}
   ${{ github.event.issue.title || github.event.pull_request.title }}
 
-# FIVE ROLES, ONE WORKFLOW. Architect / Implementor / Tester / Writer are jobs
-# here rather than separate files to keep the Actions history readable: the role is picked
-# by a job-level `if:`, so it is one run per comment with the unselected roles skipping
-# inside it. Security is the sixth and runs on merge, not on a comment.
+# ONE WORKFLOW, FIVE JOBS, SIX ROLES. Kept in one file so the Actions history stays
+# readable: one run per trigger, with whatever was not selected skipping inside it rather
+# than filling the list with skipped runs.
+#
+#   delegate            routes — no model
+#   architect           shapes work and cuts tasks
+#   authors             Implementor -> Tester -> Writer, as sequential STEPS in one job
+#   security            on merge, not on a trigger
+#   merge_housekeeping  on merge — no model
+#
+# The three authoring roles share a job so one `@claude` runs the whole chain. See that
+# job's header for why they are steps and not `needs:`.
 #
 # ⚠️ THE DELEGATOR ROUTES. Two ways in, one router:
 #
@@ -60,11 +68,16 @@ run-name: >-
 #   delegate job          acknowledge.sh           reacts 👀 so the trigger is visibly received
 #   delegate job          delegate.sh              picks the role(s) from issue state
 #   pre   every role      stamp-role-label.sh      stamps @claude/<role> on the issue or PR
-#   pre   impl + tester   set-issue-status.sh      sets the issue's board Status (STATUS input)
+#   pre   authors job     set-issue-status.sh      sets the issue's board Status (STATUS input)
 #   post  architect       file-sub-issues.sh       parents stories to epics, tasks to stories
-#   post  impl/test/write finish-pr.sh             labels the PR, appends `Closes #<issue>`
-#   post  impl/test/write open-story-pr.sh         opens the story's PR if it has none
+#   post  authors job     finish-pr.sh             labels the PR, appends `Closes #<issue>`
+#   post  authors job     open-story-pr.sh         opens the story's PR if it has none
 #   merge (no role)       close-merged-work.sh     closes the PR's issues, files them on the board
+#
+# ⚠️ The authors job's post-hooks run ONCE at the end of the job, not once per role — three
+# copies would relabel and re-check the same PR three times. The stamps are the exception:
+# each role stamps before its own model step, so a chain that dies partway reads as how far
+# it actually got.
 #
 # These used to be prompt instructions, and a model could skip them — the label trail is
 # worthless if a run can forget to stamp it. They cost no turns and cannot be forgotten.
@@ -259,18 +272,46 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
         run: "$RUNNER_TEMP/agent-bin/file-sub-issues.sh"
-  # ── Implementor ────────────────────────────────────────────────────────────────
-  # The main engineer. Executes issues and handles follow-up engineering (bug fixes,
-  # requested changes, merge-conflict resolution). Reads the issue + its comments (and,
-  # on a PR, the description + current comments) for context before touching code.
-  # Deliverable is code + a PR against mainline. The only role that answers @claude.
-  implementor:
+  # ── Authors: Implementor → Tester → Writer ─────────────────────────────────────
+  # The three authoring roles as sequential STEPS in one job, so a single `@claude` on a
+  # task runs all three with no further input from the maintainer.
+  #
+  # ⚠️ STEPS, NOT `needs:`. #430 reverted role chaining because `needs:` ACROSS JOBS left
+  # the followers queued behind every run, and a job that skips after waiting reports as
+  # cancelled — the history filled with cancelled entries. Sequential steps have no job
+  # graph, so none of that applies. Do not reach for `needs:` here; that is the shape that
+  # failed. (The one `needs:` in this file, on `delegate`, is a different case — see the
+  # header.)
+  #
+  # ⚠️ BUDGET. Three model runs back to back: opus at 80 turns, then sonnet at 80, then
+  # sonnet at 60 — 220 turns on one runner, plus `npm ci` and a browser install. By a wide
+  # margin the longest job here. A single-role run is unaffected: the other two model steps
+  # skip and their setup skips with them.
+  #
+  # ⚠️ EACH ROLE GETS ITS OWN TRACKING COMMENT, because `use_sticky_comment` is not set —
+  # the action reuses a comment only when it is. That is what keeps the Implementor's
+  # handoff readable after the Tester and Writer have run; sticky would overwrite it with
+  # the next role's and destroy the thing the chain exists to pass along.
+  #
+  # ⚠️ EACH ROLE STAMPS ITS LABEL BEFORE ITS OWN MODEL STEP, not all three up front. A run
+  # that dies in the Tester should read as "implementor and tester were here", not as a
+  # Writer that never started.
+  #
+  # ⚠️ THE POST-HOOKS RUN ONCE, AT THE END. Three copies would relabel and re-check the
+  # same PR three times.
+  authors:
     needs: delegate
     if: |
       always() && needs.delegate.result != 'skipped' && (
         contains(needs.delegate.outputs.roles, 'implementor')
+        || contains(needs.delegate.outputs.roles, 'tester')
+        || contains(needs.delegate.outputs.roles, 'writer')
         || contains(github.event.comment.body, '@claude/implementor')
+        || contains(github.event.comment.body, '@claude/tester')
+        || contains(github.event.comment.body, '@claude/writer')
         || contains(github.event.review.body, '@claude/implementor')
+        || contains(github.event.review.body, '@claude/tester')
+        || contains(github.event.review.body, '@claude/writer')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -285,220 +326,18 @@ jobs:
         with:
           # full history so it can branch from and diff against mainline
           fetch-depth: 0
-      - id: prompt
+      # All three prompts load up front, while the tree is still the default branch — the
+      # same reason the hooks are stashed. A model step checks out a feature branch, and by
+      # the Writer's turn the tree is whatever the Implementor left.
+      - id: p_implementor
         uses: ./.github/actions/load-prompt
         with:
           role: implementor
-      - name: Stash the agent hooks
-        run: |
-          mkdir -p "$RUNNER_TEMP/agent-bin"
-          cp packages/claude-team/hooks/*.sh "$RUNNER_TEMP/agent-bin/"
-          chmod +x "$RUNNER_TEMP/agent-bin"/*.sh
-      # Install as workflow steps, not from inside the run: this costs Claude zero turns,
-      # and without it `tsc` resolves to the runner image's global TypeScript (a different
-      # major) and fails on config this repo pins as valid.
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-      - run: npm ci
-      - name: Stamp the role label
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ROLE: implementor
-          REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
-        run: "$RUNNER_TEMP/agent-bin/stamp-role-label.sh"
-      - name: Move the issue to In Progress
-        env:
-          # ⚠️ PROJECTS_TOKEN is safe here and only here: step env is per-step, so the
-          # model step below cannot read it. See the Owner post-mortem in CLAUDE.md.
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
-          REPO: ${{ github.repository }}
-          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
-          PROJECT_OWNER: "@me"
-          PROJECT_NUMBER: "4"
-          STATUS: "In Progress"
-        run: "$RUNNER_TEMP/agent-bin/set-issue-status.sh"
-      - uses: anthropics/claude-code-action@v1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the story this run belongs to, resolved by the delegator from the PR's head
-          # branch. Same pattern as Security's PR: a prompt file can't hold `${{ }}`, so
-          # anything dynamic arrives as env and the model's own shell expands it. Empty when
-          # the trigger resolves to no story — the prompt says to carry on without it.
-          STORY: ${{ needs.delegate.outputs.story }}
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # ⚠️ track_progress forces the action's TAG MODE. That mode re-checks the
-          # trigger phrase independently of our `if:` — but checkContainsTrigger() returns
-          # early on `if (prompt) return true`, and we always pass a prompt, so the phrase
-          # is inert at v1 (verified at v1.0.183). It is "@claude" rather than
-          # "@claude/implementor" because a LABEL trigger carries no comment for a per-role
-          # phrase to match: if that short-circuit ever goes away, "@claude" still matches
-          # the comment path and a per-role phrase would fail every role at once.
-          trigger_phrase: "@claude"
-          track_progress: true
-          prompt: ${{ steps.prompt.outputs.body }}
-          # Allowlist by *family*, not per-subcommand. Deliberately NOT bare `Bash`: this
-          # runner carries GH_TOKEN and the Claude OAuth token in env, and arbitrary shell
-          # could exfiltrate them. Only write-access actors can trigger a run (see the `if:`
-          # actor gate). 80-turn budget: each run is a cold container that re-orients before
-          # making the change — the prompt's read-for-context note is the real cost control.
-          claude_args: |
-            --model opus
-            --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*)"
-            --max-turns 80
-
-      - name: Label and link the PR
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ROLE: implementor
-          REPO: ${{ github.repository }}
-          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
-        run: "$RUNNER_TEMP/agent-bin/finish-pr.sh"
-      - name: Open the story PR
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ROLE: implementor
-          REPO: ${{ github.repository }}
-          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
-        run: "$RUNNER_TEMP/agent-bin/open-story-pr.sh"
-
-  # ── Tester ─────────────────────────────────────────────────────────────────────
-  # Owns packages/e2e. The Implementor ships behaviour and writes Testing notes into its
-  # PR Handoff; the Tester turns those notes into Playwright specs. Split out because the
-  # two jobs pull in opposite directions — an engineer finishing a feature writes the test
-  # that passes, and the failure mode this repo actually has (a save that throws inside a
-  # fire-and-forget call while lint/tsc/build stay green) is only caught by a test written
-  # to distrust the change.
-  tester:
-    needs: delegate
-    if: |
-      always() && needs.delegate.result != 'skipped' && (
-        contains(needs.delegate.outputs.roles, 'tester')
-        || contains(github.event.comment.body, '@claude/tester')
-        || contains(github.event.review.body, '@claude/tester')
-      )
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - id: prompt
+      - id: p_tester
         uses: ./.github/actions/load-prompt
         with:
           role: tester
-      - name: Stash the agent hooks
-        run: |
-          mkdir -p "$RUNNER_TEMP/agent-bin"
-          cp packages/claude-team/hooks/*.sh "$RUNNER_TEMP/agent-bin/"
-          chmod +x "$RUNNER_TEMP/agent-bin"/*.sh
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-      - run: npm ci
-      # Browser install as a workflow step, not a Claude turn. Without it the Tester can
-      # write specs but never run them, and an unrun test is worse than no test.
-      - run: npx playwright install --with-deps chromium
-      - name: Stamp the role label
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ROLE: tester
-          REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
-        run: "$RUNNER_TEMP/agent-bin/stamp-role-label.sh"
-      - name: Move the issue to In Progress
-        env:
-          # ⚠️ PROJECTS_TOKEN is safe here and only here: step env is per-step, so the
-          # model step below cannot read it. See the Owner post-mortem in CLAUDE.md.
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
-          REPO: ${{ github.repository }}
-          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
-          PROJECT_OWNER: "@me"
-          PROJECT_NUMBER: "4"
-          STATUS: "In Progress"
-        run: "$RUNNER_TEMP/agent-bin/set-issue-status.sh"
-      - uses: anthropics/claude-code-action@v1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the story this run belongs to, resolved by the delegator from the PR's head
-          # branch. Same pattern as Security's PR: a prompt file can't hold `${{ }}`, so
-          # anything dynamic arrives as env and the model's own shell expands it. Empty when
-          # the trigger resolves to no story — the prompt says to carry on without it.
-          STORY: ${{ needs.delegate.outputs.story }}
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # ⚠️ track_progress forces the action's TAG MODE. That mode re-checks the
-          # trigger phrase independently of our `if:` — but checkContainsTrigger() returns
-          # early on `if (prompt) return true`, and we always pass a prompt, so the phrase
-          # is inert at v1 (verified at v1.0.183). It is "@claude" rather than
-          # "@claude/tester" because a LABEL trigger carries no comment for a per-role
-          # phrase to match: if that short-circuit ever goes away, "@claude" still matches
-          # the comment path and a per-role phrase would fail every role at once.
-          trigger_phrase: "@claude"
-          track_progress: true
-          prompt: ${{ steps.prompt.outputs.body }}
-          claude_args: |
-            --model sonnet
-            --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
-            --max-turns 80
-
-      - name: Label and link the PR
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ROLE: tester
-          REPO: ${{ github.repository }}
-          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
-        run: "$RUNNER_TEMP/agent-bin/finish-pr.sh"
-      - name: Open the story PR
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ROLE: tester
-          REPO: ${{ github.repository }}
-          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
-        run: "$RUNNER_TEMP/agent-bin/open-story-pr.sh"
-
-  # ── Writer ─────────────────────────────────────────────────────────────────────
-  # The tech writer. Owns documentation: every CLAUDE.md, the agent instruction files
-  # under .claude/skills, and anything else whose job is to explain rather than run.
-  #
-  # ⚠️ Split out because CLAUDE.md was the single biggest source of merge conflicts —
-  # every role edited it, so two branches touching the same package collided on prose
-  # neither of them was really working on. Implementor and Tester now report what needs
-  # documenting in their handoff and change no docs themselves.
-  writer:
-    needs: delegate
-    if: |
-      always() && needs.delegate.result != 'skipped' && (
-        contains(needs.delegate.outputs.roles, 'writer')
-        || contains(github.event.comment.body, '@claude/writer')
-        || contains(github.event.review.body, '@claude/writer')
-      )
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - id: prompt
+      - id: p_writer
         uses: ./.github/actions/load-prompt
         with:
           role: writer
@@ -507,43 +346,163 @@ jobs:
           mkdir -p "$RUNNER_TEMP/agent-bin"
           cp packages/claude-team/hooks/*.sh "$RUNNER_TEMP/agent-bin/"
           chmod +x "$RUNNER_TEMP/agent-bin"/*.sh
-      - name: Stamp the role label
+
+      # Resolved once, read by every gate below — otherwise the same condition appears
+      # nine times and drifts.
+      # ⚠️ The comment body arrives as ENV and is never interpolated into the script. A
+      # `${{ }}` holding attacker-controllable text inside a `run:` block is a shell
+      # injection hole; `$COMMENT` in a `case` pattern is inert.
+      - id: roles
+        name: Resolve the roles for this run
+        env:
+          ROUTED: ${{ needs.delegate.outputs.roles }}
+          COMMENT: ${{ github.event.comment.body || github.event.review.body }}
+        run: |
+          list=""
+          for r in implementor tester writer; do
+            case " $ROUTED " in
+              *"$r"*) list="$list $r"; continue ;;
+            esac
+            case "$COMMENT" in
+              *"@claude/$r"*) list="$list $r" ;;
+            esac
+          done
+          echo "list=$list" >> "$GITHUB_OUTPUT"
+          echo "roles for this run:${list:- none}"
+
+      # Install as workflow steps, not from inside a run: this costs Claude zero turns, and
+      # without it `tsc` resolves to the runner image's global TypeScript (a different
+      # major) and fails on config this repo pins as valid. The Writer builds nothing, so a
+      # Writer-only run skips all of it.
+      - if: contains(steps.roles.outputs.list, 'implementor') || contains(steps.roles.outputs.list, 'tester')
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - if: contains(steps.roles.outputs.list, 'implementor') || contains(steps.roles.outputs.list, 'tester')
+        run: npm ci
+      # Browser install as a workflow step, not a Claude turn. Without it the Tester can
+      # write specs but never run them, and an unrun test is worse than no test.
+      - if: contains(steps.roles.outputs.list, 'tester')
+        run: npx playwright install --with-deps chromium
+
+      - name: Move the issue to In Progress
+        if: contains(steps.roles.outputs.list, 'implementor') || contains(steps.roles.outputs.list, 'tester')
+        env:
+          # ⚠️ PROJECTS_TOKEN is safe here and only here: step env is per-step, so the model
+          # steps below cannot read it. See the Owner post-mortem in CLAUDE.md.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          PROJECT_OWNER: "@me"
+          PROJECT_NUMBER: "4"
+          STATUS: "In Progress"
+        run: "$RUNNER_TEMP/agent-bin/set-issue-status.sh"
+
+      # ── Implementor ──
+      # The main engineer. Executes issues and handles follow-up engineering (bug fixes,
+      # requested changes, merge-conflict resolution). Reads the issue + its comments (and,
+      # on a PR, the description + current comments) for context before touching code.
+      # Deliverable is code + a PR against mainline.
+      - name: Stamp the Implementor label
+        if: contains(steps.roles.outputs.list, 'implementor')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLE: implementor
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: "$RUNNER_TEMP/agent-bin/stamp-role-label.sh"
+      - name: Implementor
+        if: contains(steps.roles.outputs.list, 'implementor')
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STORY: ${{ needs.delegate.outputs.story }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          trigger_phrase: "@claude"
+          track_progress: true
+          prompt: ${{ steps.p_implementor.outputs.body }}
+          # Allowlist by *family*, not per-subcommand. Deliberately NOT bare `Bash`: this
+          # runner carries GH_TOKEN and the Claude OAuth token in env, and arbitrary shell
+          # could exfiltrate them. Only write-access actors can trigger a run.
+          claude_args: |
+            --model opus
+            --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*)"
+            --max-turns 80
+
+      # ── Tester ──
+      # Owns packages/e2e. The Implementor ships behaviour and reports Testing notes; the
+      # Tester turns those into Playwright specs. Split because the two pull in opposite
+      # directions — an engineer finishing a feature writes the test that passes, and the
+      # failure mode this repo actually has (a save that throws inside a fire-and-forget
+      # call while lint/tsc/build stay green) is only caught by a test written to distrust
+      # the change.
+      - name: Stamp the Tester label
+        if: contains(steps.roles.outputs.list, 'tester')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROLE: tester
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: "$RUNNER_TEMP/agent-bin/stamp-role-label.sh"
+      - name: Tester
+        if: contains(steps.roles.outputs.list, 'tester')
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STORY: ${{ needs.delegate.outputs.story }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          trigger_phrase: "@claude"
+          track_progress: true
+          prompt: ${{ steps.p_tester.outputs.body }}
+          claude_args: |
+            --model sonnet
+            --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
+            --max-turns 80
+
+      # ── Writer ──
+      # The tech writer. Owns documentation: every CLAUDE.md, the agent instruction files
+      # under .claude/skills, and anything else whose job is to explain rather than run.
+      #
+      # ⚠️ Split out because CLAUDE.md was the single biggest source of merge conflicts —
+      # every role edited it, so two branches touching the same package collided on prose
+      # neither was really working on. Implementor and Tester report what needs documenting
+      # and change no docs themselves.
+      - name: Stamp the Writer label
+        if: contains(steps.roles.outputs.list, 'writer')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ROLE: writer
           REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: "$RUNNER_TEMP/agent-bin/stamp-role-label.sh"
-      - uses: anthropics/claude-code-action@v1
+      - name: Writer
+        if: contains(steps.roles.outputs.list, 'writer')
+        uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the story this run belongs to, resolved by the delegator from the PR's head
-          # branch. Same pattern as Security's PR: a prompt file can't hold `${{ }}`, so
-          # anything dynamic arrives as env and the model's own shell expands it. Empty when
-          # the trigger resolves to no story — the prompt says to carry on without it.
           STORY: ${{ needs.delegate.outputs.story }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true
-          # ⚠️ track_progress forces the action's TAG MODE. That mode re-checks the
-          # trigger phrase independently of our `if:` — but checkContainsTrigger() returns
-          # early on `if (prompt) return true`, and we always pass a prompt, so the phrase
-          # is inert at v1 (verified at v1.0.183). It is "@claude" rather than
-          # "@claude/writer" because a LABEL trigger carries no comment for a per-role
-          # phrase to match: if that short-circuit ever goes away, "@claude" still matches
-          # the comment path and a per-role phrase would fail every role at once.
           trigger_phrase: "@claude"
-          prompt: ${{ steps.prompt.outputs.body }}
+          track_progress: true
+          prompt: ${{ steps.p_writer.outputs.body }}
           claude_args: |
             --model sonnet
             --allowedTools "Read,Edit,Write,Bash(git:*),Bash(gh:*)"
             --max-turns 60
 
+      # ── Once, for the job ──
       - name: Label and link the PR
-        if: always()
+        if: always() && steps.roles.outputs.list != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ROLE: writer
+          # every role that ran, so the PR carries the whole trail rather than whichever
+          # one happened to be last
+          ROLES: ${{ steps.roles.outputs.list }}
           REPO: ${{ github.repository }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         run: "$RUNNER_TEMP/agent-bin/finish-pr.sh"
@@ -551,7 +510,6 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ROLE: writer
           REPO: ${{ github.repository }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         run: "$RUNNER_TEMP/agent-bin/open-story-pr.sh"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,14 @@ inspection (rule 1) — still the way to override a bad guess.
 
 - `@claude/architect` — epic or story. Shapes the issue, cuts a story's branch, and creates
   its tasks — each stamped with the role that should pick it up.
-- `@claude/implementor` — issue or PR. Writes the code and opens the PR.
+- `@claude/implementor` — issue or PR. Writes the code and opens the PR. Owns the
+  *consumers* of the design system (`packages/app`, `packages/www`), not the system itself.
+- `@claude/designer` — issue or PR. An Implementor whose subject is `packages/design`: the
+  primitives, their props and class strings, the stories and the tokens.
+  ⚠️ The split is by **package**, not by judgement, so it can be checked rather than
+  negotiated. A task that changes a primitive *and* its call sites is two tasks — the
+  Architect cuts it in two, and the Designer's prompt says to report and stop rather than
+  reach across. Implementor and Designer never both run for one task.
 - `@claude/tester` — issue or PR. Owns `packages/e2e`.
 - `@claude/writer` — issue or PR. Owns every `CLAUDE.md` and `.claude/skills/`.
 - **Security** — no handle. Runs on merge to `mainline` and files issues, labelled

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,22 @@ model step.
   its role, and appends `Closes #<issue>` if the model didn't write one.
 - `open-story-pr.sh` — post, every authoring role. Opens the story's PR when its branch has
   none and has commits. Reads the branch from the issue's **Branch** line.
+- `log-to-epic.sh` — post, authors job. Rewrites **one** rolling work-log comment on the
+  epic: what is open across every story, what just ran, and **what to pick up next** named
+  with its `Role:` stamp so the maintainer can assign without opening anything.
+  ⚠️ Entirely derived from GitHub state — no model writes any part of it, which is the
+  whole reason it can be trusted as a status board. ⚠️ One comment, rewritten, not one per
+  run: an epic with ten tasks × three roles would otherwise bury itself in thirty comments.
 - `close-merged-work.sh` — on merge. Closes the PR's issues and files them on the board.
+  ⚠️ It also closes a closed issue's **open sub-issues**: `open-story-pr.sh` lists the
+  tasks with closing keywords, but that body is written once when the PR opens, so a task
+  cut afterwards is nowhere in it.
+
+⚠️ **`gh api` prints its error body to STDOUT, so `--jq` never runs and a 404 lands in your
+variable.** `repos/…/issues/<n>/parent` 404s for anything unparented — most issues — so an
+unguarded capture returns `{"message":"No parent issue found",…}` and the caller treats that
+blob as an issue number. `delegate.sh` and `log-to-epic.sh` both filter captures to digits
+and read anything else as absent. Any new hook reading that endpoint must do the same.
 
 ⚠️ These were prompt instructions until a model skipped them. A label trail is worthless if
 a run can forget to stamp it, and the merge hook is the only backlog behaviour that worked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,10 @@ editing its markdown, not hunting a block scalar; the workflow went 1102 lines t
   needed the merged PR number, so it arrives as `PR` in the model step's env and the prompt
   says `gh pr diff "$PR"`. Anything else dynamic takes the same route.
 
-**Routing.** The handle in the comment picks the role. Labels route nothing.
+**Routing.** The **`@claude` label** is the front door: applying it to an issue starts a run,
+and `delegate.sh` reads the issue's state to pick the role. A bare `@claude` in a comment does
+the same. A `@claude/<role>` handle in a comment names the role outright and skips the
+inspection (rule 1) — still the way to override a bad guess.
 
 - `@claude/architect` — epic or story. Shapes the issue, cuts a story's branch, and creates
   its tasks — each stamped with the role that should pick it up.
@@ -153,13 +156,39 @@ editing its markdown, not hunting a block scalar; the workflow went 1102 lines t
   `@claude/security`. ⚠️ The one exception to "create issues unlabeled": it marks
   provenance so a finding stands out in a queue.
 
-⚠️ All six `@claude/*` labels must exist in the repo or the stamp hook warns and skips.
+⚠️ `@claude` **and** every `@claude/<role>` label must exist in the repo — `@claude` or nothing
+triggers, and a missing role label makes the stamp hook warn and skip.
 
-⚠️ A bare `@claude` does nothing, so a half-typed handle cannot start the wrong agent.
-⚠️ The Architect requires `!github.event.issue.pull_request` — `issue_comment` fires
-for PRs too, and without the guard a PR comment started a role written for an epic issue.
+⚠️ **The delegator is its own job and every role carries `needs: delegate`.** A job cannot gate
+on a step inside itself. This is not the `needs:` shape reverted below: there, roles needed
+`implementor`, which *itself* skipped most runs, and a job needing a skipped job reports
+cancelled. `delegate` always runs when the workflow triggers, so dependents reach their own
+`if:` and skip cleanly.
 
-⚠️ Every role is started by hand. **Tester and Writer briefly chained off the Implementor via
+⚠️ **The loop guard is the exact label name.** Roles stamp `@claude/<role>`, and every stamp is
+another `labeled` event. The delegate job requires `github.event.label.name == '@claude'` —
+an exact match — backed by the bot-actor guard. Both hold independently; either alone is one
+edit away from an infinite loop rather than a visible failure.
+
+⚠️ **Re-adding `@claude` is the "run again" gesture**, deliberately — `labeled` fires on every
+add, so remove-and-re-add re-runs the delegator against current issue state.
+
+⚠️ **A handle is never blocked by the router.** Each role's `if:` is
+`always() && (router picked me || the comment names me)`, so an explicit handle still routes if
+`delegate.sh` fails outright. Only a *skipped* delegate skips the roles.
+
+⚠️ `trigger_phrase` is `@claude` on every role, not `@claude/<role>`. A label trigger carries no
+comment for a per-role phrase to match. It is inert today regardless — `checkContainsTrigger()`
+returns early on `if (prompt) return true` and we always pass a prompt (verified at `v1.0.183`)
+— but if that short-circuit ever goes, `@claude` still matches the comment path where a
+per-role phrase would fail every role at once.
+
+⚠️ The Architect requires `!github.event.issue.pull_request` on its handle arm — `issue_comment`
+fires for PRs too, and without the guard a PR comment started a role written for an epic issue.
+The router cannot pick it on a PR (rule 2 sends every PR to the Implementor).
+
+⚠️ Every run is started by hand — a label or a comment — and the delegator picks the role from
+there. No role chains off another. **Tester and Writer briefly chained off the Implementor via
 `needs:` and it was reverted** — the job graph left them queued behind every run, and a role
 that skips after waiting reports as cancelled, so the history filled with cancelled jobs. If
 it is ever retried, the constraint that shaped it still holds: a comment cannot chain the
@@ -170,8 +199,9 @@ the noise. Cost the chain carried, for whoever revisits it: `!cancelled()` in bo
 (without it a skipped Implementor skips them, so a hand-typed handle could never run), and
 `trigger_phrase: "@claude/"` (tag mode gates on the phrase independently of the `if:`, and a
 chained run's comment says `@claude/implementor`).
-⚠️ Workflow changes to any of this **cannot be tested before merge**: `issue_comment` always
-runs the workflow from the default branch, so a PR branch's version is never the one that fires.
+⚠️ Workflow changes to any of this **cannot be tested before merge**: `issues` and
+`issue_comment` both always run the workflow from the default branch, so a PR branch's version
+is never the one that fires.
 
 **Backlog work is scripted, never prompted.** Hooks in `packages/claude-team/hooks/` run around each
 model step.
@@ -182,11 +212,14 @@ model step.
   milestone down. **Discovers** them — a bot-authored issue, numbered above the epic, whose
   body references it as `epic #N` or `story #N`. Honours an old `owner-manifest` comment
   too, unioned.
-- `acknowledge.sh` — pre, every role. Reacts 👀 so a trigger is visibly received before any
-  model runs.
-- `delegate.sh` — pre, every role. Picks the role(s) from issue state and emits them; routing
-  is a shell script, never a model. ⚠️ A missing `Role:` stamp defaults to Implementor and
-  says so — wrong is recoverable, silent is not.
+- `acknowledge.sh` — the **delegate** job, first step of every run. Reacts 👀 so a trigger is
+  visibly received before any model runs. ⚠️ It reacts via `issues/comments/<id>`, so it is
+  handed a `COMMENT_ID` only for `issue_comment` — a review comment's id belongs to the
+  *pulls* collection and would react to an unrelated comment. Empty falls back to the issue
+  or PR itself.
+- `delegate.sh` — the **delegate** job, and the gate every role hangs off. Picks the role(s)
+  from issue state and emits them; routing is a shell script, never a model. ⚠️ A missing
+  `Role:` stamp defaults to Implementor and says so — wrong is recoverable, silent is not.
 - `set-issue-status.sh` — pre, Implementor and Tester. Moves the triggering issue to
   **In Progress** on project #4, so the board reflects reality when work starts rather than
   only when it merges. Skips a closed issue, so a re-run never resurrects finished work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,21 +275,35 @@ read as "these agents have been here". The maintainer clears them as a check-off
   the link where a human reads it; the hook is the net, because a missing keyword loses the
   close and the board move with nothing to signal it.
 
-**Documentation belongs to the Writer.** Implementor and Tester change no `CLAUDE.md`. They
-optionally end their handoff with a fenced `json` block of **docs candidates** —
-`{"docsCandidates": [{"file", "note", "why"}]}` — and the Writer decides what earns a place.
+**The handoff between authors is a JSON contract**, not prose. The Implementor's step
+carries `--json-schema`, so its final message must match
+[`packages/claude-team/schemas/handoff.json`](packages/claude-team/schemas/handoff.json) —
+`testingNotes` for the Tester, `docsCandidates` for the Writer. The action exposes it as
+`structured_output`, and the workflow appends it to the other two roles' prompts.
 
-- ⚠️ A candidate is a proposal, not an order. The files only stay useful if the Writer says
-  no to what restates the diff or goes stale within a release.
-- ⚠️ Omit the block when nothing cost you time. A dutiful list trains the Writer to skim.
-- `why` is the field that decides it — a note without a real cost behind it usually isn't one.
-- This exists because `CLAUDE.md` was the biggest single source of merge conflicts: every
-  role edited it, so parallel branches collided on prose neither was really working on.
-
-**Testing belongs to the Tester.** The Implementor writes no e2e specs and leaves
-**Testing notes** instead. An engineer finishing a feature writes the test that passes; this repo's
-actual failure mode — a save that throws inside a fire-and-forget call while lint, tsc and
-build stay green — is only caught by a test written to distrust the change.
+- ⚠️ **Both keys are required, and `[]` is a real answer** — "I looked, there is nothing".
+  A consumer that cannot tell that from "forgot" is the exact failure that killed
+  `owner-manifest`: prose sections a later role has to find and parse are optional in
+  practice. A schema is not.
+- ⚠️ **An empty/absent block means no Implementor ran** (a Tester-only trigger, or its step
+  failed) — different again from `[]`. All three prompts spell out the three cases.
+- ⚠️ **The schema lives in `packages/claude-team`, but `--json-schema` takes inline JSON,
+  not a path.** A workflow step compacts the file with `jq -c` and injects it, the same way
+  `load-prompt` carries prompts. That step **fails the run** if the file contains a single
+  quote, since the value is wrapped in single quotes inside `claude_args` — and
+  `claude_args` is parsed line by line, so it must also stay one line.
+- ⚠️ `docsCandidates[].file` is a free string, never an enum of this repo's paths — the
+  roles are portable and must not encode one repository's layout.
+- ⚠️ A candidate is a proposal, not an order; arriving as structured data changes nothing
+  about that. The files only stay useful if the Writer says no to what restates the diff or
+  goes stale within a release, and rejecting every candidate stays a correct outcome.
+- `why` is the field that decides an entry — no real cost behind it, no entry.
+- Documentation is split out because `CLAUDE.md` was the biggest single source of merge
+  conflicts: every role edited it, so parallel branches collided on prose neither was
+  really working on. Testing is split out because an engineer finishing a feature writes
+  the test that passes, and this repo's actual failure mode — a save that throws inside a
+  fire-and-forget call while lint, tsc and build stay green — is only caught by a test
+  written to distrust the change.
 
 **Epic → story → task.** The team definition lives in
 [`packages/claude-team`](packages/claude-team/README.md); this repo extends it with

--- a/packages/claude-team/README.md
+++ b/packages/claude-team/README.md
@@ -24,7 +24,7 @@ its packages or its conventions — if it does, it belongs in the consumer's ove
 ## How a story moves
 
 1. **Architect** shapes the story and cuts its branch off the default branch.
-2. The **first author to run** — Implementor, Tester or Writer — opens the story's PR.
+2. The **first author to run** — Implementor or Designer, Tester, Writer — opens the story's PR.
 3. **Every subsequent role commits to that same branch.** No role cuts its own.
 4. The maintainer reviews one PR as it accumulates each role's contribution, and merges.
 
@@ -36,7 +36,8 @@ A reviewer sees the story land as a whole.
 | role | trigger | works on | writes |
 |---|---|---|---|
 | Architect | `@claude/architect` | epic or story | the issue, a story's branch, and its tasks |
-| Implementor | `@claude/implementor` | story or task | code |
+| Implementor | `@claude/implementor` | story or task | code, outside the design system |
+| Designer | `@claude/designer` | story or task | code, inside the design system |
 | Tester | `@claude/tester` | story or task | tests |
 | Writer | `@claude/writer` | story or task | documentation |
 | Security | none — runs on merge | the merged PR | issues it files |

--- a/packages/claude-team/hooks/close-merged-work.sh
+++ b/packages/claude-team/hooks/close-merged-work.sh
@@ -21,6 +21,21 @@ if [ -z "$issues" ]; then
   exit 0
 fi
 
+# ⚠️ Closing a story closes its tasks by definition, so derive them instead of trusting the
+# PR body. open-story-pr.sh lists the tasks with closing keywords, but it writes that body
+# ONCE when the PR opens — a task the Architect cuts afterwards is nowhere in it and would
+# be left open by a merge that plainly finished it. One level only: a story's children are
+# its tasks, and nothing recurses into an epic.
+for issue in $issues; do
+  kids=$(gh api "repos/$REPO/issues/$issue/sub_issues" \
+    --jq '.[] | select(.state == "open") | .number' 2>/dev/null || true)
+  if [ -n "$kids" ]; then
+    echo "#$issue has open sub-issues:" $kids
+    issues=$(printf '%s\n%s\n' "$issues" "$kids")
+  fi
+done
+issues=$(printf '%s\n' $issues | sort -un)
+
 for issue in $issues; do
   if [ "$(gh issue view "$issue" --repo "$REPO" --json state --jq '.state')" = "OPEN" ]; then
     gh issue close "$issue" --repo "$REPO" --comment "Completed by #${PR}."

--- a/packages/claude-team/hooks/delegate.sh
+++ b/packages/claude-team/hooks/delegate.sh
@@ -102,8 +102,15 @@ fi
 
 body=$(gh issue view "$NUMBER" --repo "$REPO" --json body --jq '.body // ""')
 branch=$(printf '%s' "$body" | grep -oiE 'branch: *`[^`]+`' | head -1 | sed -E 's/.*`([^`]+)`.*/\1/' || true)
-kids=$(gh api "repos/$REPO/issues/$NUMBER/sub_issues" --jq 'length' 2>/dev/null || echo 0)
-parent=$(gh api "repos/$REPO/issues/$NUMBER/parent" --jq '.number' 2>/dev/null || true)
+# ⚠️ `gh api` prints its ERROR BODY TO STDOUT, so a 404 lands in the variable and `--jq`
+# never runs. `repos/…/parent` 404s for anything unparented — most issues — so an unguarded
+# capture yields `{"message":"No parent issue found",…}` and every caller downstream treats
+# that blob as an issue number. Keep digits, and read anything else as absent.
+digits_or_empty() { case "$1" in ''|*[!0-9]*) ;; *) printf '%s' "$1" ;; esac; }
+
+kids=$(digits_or_empty "$(gh api "repos/$REPO/issues/$NUMBER/sub_issues" --jq 'length' 2>/dev/null || true)")
+kids=${kids:-0}
+parent=$(digits_or_empty "$(gh api "repos/$REPO/issues/$NUMBER/parent" --jq '.number' 2>/dev/null || true)")
 
 # ---- 3 & 4. nothing shaped yet, or an epic holding stories -> architect
 if [ -z "$branch" ] && [ "$kids" -eq 0 ]; then

--- a/packages/claude-team/hooks/delegate.sh
+++ b/packages/claude-team/hooks/delegate.sh
@@ -46,24 +46,48 @@ unroutable() {
     exit 0
 }
 
-# ---- 1. an explicit handle wins, with no further inspection
-for r in architect implementor tester writer designer; do
-    case "${COMMENT_BODY:-}" in
-        *"@claude/$r"*) ROLES="$r"; REASON="handle @claude/$r in the comment"; emit; exit 0 ;;
-    esac
-done
-
-# ---- 2. triggered on a PR: resolve its story, default to implementor
-if [ "${IS_PR:-false}" = "true" ]; then
-    [ -n "${NUMBER:-}" ] || unroutable "a PR trigger with no number"
-    STORY=$(gh pr view "$NUMBER" --repo "$REPO" --json closingIssuesReferences \
-        --jq '.closingIssuesReferences[0].number // empty' 2>/dev/null || true)
+# Sets STORY from a PR number. Every role triggered on a PR gets this, including one named
+# by an explicit handle — rule 1 short-circuits the routing *decision*, not the context: a
+# `@claude/tester` on a story's PR should arrive knowing which story it is testing.
+resolve_pr_story() {
+    # ⚠️ THE HEAD BRANCH NAMES THE STORY — the closing reference does not. A story branch is
+    # `<story#>-<summary>`, minted by the Architect; the closing refs are whatever the
+    # authors happened to write, and a task's `Closes #<task>` lands in there too. Measured
+    # across four real story PRs, `closingIssuesReferences[0]` gave a TASK or an unrelated
+    # story in two of them, while the branch name was right in all four.
+    local head
+    head=$(gh pr view "$NUMBER" --repo "$REPO" --json headRefName --jq '.headRefName // empty' 2>/dev/null || true)
+    STORY=$(printf '%s' "$head" | grep -oE '^[0-9]+' || true)
+    # a hand-cut branch with no issue prefix: fall back to what the PR claims to close.
+    if [ -z "$STORY" ]; then
+        STORY=$(gh pr view "$NUMBER" --repo "$REPO" --json closingIssuesReferences \
+            --jq '.closingIssuesReferences[0].number // empty' 2>/dev/null || true)
+    fi
     # ⚠️ closingIssuesReferences only populates when the PR targets the default branch —
     # GitHub ignores closing keywords otherwise. Fall back to the body for anything else.
     if [ -z "$STORY" ]; then
         STORY=$(gh pr view "$NUMBER" --repo "$REPO" --json body --jq '.body // ""' 2>/dev/null \
             | grep -oiE '(clos|fix|resolv)[a-z]* +#[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
     fi
+}
+
+# ---- 1. an explicit handle wins, with no further inspection
+for r in architect implementor tester writer designer; do
+    case "${COMMENT_BODY:-}" in
+        *"@claude/$r"*)
+            ROLES="$r"; REASON="handle @claude/$r in the comment"
+            if [ "${IS_PR:-false}" = "true" ] && [ -n "${NUMBER:-}" ]; then
+                resolve_pr_story
+                REASON="$REASON; PR #$NUMBER belongs to story #${STORY:-unknown}"
+            fi
+            emit; exit 0 ;;
+    esac
+done
+
+# ---- 2. triggered on a PR: resolve its story, default to implementor
+if [ "${IS_PR:-false}" = "true" ]; then
+    [ -n "${NUMBER:-}" ] || unroutable "a PR trigger with no number"
+    resolve_pr_story
     ROLES="implementor"
     if [ -z "$STORY" ]; then
         DEFAULTED=true

--- a/packages/claude-team/hooks/finish-pr.sh
+++ b/packages/claude-team/hooks/finish-pr.sh
@@ -2,15 +2,19 @@
 # Post-hook for every role that opens a PR. Does the two things a prompt kept
 # being asked to remember:
 #
-#   1. labels the PR with the role that opened it
+#   1. labels the PR with the role(s) that worked it
 #   2. makes sure the body carries `Closes #<issue>`
 #
 # (2) is the one that silently loses work: close-merged-work.sh finds what a PR
 # finished by parsing that keyword, so a missing line means the issue never
 # closes and never reaches Done, with nothing to signal it.
+#
+# ROLES is a space-separated list because the authoring roles run as sequential
+# steps in ONE job and this hook runs once at the end of it. A single role is a
+# list of one; the PR should carry the whole trail, not whichever ran last.
 set -euo pipefail
 
-: "${ROLE:?ROLE is required}"
+: "${ROLES:?ROLES is required}"
 : "${REPO:?REPO is required}"
 
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
@@ -31,11 +35,13 @@ if [ -z "$pr" ]; then
     exit 0
 fi
 
-if gh pr edit "$pr" --repo "$REPO" --add-label "@claude/$ROLE" >/dev/null 2>&1; then
-    echo "PR #$pr -> @claude/$ROLE"
-else
-    echo "::warning::could not label PR #$pr — does @claude/$ROLE exist in this repo?"
-fi
+for role in $ROLES; do
+    if gh pr edit "$pr" --repo "$REPO" --add-label "@claude/$role" >/dev/null 2>&1; then
+        echo "PR #$pr -> @claude/$role"
+    else
+        echo "::warning::could not label PR #$pr — does @claude/$role exist in this repo?"
+    fi
+done
 
 if [ -z "${ISSUE:-}" ]; then
     echo "No triggering issue — nothing to close."

--- a/packages/claude-team/hooks/log-to-epic.sh
+++ b/packages/claude-team/hooks/log-to-epic.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Post-hook for the authoring job. Keeps ONE rolling work-log comment on the epic, so the
+# maintainer can see the state of the whole epic in one place and decide what to assign
+# next — without opening every story.
+#
+# ⚠️ FULLY DERIVED. Nothing here is written by a model. Which issue ran, which roles ran,
+# what is still open and what comes next are all readable from GitHub, so none of it can be
+# skipped or misreported. This repo's recurring failure is the opposite shape: sub-issue
+# filing asked the deciding role to leave a machine-readable manifest, and across nine epics
+# it wrote one exactly once.
+#
+# ⚠️ ONE COMMENT, REWRITTEN — not one comment per run. An epic with ten tasks and three
+# roles each would otherwise accumulate thirty comments, which is the same "dutiful list
+# nobody reads" failure the handoff rules already warn about. The status table is rebuilt
+# from live state every time, so it is never stale; only the Recent lines accumulate, and
+# they are capped.
+set -euo pipefail
+
+: "${REPO:?REPO is required}"
+
+MARKER='<!-- claude-team:worklog -->'
+KEEP=12
+
+if [ -z "${ISSUE:-}" ]; then
+    echo "Not triggered on an issue — no epic to log against."
+    exit 0
+fi
+
+# ⚠️ `gh api` prints its ERROR BODY TO STDOUT, so a 404 lands in the variable and `--jq`
+# never runs. `repos/…/parent` 404s for anything unparented — which is most issues — so an
+# unguarded capture returns `{"message":"No parent issue found",…}` and every caller then
+# treats that blob as an issue number. Filter to digits and let anything else read as
+# absent, which is what a 404 actually means here.
+parent_of() {
+    local v
+    v=$(gh api "repos/$REPO/issues/$1/parent" --jq '.number' 2>/dev/null || true)
+    case "$v" in ''|*[!0-9]*) ;; *) printf '%s' "$v" ;; esac
+}
+title_of() { gh issue view "$1" --repo "$REPO" --json title --jq '.title' 2>/dev/null || true; }
+# same trap: keep only well-formed `<number>\t<state>\t<title>` rows.
+kids_of() {
+    gh api "repos/$REPO/issues/$1/sub_issues" \
+        --jq '.[] | "\(.number)\t\(.state)\t\(.title)"' 2>/dev/null \
+        | grep -E '^[0-9]+	' || true
+}
+
+role_of() {
+    gh issue view "$1" --repo "$REPO" --json body --jq '.body // ""' 2>/dev/null \
+        | grep -oiE 'role: *`?[a-z]+`?' | head -1 | sed -E 's/.*[Rr]ole: *`?([a-z]+)`?.*/\1/' || true
+}
+
+# ── locate the epic ────────────────────────────────────────────────────────────────────
+# A task's parent is its story and the story's parent is the epic; a story's parent is the
+# epic directly. Walk up at most two levels and stop at whatever has no parent.
+STORY=""; EPIC=""
+p1=$(parent_of "$ISSUE")
+if [ -z "$p1" ]; then
+    echo "#$ISSUE has no parent — an epic itself, or unparented work. Nothing to log."
+    exit 0
+fi
+p2=$(parent_of "$p1")
+if [ -n "$p2" ]; then
+    STORY="$p1"; EPIC="$p2"
+else
+    STORY="$ISSUE"; EPIC="$p1"
+fi
+
+echo "logging #$ISSUE (story #$STORY) against epic #$EPIC"
+
+# ── what comes next ────────────────────────────────────────────────────────────────────
+# The next open task of the story just worked; failing that, the next open story of the
+# epic. Named with its Role stamp so the maintainer can act on it without opening it.
+next_line="_Nothing open — the epic looks complete._"
+next=$(kids_of "$STORY" | awk -F'\t' '$2=="open" && $1!='"$ISSUE"' {print $1"\t"$3; exit}')
+kind="task"; scope="task of story #$STORY"
+if [ -z "$next" ]; then
+    next=$(kids_of "$EPIC" | awk -F'\t' '$2=="open" && $1!='"$STORY"' {print $1"\t"$3; exit}')
+    kind="story"; scope="story of epic #$EPIC"
+fi
+if [ -n "$next" ]; then
+    n=$(printf '%s' "$next" | cut -f1)
+    t=$(printf '%s' "$next" | cut -f2)
+    note=""
+    # ⚠️ Only a TASK carries a `Role:` stamp — it is what routes an author to it. A story
+    # is shaped by the Architect and has no stamp by design, so demanding one there would
+    # be a standing false alarm on every epic.
+    if [ "$kind" = "task" ]; then
+        r=$(role_of "$n")
+        if [ -n "$r" ]; then
+            note=$(printf ', stamped `Role: %s`' "$r")
+        else
+            note=', **no `Role:` stamp** — the Architect should add one'
+        fi
+    else
+        note=' — label it `@claude` and the Architect will shape it'
+    fi
+    next_line=$(printf '**#%s — %s**  \n%s%s' "$n" "$t" "next open $scope" "$note")
+fi
+
+# ── the status table ───────────────────────────────────────────────────────────────────
+table=$(
+    printf '| story | state | tasks |\n|---|---|---|\n'
+    kids_of "$EPIC" | while IFS=$'\t' read -r sn ss st; do
+        kids=$(kids_of "$sn")
+        if [ -z "$kids" ]; then
+            counts="—"
+        else
+            total=$(printf '%s\n' "$kids" | wc -l | tr -d ' ')
+            done_n=$(printf '%s\n' "$kids" | awk -F'\t' '$2=="closed"' | wc -l | tr -d ' ')
+            open_ns=$(printf '%s\n' "$kids" | awk -F'\t' '$2=="open" {printf "#%s ", $1}')
+            counts="${done_n}/${total}${open_ns:+ · open: ${open_ns}}"
+        fi
+        mark=$([ "$ss" = "closed" ] && printf '✅' || printf '⬜')
+        printf '| #%s %s | %s %s | %s |\n' "$sn" "$st" "$mark" "$ss" "$counts"
+    done
+)
+
+# ── carry the previous Recent lines forward ────────────────────────────────────────────
+comment_id=$(gh api "repos/$REPO/issues/$EPIC/comments" --paginate \
+    --jq "[.[] | select((.body // \"\") | contains(\"$MARKER\")) | .id] | last // empty" 2>/dev/null || true)
+
+previous=""
+if [ -n "$comment_id" ]; then
+    previous=$(gh api "repos/$REPO/issues/comments/$comment_id" --jq '.body // ""' 2>/dev/null \
+        | sed -n '/^### Recent/,$p' | grep '^- ' || true)
+fi
+
+entry=$(printf -- '- `%s` **#%s** %s — %s%s' \
+    "$(date -u '+%Y-%m-%d %H:%M')" "$ISSUE" "$(title_of "$ISSUE")" \
+    "${ROLES:-（unknown）}" \
+    "${PR:+ · PR #$PR}")
+
+recent=$(printf '%s\n%s\n' "$entry" "$previous" | grep '^- ' | head -"$KEEP")
+
+# ── write it ───────────────────────────────────────────────────────────────────────────
+body_file=$(mktemp)
+{
+    printf '%s\n' "$MARKER"
+    printf '## Work log\n\n'
+    printf 'Rebuilt automatically after every authoring run. Status is read live from the\n'
+    printf 'issues, so it is current as of the newest entry below.\n\n'
+    printf '### Next up\n\n%s\n\n' "$next_line"
+    printf '### Stories\n\n%s\n\n' "$table"
+    printf '### Recent\n\n%s\n' "$recent"
+} > "$body_file"
+
+if [ -n "$comment_id" ]; then
+    if gh api --method PATCH "repos/$REPO/issues/comments/$comment_id" \
+        -f body="$(cat "$body_file")" >/dev/null 2>&1; then
+        echo "updated the work log on epic #$EPIC"
+    else
+        echo "::warning::could not update the work log comment on epic #$EPIC"
+    fi
+else
+    if gh issue comment "$EPIC" --repo "$REPO" --body-file "$body_file" >/dev/null 2>&1; then
+        echo "opened the work log on epic #$EPIC"
+    else
+        echo "::warning::could not comment the work log on epic #$EPIC"
+    fi
+fi
+rm -f "$body_file"

--- a/packages/claude-team/hooks/open-story-pr.sh
+++ b/packages/claude-team/hooks/open-story-pr.sh
@@ -51,14 +51,40 @@ if [ "$(git rev-list --count "origin/$default..origin/$branch")" -eq 0 ]; then
     exit 0
 fi
 
-title=$(gh issue view "$ISSUE" --repo "$REPO" --json title --jq '.title')
+# ⚠️ THE PR CLOSES THE STORY, NOT THE TRIGGERING ISSUE. Writing `Closes #<task>` here is
+# what sank the model once already: the first task's PR announced itself finished, CI went
+# green, and merging was the obvious move — closing the branch with the story's other tasks
+# unstarted. A branch is named `<story#>-<summary>`, so the number it starts with is the
+# story: itself when a story triggered the run, its parent when a task did.
+STORY=$(printf '%s' "$branch" | grep -oE '^[0-9]+' || true)
+[ -n "$STORY" ] || STORY="$ISSUE"
+
+title=$(gh issue view "$STORY" --repo "$REPO" --json title --jq '.title')
+tasks=$(gh api "repos/$REPO/issues/$STORY/sub_issues" \
+    --jq '.[] | "\(.number)\t\(.title)"' 2>/dev/null || true)
 
 body_file=$(mktemp)
 {
     printf 'Story PR for `%s`.\n\n' "$branch"
-    printf 'Every role working this story commits to this branch, so this PR grows as the\n'
-    printf 'story lands — code, tests and docs together — rather than arriving as several.\n'
-    printf '\nCloses #%s\n' "$ISSUE"
+    printf '⚠️ **This PR stays open until the story is complete.** Every role working the story\n'
+    printf 'commits to this branch, so it grows as the story lands — code, tests and docs\n'
+    printf 'together — rather than arriving as several PRs. One task looking finished is not a\n'
+    printf 'signal to merge.\n\n'
+    printf 'Closes #%s\n' "$STORY"
+
+    if [ -n "$tasks" ]; then
+        printf '\n### Tasks\n\n'
+        printf '%s\n' "$tasks" | while IFS=$'\t' read -r n t; do
+            printf -- '- #%s — %s\n' "$n" "$t"
+        done
+        # ⚠️ The tasks need their own closing keywords. close-merged-work.sh only falls back
+        # to parsing the body when `closingIssuesReferences` is EMPTY, and a story PR targets
+        # the default branch — so GitHub populates it with the story and the parse never runs.
+        # Listing the tasks without keywords would leave every one of them open on merge.
+        printf '\nMerging closes them too:'
+        printf '%s\n' "$tasks" | cut -f1 | while read -r n; do printf ' closes #%s' "$n"; done
+        printf '\n'
+    fi
 } > "$body_file"
 
 if gh pr create --repo "$REPO" --base "$default" --head "$branch" --title "$title" --body-file "$body_file" >/dev/null 2>&1; then

--- a/packages/claude-team/prompts/_shared.md
+++ b/packages/claude-team/prompts/_shared.md
@@ -19,6 +19,12 @@ branch and appears in the **story's** PR.
 3. **Every role after that commits to the same branch.** No role cuts its own.
 4. The maintainer reviews one PR as it accumulates and merges it.
 
+⚠️ **The story's PR is not yours to finish.** It belongs to the story and closes when the
+story does — it says `Closes #<story>`, never `Closes #<your task>`. Finishing your task
+does not finish the PR, so do not describe it as ready, complete, or good to merge; other
+tasks are still landing on the same branch. Report what *your task* did and leave the PR's
+state to the story.
+
 ⚠️ **Do not create a branch.** Check out the story's existing branch:
 
 ```

--- a/packages/claude-team/prompts/_shared.md
+++ b/packages/claude-team/prompts/_shared.md
@@ -12,6 +12,22 @@ a story. If you find yourself wanting to open a PR for an epic, you are looking 
 ⚠️ **A task never has its own branch or PR.** Its work is committed to its **story's**
 branch and appears in the **story's** PR.
 
+## Knowing which story you are in
+
+`$STORY` holds the story's issue number, resolved before you started. Read it for context
+before you touch anything:
+
+```
+gh issue view "$STORY"
+```
+
+This matters most when a **comment on a PR** triggered you: the PR shows a diff, and the
+story is the only place that says what the diff was supposed to achieve. Read both.
+
+⚠️ `$STORY` can be empty — a PR with no resolvable story, or a trigger that is not part of
+one. That is not an error and not a reason to stop: work from the issue or PR you were
+given, and say in your report that you had no story context.
+
 ## How a story moves
 
 1. **Architect** shapes the story and cuts its branch off the default branch.

--- a/packages/claude-team/prompts/architect.md
+++ b/packages/claude-team/prompts/architect.md
@@ -62,6 +62,17 @@ fresh in front of you.
 ⚠️ **A task you cannot cleanly assign should be split, not guessed at.** If a task spans two
 roles' territory, that is a sign it is two tasks.
 
+⚠️ **Implementor vs Designer is decided by the package, not by judgement.** A task whose
+changes fall inside the design-system package is `designer`; everything else is
+`implementor`. Read the paths rather than reasoning about which side a change "really"
+belongs to — the boundary is drawn to be checkable.
+
+**A task that changes a primitive *and* its call sites is two tasks**, and you are the only
+one who can split it: cut the design-package change as a `designer` task and the consumer
+updates as an `implementor` task, and say in the consumer task that it depends on the other.
+Neither role will reach across on its own — both are told to report and stop — so a task
+left spanning both simply stalls.
+
 ## Sizing is about exploration cost, not just reviewability
 
 An author has a fixed turn budget and must **read the files it will touch before it can edit

--- a/packages/claude-team/prompts/designer.md
+++ b/packages/claude-team/prompts/designer.md
@@ -1,0 +1,76 @@
+You are the **Designer** — the Implementor of the design system. You write the code the
+other code is built out of.
+
+You are reached either by the delegator routing a task stamped `Role: designer`, or by
+**`@claude/designer`** named directly in a comment on an issue or a PR.
+
+## Where your work goes
+
+Read the issue's **Branch** line and commit there. On a **task**, that line names its
+*story's* branch — your work lands in the story's PR alongside every other role's.
+
+⚠️ **Do not create a branch, and do not open a PR if one already exists for the story.** A
+scripted hook opens it on whichever author runs first. If you are that first author, the
+hook opens it after you finish; you do not need to.
+
+## What you own
+
+The **design-system package**: its primitives, the props they accept, the class strings or
+styles they emit, their stories, and the design tokens.
+
+The Implementor owns everything that *uses* them.
+
+⚠️ **The boundary is the package, not a judgement call.** It is drawn that way so it can be
+checked rather than negotiated: if the file is inside the design package it is yours, and if
+it is outside it is not. Do not reason about which side a change "really" belongs to — read
+the path.
+
+⚠️ **When a task spans both sides, say so and stop.** A change to a primitive *and* its call
+sites is two tasks, and the Architect cuts it into two. Do not fix the primitive and then
+follow it out into the consumers, and do not reshape a consumer to avoid touching the
+primitive. Report what you found, name the two halves, and leave it — a Designer quietly
+editing consumer code is exactly the drift the package boundary exists to prevent.
+
+- ⚠️ **You write no tests.** The Tester owns them. Report `testingNotes` instead.
+- ⚠️ **You change no documentation.** The Writer owns it. Report `docsCandidates` instead —
+  and only for things that actually cost you time.
+
+## What a good change looks like here
+
+- **A primitive is an API.** Every consumer inherits its prop names, its defaults and its
+  behaviour, so a careless rename is a breaking change across the whole repo. Prefer adding
+  a prop over repurposing one.
+- **Look for the existing primitive first.** The most common failure in a design system is
+  a second component that does almost what the first one does. If something close exists,
+  extend it or say plainly why it cannot be extended.
+- **A story is how a primitive is reviewed.** A variant nobody can see is a variant nobody
+  checks. If the package has stories, a new or changed variant gets one.
+- **Say what a visual change looks like.** The maintainer cannot read a diff and see the
+  result. Attach a screenshot, or describe the before and after concretely.
+
+## Before you finish
+
+- Make the repo's gate green. Never hand over a red gate.
+- Push to the story branch.
+- End your comment with a **Handoff**: what changed, what is still open, decisions and
+  gotchas discovered, a one-line-per-file map, and how to verify. ⚠️ Name every consumer
+  you believe is affected but did not touch — that list is what the Implementor picks up.
+  Keep it a scannable status doc. A **🔔 Maintainer** section, if you have one, goes below.
+
+## The handoff to the Tester and the Writer
+
+Your **final message is a JSON object** matching the schema you were given: `testingNotes`
+for the Tester, `docsCandidates` for the Writer. They are handed it directly as context —
+neither goes looking for a section in a comment.
+
+- **Both keys are required.** `[]` is a real answer, and the right one when there is
+  genuinely nothing: it says "I considered this and there is nothing here", which a later
+  role can act on. A missing key says nothing at all.
+- ⚠️ **Do not pad either list.** An entry that restates the diff costs another role a turn
+  to read and reject, and trains them to skim the ones that matter.
+- `why` is the field that decides an entry. For a testing note it is the silent failure
+  lint, typecheck and build would all miss; for a docs candidate it is the time you
+  actually lost. If you cannot write a real `why`, the entry does not belong.
+
+⚠️ Keep any task checklist to 3–5 outcome-level items. Each one costs a turn to narrate
+back, so a ten-item list spends the budget before code is written.

--- a/packages/claude-team/prompts/implementor.md
+++ b/packages/claude-team/prompts/implementor.md
@@ -1,6 +1,11 @@
 You are the **Implementor** — the engineer. You write the code.
 
-You are triggered by **`@claude/implementor`** in a comment, on an issue or a PR.
+You are reached either by the delegator routing a task stamped `Role: implementor`, or by
+**`@claude/implementor`** named directly in a comment on an issue or a PR.
+
+⚠️ **You own the consumers, not the design system.** If the task's changes fall inside the
+design-system package, it belongs to the Designer — say so and stop rather than reaching
+across. See _What you own_.
 
 ## Where your work goes
 
@@ -30,6 +35,7 @@ Code, and only code.
   and gotchas discovered, a one-line-per-file map, and how to verify. Keep it a scannable
   status doc — a bloated handoff costs the turns it was meant to save. A **🔔 Maintainer**
   section, if you have one, goes below it.
+
 ## The handoff to the Tester and the Writer
 
 Your **final message is a JSON object** matching the schema you were given: `testingNotes`

--- a/packages/claude-team/prompts/implementor.md
+++ b/packages/claude-team/prompts/implementor.md
@@ -17,8 +17,8 @@ Code, and only code.
 
 - ⚠️ **You write no tests.** The Tester owns them. An engineer finishing a feature writes
   the test that passes; the failure this catches is the one written to distrust the change.
-  Leave **Testing notes** in your handoff instead.
-- ⚠️ **You change no documentation.** The Writer owns it. Leave **docs candidates**
+  Report `testingNotes` instead.
+- ⚠️ **You change no documentation.** The Writer owns it. Report `docsCandidates`
   instead — and only for things that actually cost you time. A dutiful list trains the
   Writer to skim.
 
@@ -30,8 +30,20 @@ Code, and only code.
   and gotchas discovered, a one-line-per-file map, and how to verify. Keep it a scannable
   status doc — a bloated handoff costs the turns it was meant to save. A **🔔 Maintainer**
   section, if you have one, goes below it.
-- Add **Testing notes** for the Tester, and **docs candidates** for the Writer, when either
-  is warranted.
+## The handoff to the Tester and the Writer
+
+Your **final message is a JSON object** matching the schema you were given: `testingNotes`
+for the Tester, `docsCandidates` for the Writer. They are handed it directly as context —
+neither goes looking for a section in a comment.
+
+- **Both keys are required.** `[]` is a real answer, and the right one when there is
+  genuinely nothing: it says "I considered this and there is nothing here", which a later
+  role can act on. A missing key says nothing at all.
+- ⚠️ **Do not pad either list.** An entry that restates the diff costs another role a turn
+  to read and reject, and trains them to skim the ones that matter.
+- `why` is the field that decides an entry. For a testing note it is the silent failure
+  lint, typecheck and build would all miss; for a docs candidate it is the time you
+  actually lost. If you cannot write a real `why`, the entry does not belong.
 
 ⚠️ Keep any task checklist to 3–5 outcome-level items. Each one costs a turn to narrate
 back, so a ten-item list spends the budget before code is written.

--- a/packages/claude-team/prompts/tester.md
+++ b/packages/claude-team/prompts/tester.md
@@ -12,11 +12,22 @@ after you finish.
 
 ## Where your work comes from
 
-Usually an Implementor's **Testing notes** in the story's PR — that section is written for
-you. Start there, then read the diff for what actually changed.
+A **Handoff from the Implementor** block, appended to this prompt as JSON. Its
+`testingNotes` are written for you: each names an `area` to cover and the `why` — the
+silent failure that lint, typecheck and build would all miss. Start there, then read the
+diff for what actually changed.
 
-If the notes are missing or too thin, say so plainly and test what you can read off the
-diff. Don't stall waiting, and don't invent behaviour the code doesn't have.
+⚠️ **Three different situations, and they do not mean the same thing:**
+
+- **`testingNotes` has entries** — the Implementor considered coverage and this is what it
+  found. Treat it as a starting point, not a ceiling.
+- **`testingNotes` is `[]`** — it considered coverage and concluded none was warranted.
+  That is a real answer. Check it against the diff; if you disagree, say so and test
+  anyway, but do not treat it as an oversight by default.
+- **The block is empty or absent** — no Implementor ran in this job, or its step failed.
+  You have no handoff at all. Work from the issue and the diff, and say so in your report.
+
+Don't stall waiting on a handoff, and don't invent behaviour the code doesn't have.
 
 ## What a good test looks like here
 

--- a/packages/claude-team/prompts/writer.md
+++ b/packages/claude-team/prompts/writer.md
@@ -13,13 +13,22 @@ finish.
 
 ## Where your work comes from
 
-Usually an Implementor's or Tester's **docs candidates** in the story's PR. Start there,
-then read the diff for what actually changed.
+A **Handoff from the Implementor** block, appended to this prompt as JSON. Its
+`docsCandidates` each name a `file`, the `note` that should go in it, and the `why` — the
+time the proposer actually lost for not knowing it. Start there, then read the diff for
+what actually changed.
 
-⚠️ **A candidate is a proposal, not an order.** Judging what deserves a place is your job,
-and the docs only stay useful if you say no. Reject anything that restates the diff, that a
-reader would infer from a good name, or that will be stale within a release. Say so briefly
-in the PR so the proposer learns the line.
+⚠️ **A candidate is a proposal, not an order.** Arriving as structured data changes nothing
+about that — judging what deserves a place is your job, and the docs only stay useful if
+you say no. Reject anything that restates the diff, that a reader would infer from a good
+name, or that will be stale within a release. `why` is the field to judge on: a candidate
+with no real cost behind it usually isn't one. Say so briefly in the PR so the proposer
+learns the line.
+
+⚠️ **Three different situations:** entries mean the Implementor found something; `[]` means
+it looked and found nothing worth your turn, which is a real answer and needs no second
+guessing; an empty or absent block means no Implementor ran here at all, so work from the
+diff and say so.
 
 If nothing survives that filter, say so and change nothing. A run that documents nothing is
 a correct outcome.

--- a/packages/claude-team/schemas/handoff.json
+++ b/packages/claude-team/schemas/handoff.json
@@ -1,0 +1,50 @@
+{
+  "type": "object",
+  "description": "What an authoring role passes to the roles that run after it. Both keys are required. An empty array is a real answer meaning nothing here is worth another role a turn, and is not the same as the step never having run at all.",
+  "properties": {
+    "testingNotes": {
+      "type": "array",
+      "description": "For the Tester. Behaviour that a test written to distrust this change should cover — not a description of what was built. Empty when the change genuinely warrants no new coverage.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "area": {
+            "type": "string",
+            "description": "The behaviour or flow to cover, named in reader-facing terms rather than as a file path."
+          },
+          "why": {
+            "type": "string",
+            "description": "What could break here and stay invisible to lint, typecheck and build. A note with no plausible silent failure behind it is not worth a test."
+          }
+        },
+        "required": ["area", "why"],
+        "additionalProperties": false
+      }
+    },
+    "docsCandidates": {
+      "type": "array",
+      "description": "For the Writer. Things that cost you time to work out and would cost the next reader the same. A proposal, never an instruction — the Writer decides what earns a place. Empty when nothing cost you time.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "Repo-relative path of the document that should carry it. A free string on purpose: these roles are portable and must not encode the layout of any one repository."
+          },
+          "note": {
+            "type": "string",
+            "description": "What the document should say, stated as the fact itself rather than as a topic to write about."
+          },
+          "why": {
+            "type": "string",
+            "description": "The concrete cost you paid for not knowing it. This is the field that decides whether the note survives; with no real cost behind it, it usually should not."
+          }
+        },
+        "required": ["file", "note", "why"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["testingNotes", "docsCandidates"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Completes epic #465 on one branch, seven commits, one per work item.

Closes #466, closes #468, closes #469
Closes #473, closes #474, closes #475, closes #476, closes #481

With #467 and #470 already merged, this finishes every story — epic #465 can close with it.

## What landed

**`@claude` is the front door.** Label an issue and `delegate.sh` reads its state to pick the role; a `@claude/<role>` handle still names one outright. The router is its own job with `needs: delegate` on the rest, because a job cannot gate on a step inside itself.

⚠️ **This is not the `needs:` shape #430 reverted.** There, roles needed `implementor`, which *itself* skipped most runs, and a job needing a skipped job reports cancelled. `delegate` always runs when the workflow triggers, so dependents reach their own `if:` and skip cleanly.

**One `@claude` runs the whole chain** — Implementor (or Designer) → Tester → Writer, as sequential **steps in one job**. Not `needs:`; that is the shape that failed. Budget: opus 80 → sonnet 80 → sonnet 60 = **220 turns**, sequential, on one runner. Implementor and Designer never both run, so 220 is the ceiling rather than 300, and a single-role run skips the other steps *and* their setup.

**The handoff is a JSON contract.** The author's step carries `--json-schema`, and the action's `structured_output` is appended to the Tester's and Writer's prompts. Both keys required, so `[]` ("I looked, there's nothing") is distinguishable from a missing key — the exact distinction `owner-manifest` lacked.

**A story PR closes the story, not its first task** — the bug that closed this branch after one of four tasks.

**A Designer**, an Implementor whose subject is `packages/design`. The boundary is the **package**, not a judgement call, so it can be checked rather than negotiated.

**A rolling work log on the epic** (your ask mid-run) — see below.

## The work log

One comment on the epic, rewritten after every authoring run: what is open across every story, what just ran, and **what to pick up next**, named with its `Role:` stamp so you can assign without opening anything. Rendered here against live state:

> ### Next up
>
> **#474 — Route PR follow-ups, resolving the story for context**
> next open task of story #466, stamped `Role: implementor`
>
> ### Stories
>
> | story | state | tasks |
> |---|---|---|
> | #466 Delegator: script the routing… | ⬜ open | 1/4 · open: #473 #474 #481 |
> | #467 Architect: merge Manager and Researcher | ✅ closed | — |
> | #468 Chain Implementor → Tester → Writer | ⬜ open | 0/2 · open: #475 #476 |
> | #469 Designer: an Implementor for the design system | ⬜ open | — |
> | #470 One standardized maintainer callout | ✅ closed | — |
>
> ### Recent
>
> - `2026-08-03 22:20` **#473** Trigger on the @claude label… — implementor tester writer · PR #485

⚠️ **Scripted, not prompted, and that is the point.** You asked for the roles to call out what is next; I made it a hook instead. Which issue ran, which roles ran, what is open and what comes next are all readable from GitHub, so none of it can be skipped or misreported — where a role *asked* to write a log is the shape that failed for `owner-manifest`, written once across nine epics. Say the word if you want the roles to narrate it in their own comments as well.

⚠️ **One comment, rewritten** — not one per run. Ten tasks × three roles would otherwise bury the epic in thirty comments.

## Two live bugs found and fixed in passing

- **`gh api` prints its error body to STDOUT**, so `--jq` never applies and a 404 lands in the variable. `repos/…/issues/<n>/parent` 404s for anything unparented — most issues — so `delegate.sh` (already on `mainline`) was capturing `{"message":"No parent issue found",…}` and treating that blob as an issue number. Reachable through the branch-without-digits fallback, where it would have written JSON into the story output. Both hooks now filter to digits.
- **`closingIssuesReferences[0]` is the wrong signal for a story.** Measured across four real story PRs it named a *task* or an unrelated story in two of them; the head branch (`<story#>-<summary>`) was right in all four. Rule 2 now prefers the branch.

## Verification

`npm test --ws` (eslint) ✓ 0 errors · `tsc --noEmit` ✓ · `vite build` ✓ · `bash -n` on all nine hooks ✓

No UI change, so no screenshots. Workflow behaviour was verified by parsing the YAML and **evaluating the real `if:` expressions** against synthetic payloads — expressions are read out of the file, not hand-copied.

**Loop guard** (a role's stamp is itself a `labeled` event):

| trigger | actor | result |
|---|---|---|
| label `@claude` | maintainer | **RUNS** |
| label `@claude/implementor` | **maintainer** | skips ← label guard alone |
| label `@claude` | `github-actions[bot]` | skips ← actor guard alone |
| label `@claude/architect` | `github-actions[bot]` | skips |
| label `bug` | maintainer | skips |
| comment `@claude` / `@claude/architect` | maintainer | **RUNS** |
| comment quoting `@claude` | `github-actions[bot]` | skips |

Rows 2 and 3 are the proof: each guard stops a stamp on its own.

**Routing** — router picks one role → only that role; handle + router agreement → that role; handle with the router **failed** → still routes; `@claude/architect` on a PR → implementor (guard holds); delegate skipped or `roles` empty → nothing runs.

**`delegate.sh` against live GitHub** — PRs #479/#477/#485/#471 all resolve to the right story; `@claude/tester` on #485 → tester **and** story #466; label path on #474 → implementor via its `Role:` stamp; on #466 → flags that you probably meant one of its tasks.

**Chain shape** — order correct; each stamp precedes its own model step; post-hooks appear once each, not per role, and run on failure; `use_sticky_comment` unset so each role gets its own tracking comment (sticky would overwrite the Implementor's handoff with the Tester's).

**Schema** — one line, no single quote (both asserted *in the workflow*, which fails the run otherwise), both keys required, `docsCandidates[].file` a free string, nothing BrewDocs-specific.

**`log-to-epic.sh`** — rendered against live state for a task, a story with no open tasks (falls through to the next story), and an unparented issue (clean no-op).

⚠️ **Verify will not run on this PR** — the path filter excludes workflows, docs and `packages/claude-team`. The gate above is the only record it ran.

⚠️ **None of it can be exercised before merge**: `issues` and `issue_comment` both run the workflow from the default branch.

## After merge

Label an issue `@claude` and watch for **one** delegate run, not two — that is the loop guard holding in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
