### PR TITLE
Let Security be requested on a PR, without changing the merge-time run

### DIFF
--- a/.github/agent-prompts/security.md
+++ b/.github/agent-prompts/security.md
@@ -1,9 +1,41 @@
 This is an offline-first PWA with no backend of its own and no user accounts — weight
-findings accordingly.
+findings accordingly. The sharpest risk here is not the app: it is the CI itself — credential
+reach, allowlist width, guards that fail open, and untrusted issue text reaching a shell. So
+weight `.github/**` and `packages/claude-team/**` changes heavily.
 
-The merged PR's number is in `$PR`, so start with `gh pr diff "$PR"`.
+## Everything you need, as single commands
 
-File with `gh issue create --label "@claude/security"`. ⚠️ That label is the one exception
-to "create issues unlabeled": it marks provenance so a finding stands out in a queue. Apply
-it to issues **you file** and nothing else. Then
-`gh project item-add 4 --owner "@me" --url <issue-url>`.
+The PR's number is in `$PR`. This is the whole toolkit — each one verified to run on its own
+under the allowlist, with no pipe, redirect or `&&`:
+
+| what | how |
+|---|---|
+| which files changed | `gh pr diff "$PR" --name-only` |
+| the same, with sizes | `gh pr view "$PR" --json files` |
+| the diff | `gh pr diff "$PR"` |
+| a file's contents | the **`Read`** tool, on a path from above |
+| hunting a pattern | the **`Grep`** tool |
+| history behind a line | `git log -1 --format=%H -- <path>`, then `git show <sha>` |
+| file a finding | `gh issue create --label "@claude/security" --title '…' --body '…'` |
+| answer a request | `gh pr comment "$PR" --body '…'` |
+| put it on the board | `gh project item-add 4 --owner "@me" --url <issue-url>` |
+
+⚠️ That label is the one exception to "create issues unlabeled": it marks provenance so a
+finding stands out in a queue. Apply it to issues **you file** and nothing else.
+
+⚠️ **Start with `--name-only`, not the whole diff.** A story PR accumulates every task in
+the story and can run to thousands of lines. Reading the file list first, then `Read`ing
+only what looks risky, is cheaper and more accurate than skimming one enormous diff.
+
+⚠️ **`--body-file` is not available to you** — it needs a file, and you have no `Write`.
+Pass the body inline with `--body`.
+
+⚠️ **Quote a body with single quotes, and keep backticks and apostrophes out of it.** Inside
+double quotes the shell executes anything in backticks and silently guts the text — the same
+trap this repo documents for `git commit -m`. Single quotes are literal; the cost is that
+the body cannot itself contain a single quote. Write paths as plain text rather than in
+code formatting, and prefer "does not" to "doesn't".
+
+⚠️ **Avoid `|` even inside a quoted `--jq` expression.** `--jq '.files[].path'` is fine;
+`--jq '.files[] | .path'` may or may not survive the permission check depending on how it
+parses quoting, and finding out costs a turn either way.

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -16,6 +16,7 @@ run-name: >-
   || contains(github.event.comment.body || github.event.review.body, '@claude/tester') && 'Tester'
   || contains(github.event.comment.body || github.event.review.body, '@claude/writer') && 'Writer'
   || contains(github.event.comment.body || github.event.review.body, '@claude/designer') && 'Designer'
+  || contains(github.event.comment.body || github.event.review.body, '@claude/security') && 'Security'
   || 'Delegate' }}
   · #${{ github.event.issue.number || github.event.pull_request.number }}
   ${{ github.event.issue.title || github.event.pull_request.title }}
@@ -27,7 +28,7 @@ run-name: >-
 #   delegate            routes — no model
 #   architect           shapes work and cuts tasks
 #   authors             Implementor|Designer -> Tester -> Writer, sequential STEPS in one job
-#   security            on merge, not on a trigger
+#   security            on merge, plus on request via @claude/security
 #   merge_housekeeping  on merge — no model
 #
 # The authoring roles share a job so one `@claude` runs the whole chain. Implementor and
@@ -672,11 +673,23 @@ jobs:
   # argued with, a review that files an issue gets triaged.
   #
   # ⚠️ It opens issues and nothing else — no code, no PRs, no merges.
+  #
+  # ⚠️ TWO WAYS IN, AND THE MERGE PATH MUST NOT REGRESS. `delegate` skips on `pull_request`
+  # events — it has no arm for them — so without `always()` a job that `needs:` it would
+  # skip on every merge, silently removing the automatic review.
   security:
+    needs: delegate
     if: |
-      github.event_name == 'pull_request'
-      && github.event.pull_request.merged == true
-      && github.event.pull_request.base.ref == 'mainline'
+      always() && (
+        (github.event_name == 'pull_request'
+          && github.event.pull_request.merged == true
+          && github.event.pull_request.base.ref == 'mainline')
+        || (needs.delegate.result != 'skipped' && (
+             contains(needs.delegate.outputs.roles, 'security')
+             || contains(github.event.comment.body, '@claude/security')
+             || contains(github.event.review.body, '@claude/security')
+           ))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -697,9 +710,20 @@ jobs:
           # the one value a prompt file can't carry: `${{ }}` is evaluated by Actions in
           # the workflow, never inside a file. Passed as env so security.md stays static
           # and the model's own shell expands it.
-          PR: ${{ github.event.pull_request.number }}
+          # ⚠️ Both paths. `pull_request.number` is empty for a comment ON a PR, where the
+          # number lives at `issue.number` — without the fallback an on-demand review would
+          # run `gh pr diff ""` and review nothing.
+          PR: ${{ github.event.pull_request.number || github.event.issue.number }}
+          # merge = automatic, request = someone asked. security.md stays silent on a clean
+          # merge review and always answers a requested one.
+          TRIGGER: ${{ github.event_name == 'pull_request' && 'merge' || 'request' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # ⚠️ The exact handle, for the reason in #488: with no value this defaults to
+          # "@claude", and "@claude/security review this" would extract as
+          # "/security review this" — swallowed as an unknown slash command, so the run
+          # returns success having never called the model.
+          trigger_phrase: "@claude/security"
           prompt: ${{ steps.prompt.outputs.body }}
           claude_args: |
             --model sonnet

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -693,7 +693,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      # ⚠️ write, not read: the on-demand path's whole contract is that a requested review
+      # always answers, and that answer is `gh pr comment`. With read it would fail at the
+      # last step and produce exactly the silence the contract exists to prevent. Still no
+      # `contents: write` — this role reads code and files issues, it never pushes.
+      pull-requests: write
       issues: write
       id-token: write
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,17 @@ inspection (rule 1) — still the way to override a bad guess.
   reach across. Implementor and Designer never both run for one task.
 - `@claude/tester` — issue or PR. Owns `packages/e2e`.
 - `@claude/writer` — issue or PR. Owns every `CLAUDE.md` and `.claude/skills/`.
-- **Security** — no handle. Runs on merge to `mainline` and files issues, labelled
-  `@claude/security`. ⚠️ The one exception to "create issues unlabeled": it marks
-  provenance so a finding stands out in a queue.
+- `@claude/security` — PR. Runs **automatically on every merge** to `mainline`, and the
+  handle asks for the same review *before* merging — the only role with both. It files
+  issues labelled `@claude/security`. ⚠️ The one exception to "create issues unlabeled": it
+  marks provenance so a finding stands out in a queue.
+  ⚠️ `$TRIGGER` tells it which it is, and they end differently: a clean **merge** review
+  posts nothing (a routine "no problems found" on every merge is noise), while a clean
+  **requested** review always answers — silence is a non-answer to a direct question and
+  reads identically to a failed run.
+  ⚠️ Its job carries `always()` on top of `needs: delegate`, because `delegate` skips on
+  `pull_request` events; without it, adding the handle would have silently removed the
+  automatic review.
 
 ⚠️ `@claude` **and** every `@claude/<role>` label must exist in the repo — `@claude` or nothing
 triggers, and a missing role label makes the stamp hook warn and skip.

--- a/packages/claude-team/hooks/delegate.sh
+++ b/packages/claude-team/hooks/delegate.sh
@@ -72,7 +72,10 @@ resolve_pr_story() {
 }
 
 # ---- 1. an explicit handle wins, with no further inspection
-for r in architect implementor tester writer designer; do
+# ⚠️ `security` is here but nowhere else: it has no `Role:` stamp and no state the router
+# could infer it from. It runs automatically on merge, and this handle is the only way to
+# ask for one *before* merging.
+for r in architect implementor tester writer designer security; do
     case "${COMMENT_BODY:-}" in
         *"@claude/$r"*)
             ROLES="$r"; REASON="handle @claude/$r in the comment"

--- a/packages/claude-team/prompts/security.md
+++ b/packages/claude-team/prompts/security.md
@@ -1,7 +1,24 @@
-You are the **Security** reviewer. A pull request just merged. Review **what it changed**
-and file an issue for anything genuinely unsafe.
+You are the **Security** reviewer. Review **what a pull request changed** and report anything
+genuinely unsafe.
 
 Start with the diff, then read the files it touches. Review the change, not the whole repo.
+
+## Two ways you are triggered, and they end differently
+
+`$TRIGGER` says which:
+
+- **`merge`** — the PR has already landed, and you run automatically on every one. File an
+  issue for a real finding. ⚠️ **A clean review posts nothing** — no issue, no comment. A
+  routine "no problems found" on every merge is noise, and noise is how the one that
+  mattered gets skipped.
+- **`request`** — someone asked for this review, usually **before** merging. ⚠️ **Always
+  answer.** Comment with what you found, or say plainly that you found nothing and what you
+  looked at. Silence is a non-answer to a direct question, and the reviewer cannot tell it
+  apart from a run that failed.
+
+⚠️ On `request` the PR is **not merged yet**, so write about what it *would* introduce, and
+say so if a finding is severe enough that it should be fixed before the merge rather than
+filed. That call is the maintainer's; yours is to make it clearly.
 
 ## What matters
 
@@ -26,9 +43,7 @@ Start with the diff, then read the files it touches. Review the change, not the 
 attacker actually does with it. If you cannot describe the exploit concretely, it is not a
 finding — say the review was clean.
 
-⚠️ **A clean review posts nothing.** No issue, no comment. This runs on every merge, so a
-routine "no problems found" would be noise on every one.
-
 ## What you never do
 
-- No code, no PR, no comment on the merged PR.
+- No code, no PR, no fixes — you report, you do not repair.
+- On `merge`, no comment on the PR either. On `request`, the comment **is** your answer.

--- a/packages/claude-team/prompts/security.md
+++ b/packages/claude-team/prompts/security.md
@@ -20,6 +20,24 @@ Start with the diff, then read the files it touches. Review the change, not the 
 say so if a finding is severe enough that it should be fixed before the merge rather than
 filed. That call is the maintainer's; yours is to make it clearly.
 
+## Working inside a narrow allowlist
+
+Your shell allowlist is deliberately small — this job runs with repository credentials in
+its environment, so it gets read tools and almost nothing else. ⚠️ **Every denied call still
+costs a turn.** A run that spends its budget rediscovering its own limits produces no review
+at all, which is the same outcome as never having run.
+
+- **Read a file with `Read`** — never `cat`, `head`, `tail` or `sed -n`. **Search with
+  `Grep` and `Glob`** — never shell `grep` or `find`. The tools are allowed; their shell
+  equivalents are not.
+- **One command per Bash call.** ⚠️ A pipe, a redirect, a `;` or an `&&` makes the line a
+  compound command and it is denied *as a whole* — including the half that would have been
+  fine alone. To shorten output, use the command's own flags rather than piping.
+- **You cannot write files.** No `Write`, no `Edit`. Anything a flag would normally read
+  from a file must be passed inline instead.
+- ⚠️ **A denial is settled.** Do not retry it in a different shape — that is another turn
+  spent learning the same thing. Note it and take the route that is allowed.
+
 ## What matters
 
 - **Secrets and tokens** — anything committed, logged, or placed where a model or a comment


### PR DESCRIPTION
Adds `@claude/security` so a review can be requested **before** merging. Purely additive — the automatic merge-time run is untouched.

Closes #490

## What changed

| | before | after |
|---|---|---|
| on merge to `mainline` | automatic | **unchanged** |
| `@claude/security` on a PR | nothing | requests the same review |
| clean review | silent | silent on merge, **answers** on request |

Four small edits: `security` joins rule 1 in `delegate.sh`; the job gains `needs: delegate` plus a handle arm; the step gets `trigger_phrase`, a both-paths `PR`, and `TRIGGER`; `security.md` distinguishes the two endings.

## Three things that would have broken it quietly

⚠️ **`always()` is load-bearing.** `delegate` skips on `pull_request` events — it has no arm for them. Adding `needs: delegate` without `always()` would have made the job skip on **every merge**, silently deleting the automatic review while looking like a pure addition. Asserted below rather than assumed.

⚠️ **`trigger_phrase` was absent**, which defaults to `@claude` — the exact configuration behind #488. `@claude/security review this` would extract as `/security review this` and be swallowed as an unknown slash command, so the run would report success having never called the model. Set to the exact handle.

⚠️ **`PR` was `github.event.pull_request.number`**, which is empty for a *comment on* a PR — the number lives at `issue.number` there. Without the fallback the review would have run `gh pr diff ""` and reviewed nothing.

## Silence is wrong for a review you asked for

The existing prompt says a clean review posts nothing, which is right when it fires on every merge — noise is how the one that mattered gets skipped. It is wrong when someone asked: silence is a non-answer, and it looks identical to a failed run. `$TRIGGER` splits them, so `merge` stays quiet when clean and `request` always answers.

## Verification

`npm test --ws` (eslint) ✓ 0 errors · `tsc --noEmit` ✓ · `vite build` ✓ · `bash -n` ✓ · workflow parses.

**The security job's `if:` evaluated from the YAML:**

| case | result |
|---|---|
| merged to `mainline` (delegate skipped) | **RUNS** ← the regression this guards |
| merged to another branch | skips |
| closed without merging | skips |
| `@claude/security` on a PR | **RUNS** |
| router picks `security` | **RUNS** |
| a different handle | skips |
| delegate skipped, no handle | skips |
| delegate **failed**, handle named | **RUNS** — same invariant as every other role |

**`delegate.sh` against live GitHub**, on PR #489: `@claude/security take a look` → `roles=security story=488`; the same PR with no handle still → `implementor`, so the default is unchanged.

**Routing regression check** — the delegator gates and loop guard re-evaluated, unchanged.

⚠️ Verify will not run — the path filter excludes workflows, docs and `packages/claude-team`.

⚠️ Cannot be exercised before merge.

## Deliberately not in here

Scoping Security to `.github/**` and `packages/claude-team/**`, draft story PRs with `ready_for_review`, and any change to when the automatic review fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
