### PR TITLE
Restore the exact handle as each role's trigger_phrase

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -245,14 +245,15 @@ jobs:
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # ⚠️ track_progress forces the action's TAG MODE. That mode re-checks the
-          # trigger phrase independently of our `if:` — but checkContainsTrigger() returns
-          # early on `if (prompt) return true`, and we always pass a prompt, so the phrase
-          # is inert at v1 (verified at v1.0.183). It is "@claude" rather than
-          # "@claude/architect" because a LABEL trigger carries no comment for a per-role
-          # phrase to match: if that short-circuit ever goes away, "@claude" still matches
-          # the comment path and a per-role phrase would fail every role at once.
-          trigger_phrase: "@claude"
+          # ⚠️ THE EXACT HANDLE, and this is load-bearing. trigger_phrase does NOT gate
+          # anything for us — checkContainsTrigger() returns early on `if (prompt) return
+          # true` and we always pass a prompt. Its ONLY effect is that the action extracts
+          # everything AFTER this phrase as "the user request" and yields it as the final
+          # content block, which the CLI scans for a SLASH COMMAND. Set to a bare "@claude",
+          # the comment "@claude/architect do X" extracts as "/architect do X" — dispatched as an
+          # unknown slash command, so the run returns success in ~150ms having never called
+          # the model. Every comment-triggered role was dead this way between #485 and #488.
+          trigger_phrase: "@claude/architect"
           track_progress: true
           prompt: ${{ steps.prompt.outputs.body }}
           # Read-and-write-issues only; no build tools needed for shaping an epic.
@@ -456,7 +457,15 @@ jobs:
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          trigger_phrase: "@claude"
+          # ⚠️ THE EXACT HANDLE, and this is load-bearing. trigger_phrase does NOT gate
+          # anything for us — checkContainsTrigger() returns early on `if (prompt) return
+          # true` and we always pass a prompt. Its ONLY effect is that the action extracts
+          # everything AFTER this phrase as "the user request" and yields it as the final
+          # content block, which the CLI scans for a SLASH COMMAND. Set to a bare "@claude",
+          # the comment "@claude/implementor do X" extracts as "/implementor do X" — dispatched as an
+          # unknown slash command, so the run returns success in ~150ms having never called
+          # the model. Every comment-triggered role was dead this way between #485 and #488.
+          trigger_phrase: "@claude/implementor"
           track_progress: true
           prompt: ${{ steps.p_implementor.outputs.body }}
           # Allowlist by *family*, not per-subcommand. Deliberately NOT bare `Bash`: this
@@ -504,7 +513,15 @@ jobs:
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          trigger_phrase: "@claude"
+          # ⚠️ THE EXACT HANDLE, and this is load-bearing. trigger_phrase does NOT gate
+          # anything for us — checkContainsTrigger() returns early on `if (prompt) return
+          # true` and we always pass a prompt. Its ONLY effect is that the action extracts
+          # everything AFTER this phrase as "the user request" and yields it as the final
+          # content block, which the CLI scans for a SLASH COMMAND. Set to a bare "@claude",
+          # the comment "@claude/designer do X" extracts as "/designer do X" — dispatched as an
+          # unknown slash command, so the run returns success in ~150ms having never called
+          # the model. Every comment-triggered role was dead this way between #485 and #488.
+          trigger_phrase: "@claude/designer"
           track_progress: true
           prompt: ${{ steps.p_designer.outputs.body }}
           claude_args: |
@@ -539,7 +556,15 @@ jobs:
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          trigger_phrase: "@claude"
+          # ⚠️ THE EXACT HANDLE, and this is load-bearing. trigger_phrase does NOT gate
+          # anything for us — checkContainsTrigger() returns early on `if (prompt) return
+          # true` and we always pass a prompt. Its ONLY effect is that the action extracts
+          # everything AFTER this phrase as "the user request" and yields it as the final
+          # content block, which the CLI scans for a SLASH COMMAND. Set to a bare "@claude",
+          # the comment "@claude/tester do X" extracts as "/tester do X" — dispatched as an
+          # unknown slash command, so the run returns success in ~150ms having never called
+          # the model. Every comment-triggered role was dead this way between #485 and #488.
+          trigger_phrase: "@claude/tester"
           track_progress: true
           # ⚠️ The handoff arrives as prompt CONTEXT, not as something to go and find.
           # Implementor OR Designer, whichever authored — they are alternatives and emit the
@@ -587,7 +612,15 @@ jobs:
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          trigger_phrase: "@claude"
+          # ⚠️ THE EXACT HANDLE, and this is load-bearing. trigger_phrase does NOT gate
+          # anything for us — checkContainsTrigger() returns early on `if (prompt) return
+          # true` and we always pass a prompt. Its ONLY effect is that the action extracts
+          # everything AFTER this phrase as "the user request" and yields it as the final
+          # content block, which the CLI scans for a SLASH COMMAND. Set to a bare "@claude",
+          # the comment "@claude/writer do X" extracts as "/writer do X" — dispatched as an
+          # unknown slash command, so the run returns success in ~150ms having never called
+          # the model. Every comment-triggered role was dead this way between #485 and #488.
+          trigger_phrase: "@claude/writer"
           track_progress: true
           # The Writer sees the author's candidates directly — Implementor or Designer,
           # whichever ran. ⚠️ Still a proposal, not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,11 +200,21 @@ add, so remove-and-re-add re-runs the delegator against current issue state.
 `always() && (router picked me || the comment names me)`, so an explicit handle still routes if
 `delegate.sh` fails outright. Only a *skipped* delegate skips the roles.
 
-⚠️ `trigger_phrase` is `@claude` on every role, not `@claude/<role>`. A label trigger carries no
-comment for a per-role phrase to match. It is inert today regardless — `checkContainsTrigger()`
-returns early on `if (prompt) return true` and we always pass a prompt (verified at `v1.0.183`)
-— but if that short-circuit ever goes, `@claude` still matches the comment path where a
-per-role phrase would fail every role at once.
+⚠️ **`trigger_phrase` must be the role's exact handle, `@claude/<role>`.** It does **not** gate
+anything for us — `checkContainsTrigger()` returns early on `if (prompt) return true` and we
+always pass a prompt. Its only effect is that the action extracts everything *after* the phrase
+as "the user request" (`src/utils/extract-user-request.ts`) and yields it as the **final content
+block**, which the CLI scans for a slash command. Set to a bare `@claude`, the comment
+`@claude/architect do X` extracts as `/architect do X` — dispatched as an unknown slash command,
+so the run returns success in ~150ms with `num_turns: 0` having never called the model. Every
+comment-triggered role was dead this way between #485 and #488. Label triggers were unaffected:
+no comment means no user-request block.
+
+⚠️ **A dead run looks like a working one.** It reports success, raises no error, and leaves the
+comment reading *"I'll analyze this and get back to you."* — which is **not a model response**
+but `createCommentBody()`, the action's hardcoded placeholder, never updated. Diagnose a
+suspicious run by `num_turns` in the log, never by the comment: #487 was built on the assumption
+that sentence was the model talking, and fixed something else entirely.
 
 ⚠️ The Architect requires `!github.event.issue.pull_request` on its handle arm — `issue_comment`
 fires for PRs too, and without the guard a PR comment started a role written for an epic issue.


### PR DESCRIPTION
Every comment-triggered role has been dead since #485 — the model was never invoked. Restores the exact handle as each role's `trigger_phrase`.

Closes #488

## The evidence

Same issue (#480), same Architect, either side of #485:

| run | when | num_turns | cost | duration |
|---|---|---|---|---|
| 30855933152 | before | **54** | $1.68 | 415s |
| 30861391111 | after | **0** | $0 | **149ms** |

`is_error: false`, `permission_denials_count: 0`. The run reports **success**.

## The cause

`trigger_phrase` does not gate anything for us — `checkContainsTrigger()` returns early on `if (prompt) return true` and we always pass a prompt. Its only effect is that the action extracts everything *after* the phrase as "the user request" (`src/utils/extract-user-request.ts`), and `base-action/src/run-claude-sdk.ts` yields that as the **final content block**, commented:

> This allows the CLI to detect and process slash commands in the user request

| trigger_phrase | `@claude/architect take stock…` extracts as |
|---|---|
| `@claude/architect` | `take stock…` |
| `@claude` | `/architect take stock…` ← **leading slash** |

`/architect …` is dispatched as an unknown slash command, so the CLI returns immediately without ever calling the model.

My reasoning in #485 was backwards. I broadened the phrase because a label trigger carries no comment for `@claude/<role>` to match — but that is exactly why a per-role phrase is safe there: no comment means no user-request block at all. It is the *bare* phrase that breaks the comment path.

## ⚠️ Why this looked like something else

The run succeeds, raises no error, and leaves a comment reading **"I'll analyze this and get back to you."** That is not a model response — it is `createCommentBody()` in `src/github/operations/comments/common.ts`, the action's hardcoded placeholder, never updated because nothing ran.

I read that sentence as the model replying conversationally and built **#487** on it. That PR's `merge_housekeeping` half was real and is proven working (`Issue #486 -> Done` in the live log). Its prompt-precedence half fixed a problem I had no evidence for — the quoted default-prompt text is real, but its effect on behaviour remains untested. Those changes are defensible on their own and stay; I am no longer claiming they fixed anything.

`CLAUDE.md` now says to diagnose a suspicious run by `num_turns`, never by the comment.

## Verification

`npm test --ws` (eslint) ✓ 0 errors · `tsc --noEmit` ✓ · `vite build` ✓ · workflow parses.

**Every model step's phrase is tied to the role its own prompt loads** — derived from `steps.p_<role>.outputs.body`, not from the step name, so a renamed step cannot fool it:

```
architect "@claude/architect" · implementor "@claude/implementor" · designer "@claude/designer"
tester "@claude/tester" · writer "@claude/writer" · security none (merge-triggered)
```

**Extraction, run against the real values:** `@claude/<role> do X` → `"do X"` for all five, none with a leading slash. And the regression re-created: with a bare `@claude` all five produce `/<role> do X`.

**Routing unchanged** — the loop guard and delegator gates re-evaluated from the YAML: label `@claude/implementor` from a *maintainer* still skips (label guard alone), `@claude` from a bot still skips (actor guard alone), handle-with-failed-router still routes, delegate skipped → nothing runs.

⚠️ Verify will not run — the path filter excludes workflows and docs.

⚠️ Cannot be exercised before merge.

## After merge

Comment `@claude/architect …` on an issue and check the run log for **`num_turns` > 0**. A comment appearing proves nothing — that is the placeholder, and it is what made this take two attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
