### PR TITLE
Fix the role-prompt precedence and the merge-housekeeping gate

### DIFF
--- a/.github/actions/load-prompt/action.yml
+++ b/.github/actions/load-prompt/action.yml
@@ -8,6 +8,12 @@ description: Assembles a role's prompt from the claude-team base and this repo's
 #   .github/agent-prompts/_shared.md          this repo's specifics, every role
 #   .github/agent-prompts/<role>.md           this repo's specifics for this role
 #
+# ⚠️ THAT ORDER IS LOAD-BEARING, and the code drifted from this comment once already.
+# `_shared.md` opens by overriding the action's own tag-mode prompt, which tells the model
+# — four times, for comment events — that its instructions are the triggering comment. Ours
+# arrives after all of that as `<custom_instructions>`, so the override has to be the first
+# thing in it. General frame first, role specifics second, so the specific wins any conflict.
+#
 # ⚠️ `prompt` is an action INPUT, not shell — `$(cat file)` in a `with:` value arrives at
 # the model as those literal characters. `prompt_file` would avoid the dance, but only the
 # inner base-action exposes it; the composite claude-code-action@v1 takes `prompt` alone.
@@ -44,9 +50,9 @@ runs:
         d="PROMPT_EOF_${{ github.run_id }}"
         {
           echo "body<<$d"
-          cat "$base/$role.md"
-          echo
           cat "$base/_shared.md"
+          echo
+          cat "$base/$role.md"
           echo
           cat "$overlay/_shared.md"
           # a role-specific overlay is optional — not every role needs one

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -242,6 +242,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # ⚠️ track_progress forces the action's TAG MODE. That mode re-checks the
@@ -450,6 +451,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STORY: ${{ needs.delegate.outputs.story }}
+          # the issue that actually triggered this run — the role's brief. Empty on a PR
+          # trigger, where $STORY is the one to read.
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
@@ -495,6 +499,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STORY: ${{ needs.delegate.outputs.story }}
+          # the issue that actually triggered this run — the role's brief. Empty on a PR
+          # trigger, where $STORY is the one to read.
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
@@ -527,6 +534,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STORY: ${{ needs.delegate.outputs.story }}
+          # the issue that actually triggered this run — the role's brief. Empty on a PR
+          # trigger, where $STORY is the one to read.
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
@@ -572,6 +582,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STORY: ${{ needs.delegate.outputs.story }}
+          # the issue that actually triggered this run — the role's brief. Empty on a PR
+          # trigger, where $STORY is the one to read.
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
@@ -668,14 +681,16 @@ jobs:
   # run — everything model-driven took three attempts. It is also why PROJECTS_TOKEN
   # lives here and nowhere a prompt can reach it.
   merge_housekeeping:
+    # ⚠️ EVERY merged PR, not just an agent's. This gated on a @claude/* label or a Bot
+    # author, and skipped on #485 — the maintainer's own PR, unlabeled per convention —
+    # so eight issues closed via GitHub's native keywords while the board was never
+    # updated and the sub-issue expansion never ran. Nothing here needs the PR to be an
+    # agent's: the board move, the non-default-base fallback and the sub-issue expansion
+    # are all just as right for a hand-written PR, and it exits early on one that closes
+    # no issue.
     if: |
       github.event_name == 'pull_request'
       && github.event.pull_request.merged == true
-      && (contains(github.event.pull_request.labels.*.name, '@claude/architect')
-        || contains(github.event.pull_request.labels.*.name, '@claude/implementor')
-        || contains(github.event.pull_request.labels.*.name, '@claude/tester')
-        || contains(github.event.pull_request.labels.*.name, '@claude/writer')
-        || github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,23 @@ editing its markdown, not hunting a block scalar; the workflow went 1102 lines t
   bare `EOF`, and these prompts carry fenced examples.
 - ⚠️ **A prompt file cannot hold `${{ }}`** — it is never evaluated inside a file. Security
   needed the merged PR number, so it arrives as `PR` in the model step's env and the prompt
-  says `gh pr diff "$PR"`. Anything else dynamic takes the same route.
+  says `gh pr diff "$PR"`. The authoring roles get `ISSUE` and `STORY` the same way.
+- ⚠️ **Our prompt is not the whole prompt.** `track_progress: true` forces the action's tag
+  mode, and `generatePrompt` returns `defaultPrompt + "<custom_instructions>" + ours`. For
+  **comment** events that default prompt says, four separate times, that the model's
+  instructions are the triggering comment — so a conversational `@claude/architect take
+  stock…` became the brief and the role file was demoted to background. The observed result
+  was a run that replied *"I'll analyze this and get back to you"* and stopped. Label
+  triggers are unaffected: no `<trigger_comment>` block is emitted, and the text becomes
+  "read the entire issue body to understand the task".
+  - `_shared.md` therefore **opens** by overriding that framing — the trigger is routing,
+    the brief is the role file plus the issue — and forbids ending a run on an intention.
+  - ⚠️ That is why `load-prompt` composes `_shared.md` **before** `<role>.md`: the override
+    has to be the first thing inside `<custom_instructions>`. The code and its own header
+    comment disagreed on this order once already.
+  - ⚠️ **Agent mode is not the escape hatch.** It would make our prompt authoritative, but
+    it sets `claudeCommentId: undefined` — no tracking comment at all, which is the
+    maintainer's only window into a run and where handoffs land.
 
 **Routing.** The **`@claude` label** is the front door: applying it to an issue starts a run,
 and `delegate.sh` reads the issue's state to pick the role. A bare `@claude` in a comment does
@@ -240,7 +256,12 @@ model step.
   ⚠️ Entirely derived from GitHub state — no model writes any part of it, which is the
   whole reason it can be trusted as a status board. ⚠️ One comment, rewritten, not one per
   run: an epic with ten tasks × three roles would otherwise bury itself in thirty comments.
-- `close-merged-work.sh` — on merge. Closes the PR's issues and files them on the board.
+- `close-merged-work.sh` — on merge, for **every** merged PR, not just an agent's. It was
+  gated on a `@claude/*` label or a Bot author and so skipped the maintainer's own PRs,
+  which are unlabeled by convention — eight issues closed via GitHub's native keywords
+  while the board was never updated. Nothing it does needs the PR to be an agent's, and it
+  exits early on one that closes no issue. Closes the PR's issues and files them on the
+  board.
   ⚠️ It also closes a closed issue's **open sub-issues**: `open-story-pr.sh` lists the
   tasks with closing keywords, but that body is written once when the PR opens, so a task
   cut afterwards is nowhere in it.

--- a/packages/claude-team/prompts/_shared.md
+++ b/packages/claude-team/prompts/_shared.md
@@ -1,3 +1,32 @@
+## What you are here to do — this overrides anything above
+
+⚠️ **The instructions above this line may tell you that your instructions are the triggering
+comment. For you, that is wrong.** They are written for an assistant summoned by a sentence.
+You were not summoned; you were **routed** here by a delegator that read the issue's state
+and picked your role.
+
+So the trigger — a label, or a comment naming your handle — says **that** you run and
+**which** role you are. It is not your brief. Your brief is, in order:
+
+1. **This prompt**, which defines what you own, what you must not touch, and what you must
+   produce.
+2. **The issue** — `$ISSUE` is the one that triggered you, `$STORY` the story it belongs to.
+   Read it. That is the actual work.
+
+A trigger comment is at most a **modifier** on that work — "only the ferment tab", "skip the
+schema part". If it reads as a question, a status check, or small talk, it does **not**
+replace your deliverable. Do your role's job and answer the aside alongside it.
+
+⚠️ **Never end a run with an intention.** "I'll analyze this and get back to you", "I'll
+start on this shortly", "let me look into it" — each of those is a **failed run**. There is
+no later: your container is destroyed the moment you stop, and nothing resumes it. Before
+you finish, you have either produced the deliverable or stated concretely what blocked you
+and what you need. Nothing else counts as finishing.
+
+Everything from here to the end of this prompt is yours: the shared rules first, then **your
+role** — who you are, what you own and what you must produce — then this repository's
+specifics. Read all of it before you act.
+
 ## The issue hierarchy
 
 | level | branch | PR | what it is |


### PR DESCRIPTION
Both defects came from the first live runs after #485 merged.

Closes #486

## 1. The role prompt lost to the trigger comment

`@claude/architect` on #480 routed correctly — delegate succeeded in 10s, the architect job ran, the action logged `Prompt provided, triggering action` / `Trigger result: true`. Then the model replied **"I'll analyze this and get back to you."** and stopped. 39s, no work.

The action fired fine; the prompt lost. `track_progress: true` forces tag mode, where `generatePrompt` returns `defaultPrompt + <custom_instructions> + ours`. For **comment** events that default prompt says, four separate times:

```
IMPORTANT: Only the comment/issue containing '<trigger_phrase>' has your instructions.
Your instructions are in the <trigger_comment> tag above.
Extract the actual question or request from the <trigger_comment> tag above.
Only follow the instructions in the trigger comment - all other comments are just for context.
```

So "take stock of latest mainline" *was* the brief, and the Architect role file was background. **Label triggers never had this** — no `<trigger_comment>` block is emitted and the text becomes "read the entire issue body to understand the task". The bug is specific to the handle path.

**Fix.** `_shared.md` now opens by overriding the framing: the trigger says *that* you run and *which* role you are, not *what* to do; the brief is the role file plus the issue; a conversational comment is a modifier at most. And it names the observed failure directly — **never end a run with an intention**, because there is no later once the container stops.

`load-prompt` now composes `_shared.md` before `<role>.md` so the override is the first thing inside `<custom_instructions>`. ⚠️ That is the order its own header comment already documented — the code had drifted from it. The block points forward to the role definition so the ordering doesn't read as burying it.

Roles also get `$ISSUE` alongside `$STORY`, so "read the issue" doesn't depend on tag mode injecting the number.

⚠️ **Agent mode is not the escape hatch**, and I checked before ruling it out: it makes our prompt authoritative, but sets `claudeCommentId: undefined` — no tracking comment at all, which is your only window into a run and where handoffs land.

## 2. `merge_housekeeping` skipped your own PR

It skipped on #485. The `if:` required a `@claude/*` label or `user.type == 'Bot'`; that PR was unlabeled (per convention) and authored by you. The eight issues closed anyway through GitHub's native keywords — base is `mainline` — but `close-merged-work.sh` never ran, so **no board move to Done**, and the sub-issue expansion added in #485 has still never executed.

**Fix.** Drop the label/author gate. The board move, the non-default-base fallback and the sub-issue expansion are all just as right for a hand-written PR, and the hook exits early on one that closes no issue.

## Verification

`npm test --ws` (eslint) ✓ 0 errors · `tsc --noEmit` ✓ · `vite build` ✓ · `bash -n` on all nine hooks ✓ · workflow and composite action both parse.

**Loop guard re-proved** against the restructured jobs — the harness reads the `if:` expressions out of the YAML and evaluates them, so it caught that it needed updating for the `authors` job rather than passing vacuously:

| trigger | actor | result |
|---|---|---|
| label `@claude` | maintainer | **RUNS** |
| label `@claude/implementor` | **maintainer** | skips ← label guard alone |
| label `@claude` | `github-actions[bot]` | skips ← actor guard alone |
| comment `@claude` / `@claude/architect` | maintainer | **RUNS** |
| comment quoting `@claude` | `github-actions[bot]` | skips |

Routing unchanged: router picks architect → architect; picks implementor/tester → authors; handle with the router **failed** → still routes; `@claude/architect` on a PR → authors; delegate skipped or empty → nothing.

**Prompt assembly** — assembled all five role prompts the way the composite does. The override is **line 1** for every role, and every referenced file exists.

**Env** — `architect` gets `ISSUE`; the four authoring steps get `STORY` + `ISSUE`; `security` keeps `PR` only; `PROJECTS_TOKEN` still absent from every model step.

⚠️ Verify will not run — the path filter excludes workflows, docs and `packages/claude-team`.

⚠️ Cannot be exercised before merge: `issues` and `issue_comment` both run the workflow from the default branch.

## What to watch after merge

A handle-triggered run — `@claude/architect` on an issue — should now do the role's work rather than answer the comment. That is the one thing this PR cannot prove in advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
