### PR TITLE
Restore Security's read-only orientation commands

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -742,15 +742,26 @@ jobs:
           # unmerged, unreviewed diffs, so its input is written by whoever authored the
           # change it is judging. `Bash(gh:*)` plus `pull-requests: write` would have let a
           # successful prompt injection run `gh pr review --approve` or `gh pr edit` on the
-          # very PR the maintainer asked it to distrust. This list is exactly what
-          # security.md's playbook uses and nothing else — `gh api` is deliberately absent,
-          # since it reaches every endpoint the token can.
+          # very PR the maintainer asked it to distrust.
+          #
+          # ⚠️ EVERY ENTRY HAS NO MUTATING FORM. That is the rule this list is built on, and
+          # why `git branch` and `git remote` are absent despite being useful for
+          # orientation. Deliberately denied, and the whole point of #492: `gh pr review`,
+          # `gh pr edit`, `gh pr merge`, `gh pr close`, `gh issue close`, `gh issue edit`,
+          # and `gh api` — which reaches every endpoint the token has and would undo the
+          # rest of this list on its own.
+          #
+          # ⚠️ TOO NARROW STARVES IT, and that failure is invisible (#494). Cut to only the
+          # playbook's own commands, the first run spent 5 of 6 turns denied and reported
+          # nothing — and on the merge path a clean review is silent, so "found nothing" and
+          # "could do nothing" look identical from outside. The read-only orientation
+          # commands a review opens with are as load-bearing as the ones that do the work.
           # ⚠️ It cannot go lower than the action's base set: `Bash(git add|commit|rm:*)`
           # and `git-push.sh` union in and cannot be removed. `contents: read` is what
           # actually stops a push, not the allowlist.
           claude_args: |
             --model sonnet
-            --allowedTools "Read,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh issue create:*),Bash(gh project item-add:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*)"
+            --allowedTools "Read,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh issue create:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh repo view:*),Bash(gh project item-add:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git status:*),Bash(git rev-parse:*),Bash(git ls-files:*),Bash(git blame:*)"
             --max-turns 40
 
   # ── Merge housekeeping ─────────────────────────────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,6 +408,17 @@ Bash(git add:*), Bash(git commit:*), Bash(git rm:*), Bash(git-push.sh:*)
   change it is judging. `Bash(gh:*)` plus `pull-requests: write` would let a successful
   prompt injection run `gh pr review --approve` on the very PR the maintainer asked it to
   distrust. `gh api` is deliberately absent — it reaches every endpoint the token has.
+  - The rule the list is built on is **no mutating form**, which is why `git branch` and
+    `git remote` are out despite being useful.
+  - ⚠️ **Too narrow starves it, and that failure is silent** (#494). Cut to only the
+    playbook's own commands, the next run spent 5 of 6 turns denied and reported nothing —
+    and a clean merge review posts nothing, so "found nothing" and "could do nothing" are
+    indistinguishable from outside. The read-only orientation commands a review opens with
+    (`git status`, `git rev-parse`, `gh pr list`, `gh issue list`) are as load-bearing as
+    the ones that do the work.
+  - ⚠️ Judge a denial count as a **rate over a whole run**, and distrust it when the run is
+    short: across three runs the absolute counts moved 8 → 4 → 5 while the rates read
+    62% → 25% → 83%.
 - ⚠️ **An allowlist has a floor no role can go below.** `Bash(git add|commit|rm:*)` and
   `git-push.sh` union in from the action's base set and cannot be removed. What stops
   Security pushing is `contents: read`, not its allowlist.


### PR DESCRIPTION
#493 narrowed Security to exactly its playbook's commands. That closed the injection path in #492, and starved it.

Closes #494

## What the third run showed

| run | playbook | allowlist | turns | denials | rate | outcome |
|---|---|---|---|---|---|---|
| #489 | old | family | 13 | 8 | 62% | clean |
| #491 | **new** | family | 16 | 4 | 25% | **filed #492** |
| #493 | new | **narrowed** | **6** | **5** | **83%** | nothing |

Six turns, 27 seconds, five denied — about one productive turn against a diff that changed an allowlist and a permission block.

⚠️ **A clean result from a run that could not act is the same false all-clear #492 was about**, reached by starvation instead of injection. On the merge path a clean review posts nothing, so "found nothing" and "could do nothing" are indistinguishable from outside. That is the part worth remembering: over-narrowing fails silently and looks like success.

## The cause

Dropping `Bash(gh:*)` and `Bash(git:*)` also removed the orientation commands a review opens with. None of them is the capability #492 was about.

## What changed

Restored, chosen on one rule — **no mutating form**:

```
git status   git rev-parse   git ls-files   git blame
gh pr list   gh pr checks    gh issue view  gh issue list   gh repo view
```

⚠️ `git branch` and `git remote` stay out despite being useful for orientation. Both have mutating forms, and while `contents: read` plus an ephemeral container makes a local mutation inert, "read-only" should mean it rather than rely on a second control.

⚠️ Still denied, and **asserted rather than assumed**: `gh pr review`, `gh pr edit`, `gh pr merge`, `gh pr close`, `gh issue close`, `gh issue edit`, `gh api`, `gh secret`, `gh workflow`, `gh release`. The four capabilities #492 named are untouched by this PR.

## Verification

`npm test --ws` (eslint) ✓ 0 errors · `tsc --noEmit` ✓ · `vite build` ✓ · workflow parses.

Against the parsed YAML: 18 allowlist entries; every capability from #492 denied; no family grants; no `Write`/`Edit`; no entry matching any of eleven mutating git subcommands; and every `gh`/`git` command in the assembled playbook still covered, parsed out of `security.md` so the two cannot drift apart silently.

Routing and loop guard re-evaluated, unchanged.

⚠️ **This is n=1 per configuration across three different PRs**, and a rate computed over 6 turns is noisy. The absolute counts moved 8 → 4 → 5 while the rates read 62% → 25% → 83%. I acted on the third run as a signal, not as proof — the next merge is data point 4.

⚠️ Verify will not run — the path filter excludes workflows, docs and `packages/claude-team`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
