### PR TITLE
Persist the author handoff, and split Writer per epic from Tester per story

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -27,13 +27,15 @@ run-name: >-
 #
 #   delegate            routes — no model
 #   architect           shapes work and cuts tasks
-#   authors             Implementor|Designer -> Tester -> Writer, sequential STEPS in one job
+#   authors             Implementor | Designer | Tester | Writer — one per run, gated steps
 #   security            on merge, plus on request via @claude/security
 #   merge_housekeeping  on merge — no model
 #
-# The authoring roles share a job so one `@claude` runs the whole chain. Implementor and
-# Designer are alternatives — a task is one or the other, split on the package it touches.
-# See that job's header for why they are steps and not `needs:`.
+# ⚠️ THE AUTHORS JOB IS NOT A CHAIN, and briefly claimed to be (#500). `delegate.sh` emits
+# exactly ONE role, so exactly one of its gated steps ever runs. That is deliberate now:
+# the Architect cuts a `Role: tester` task per story and a docs story per epic, so the
+# Tester and Writer are triggered on their own work rather than dragged behind every author.
+# They share a job to share its setup, not to run in sequence.
 #
 # ⚠️ THE DELEGATOR ROUTES. Two ways in, one router:
 #
@@ -74,6 +76,7 @@ run-name: >-
 #   post  architect       file-sub-issues.sh       parents stories to epics, tasks to stories
 #   post  authors job     finish-pr.sh             labels the PR, appends `Closes #<issue>`
 #   post  authors job     open-story-pr.sh         opens the story's PR if it has none
+#   post  authors job     post-handoff.sh          puts the JSON handoff on the story's PR
 #   post  authors job     log-to-epic.sh           rewrites the epic's rolling work log
 #   merge (no role)       close-merged-work.sh     closes the PR's issues, files them on the board
 #
@@ -277,23 +280,30 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
         run: "$RUNNER_TEMP/agent-bin/file-sub-issues.sh"
-  # ── Authors: Implementor | Designer → Tester → Writer ──────────────────────────
-  # The authoring roles as sequential STEPS in one job, so a single `@claude` on a task
-  # runs the whole chain with no further input from the maintainer. Implementor and Designer
-  # are alternatives — a task is one or the other, split on the package it touches.
+  # ── Authors: Implementor | Designer | Tester | Writer ──────────────────────────
+  # The four authoring roles as gated steps in one job. ⚠️ EXACTLY ONE RUNS PER TRIGGER —
+  # `delegate.sh` emits a single role, and each step gates on it. They share a job to share
+  # its setup (checkout, prompts, npm ci), not to run in sequence.
   #
-  # ⚠️ STEPS, NOT `needs:`. #430 reverted role chaining because `needs:` ACROSS JOBS left
-  # the followers queued behind every run, and a job that skips after waiting reports as
-  # cancelled — the history filled with cancelled entries. Sequential steps have no job
-  # graph, so none of that applies. Do not reach for `needs:` here; that is the shape that
-  # failed. (The one `needs:` in this file, on `delegate`, is a different case — see the
-  # header.)
+  # Implementor and Designer are alternatives, split on the package a task touches. The
+  # Tester is triggered by its own `Role: tester` task, cut per story; the Writer by a docs
+  # story cut per epic, so documentation lands in one pass from one branch.
   #
-  # ⚠️ BUDGET. Three model runs back to back — an author at opus 80 turns, then sonnet 80,
-  # then sonnet 60: 220 turns on one runner, plus `npm ci` and a browser install. By a wide
-  # margin the longest job here. Implementor and Designer never both run, so 220 is the
-  # ceiling, not 300. A single-role run is unaffected: the other model steps skip and their
-  # setup skips with them.
+  # ⚠️ DO NOT REACH FOR `needs:` BETWEEN THESE STEPS if the chain idea returns. #430 tried
+  # role chaining across jobs: the followers sat queued behind every run, and a job that
+  # skips after waiting reports as cancelled, so the history filled with cancelled entries.
+  # (The one `needs:` in this file, on `delegate`, is a different case — see the header.)
+  #
+  # ⚠️ AND #500 IS WHY CHAINING DID NOT SIMPLY MOVE HERE. As steps the job graph problem
+  # goes away, but `delegate.sh` emits one role, so the steps never co-fired and the
+  # `structured_output` handoff between them never had a consumer — shipped, closed, and
+  # dead for both #475 and #476. The handoff now travels by comment (`post-handoff.sh`)
+  # precisely so roles do NOT have to share a run to hand off.
+  #
+  # ⚠️ BUDGET is per role, not cumulative, because only one runs: opus 80 for an author,
+  # sonnet 80 for the Tester, sonnet 120 for the Writer. The Writer is the highest because
+  # it reads a whole epic — every story, its PR and its handoff comments — where the others
+  # read one task.
   #
   # ⚠️ EACH ROLE GETS ITS OWN TRACKING COMMENT, because `use_sticky_comment` is not set —
   # the action reuses a comment only when it is. That is what keeps the Implementor's
@@ -567,20 +577,11 @@ jobs:
           # the model. Every comment-triggered role was dead this way between #485 and #488.
           trigger_phrase: "@claude/tester"
           track_progress: true
-          # ⚠️ The handoff arrives as prompt CONTEXT, not as something to go and find.
-          # Implementor OR Designer, whichever authored — they are alternatives and emit the
-          # same schema, so `||` takes the one that ran (an unrun step's output is empty,
-          # which is falsy). Empty when neither ran (a Tester-only trigger) or when the
-          # author's step failed — exactly why `testingNotes: []` and an absent block have
-          # to read differently. The prompt says how to tell them apart.
-          prompt: |
-            ${{ steps.p_tester.outputs.body }}
-
-            ## Handoff from the Implementor
-
-            ```json
-            ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output }}
-            ```
+          # ⚠️ NO handoff is appended here. Only one role runs per trigger (#500), so an
+          # author's `structured_output` is never available to this step — it would always
+          # render an empty fenced block and contradict the prompt, which sends the Tester to
+          # the Handoff comments on the story's PR instead.
+          prompt: ${{ steps.p_tester.outputs.body }}
           claude_args: |
             --model sonnet
             --allowedTools "Edit,Write,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
@@ -623,22 +624,13 @@ jobs:
           # the model. Every comment-triggered role was dead this way between #485 and #488.
           trigger_phrase: "@claude/writer"
           track_progress: true
-          # The Writer sees the author's candidates directly — Implementor or Designer,
-          # whichever ran. ⚠️ Still a proposal, not
-          # an order — a schema must not imply obligation, and rejecting every candidate
-          # stays a correct outcome. writer.md carries that.
-          prompt: |
-            ${{ steps.p_writer.outputs.body }}
-
-            ## Handoff from the Implementor
-
-            ```json
-            ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output }}
-            ```
+          # ⚠️ NO handoff appended — same reason as the Tester. The Writer reads Handoff
+          # comments across the whole epic, which is why it runs from its own docs story.
+          prompt: ${{ steps.p_writer.outputs.body }}
           claude_args: |
             --model sonnet
             --allowedTools "Read,Edit,Write,Bash(git:*),Bash(gh:*)"
-            --max-turns 60
+            --max-turns 120
 
       # ── Once, for the job ──
       - name: Label and link the PR
@@ -658,6 +650,18 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         run: "$RUNNER_TEMP/agent-bin/open-story-pr.sh"
+      - name: Persist the author's handoff
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          ROLES: ${{ steps.roles.outputs.list }}
+          # whichever author ran — they are alternatives and emit the same schema, so `||`
+          # takes the one that produced output. Empty when neither ran or the step failed,
+          # which the hook treats as "nothing to post" rather than an error.
+          HANDOFF: ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output }}
+        run: "$RUNNER_TEMP/agent-bin/post-handoff.sh"
       - name: Update the epic's work log
         if: always()
         env:

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -32,10 +32,14 @@ run-name: >-
 #   merge_housekeeping  on merge — no model
 #
 # ⚠️ THE AUTHORS JOB IS NOT A CHAIN, and briefly claimed to be (#500). `delegate.sh` emits
-# exactly ONE role, so exactly one of its gated steps ever runs. That is deliberate now:
-# the Architect cuts a `Role: tester` task per story and a docs story per epic, so the
-# Tester and Writer are triggered on their own work rather than dragged behind every author.
-# They share a job to share its setup, not to run in sequence.
+# exactly ONE role, so exactly one of its gated steps ever runs. That is deliberate: the
+# Architect cuts `Role: tester` and `Role: writer` tasks per story, ordered after the
+# authoring ones, so every role is triggered on its own work rather than dragged behind
+# another. They share a job to share its setup, not to run in sequence.
+#
+# ⚠️ WHICH IS WHY THE HANDOFF TRAVELS BY COMMENT. Roles that do not share a run cannot share
+# a step output — `post-handoff.sh` puts the author's JSON on the story's PR, where the
+# Tester and Writer read it on their own triggers.
 #
 # ⚠️ THE DELEGATOR ROUTES. Two ways in, one router:
 #
@@ -301,9 +305,10 @@ jobs:
   # precisely so roles do NOT have to share a run to hand off.
   #
   # ⚠️ BUDGET is per role, not cumulative, because only one runs: opus 80 for an author,
-  # sonnet 80 for the Tester, sonnet 120 for the Writer. The Writer is the highest because
-  # it reads a whole epic — every story, its PR and its handoff comments — where the others
-  # read one task.
+  # sonnet 80 for the Tester, sonnet 80 for the Writer. The Writer was briefly 120 for an
+  # epic-wide read that this repo does not need — stories merge one at a time, so a later
+  # story already carries the previous one's docs and there is no cross-story conflict to
+  # defer around.
   #
   # ⚠️ EACH ROLE GETS ITS OWN TRACKING COMMENT, because `use_sticky_comment` is not set —
   # the action reuses a comment only when it is. That is what keeps the Implementor's
@@ -624,13 +629,13 @@ jobs:
           # the model. Every comment-triggered role was dead this way between #485 and #488.
           trigger_phrase: "@claude/writer"
           track_progress: true
-          # ⚠️ NO handoff appended — same reason as the Tester. The Writer reads Handoff
-          # comments across the whole epic, which is why it runs from its own docs story.
+          # ⚠️ NO handoff appended — same reason as the Tester. The Writer reads the Handoff
+          # comments on its own story's PR, on its own trigger.
           prompt: ${{ steps.p_writer.outputs.body }}
           claude_args: |
             --model sonnet
             --allowedTools "Read,Edit,Write,Bash(git:*),Bash(gh:*)"
-            --max-turns 120
+            --max-turns 80
 
       # ── Once, for the job ──
       - name: Label and link the PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,11 +335,11 @@ one per task, updated rather than duplicated on a re-run.
 - ⚠️ **Deterministic at both ends:** the schema forces production, the hook forces delivery.
   That is what separates it from `owner-manifest`, which asked a model to leave a
   machine-readable block and got one across nine epics exactly once.
-- **Writer once per epic, Tester once per story.** Docs describe the state a reader arrives
-  at, so one pass from one branch is both cheaper and the thing that stops two roles editing
-  the same file on parallel branches. Tests stay next to the work: written later from a cold
-  read of several merged diffs, they are further from the behaviour, which is the distance
-  the role exists to close. The Architect cuts both.
+- **Tester and Writer are cut per story**, as tasks ordered after the authoring ones, so
+  tests and docs land in the story's PR beside the code. ⚠️ An epic-wide Writer was tried
+  and dropped: the merge-conflict argument for it does not hold here, because stories merge
+  one at a time, so a later story already carries the previous one's docs. Deferring would
+  only put the explanation further from the change.
 
 - ⚠️ **Both keys are required, and `[]` is a real answer** — "I looked, there is nothing".
   A consumer that cannot tell that from "forgot" is the exact failure that killed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,11 +321,25 @@ read as "these agents have been here". The maintainer clears them as a check-off
   the link where a human reads it; the hook is the net, because a missing keyword loses the
   close and the board move with nothing to signal it.
 
-**The handoff between authors is a JSON contract**, not prose. The Implementor's step
-carries `--json-schema`, so its final message must match
+**The handoff between authors is a JSON contract**, and it travels by comment. The author's
+step carries `--json-schema`, so its final message must match
 [`packages/claude-team/schemas/handoff.json`](packages/claude-team/schemas/handoff.json) —
 `testingNotes` for the Tester, `docsCandidates` for the Writer. The action exposes it as
-`structured_output`, and the workflow appends it to the other two roles' prompts.
+`structured_output`, and `post-handoff.sh` posts it to the story's PR as a marked comment,
+one per task, updated rather than duplicated on a re-run.
+
+- ⚠️ **The transport was the broken half, not the schema** (#500). It used to be appended to
+  the Tester's and Writer's prompts from the same job — but `delegate.sh` emits ONE role, so
+  those steps never co-fired and no consumer ever saw it. #475 and #476 both closed on
+  criteria that were never met. A comment survives the run; a step output does not.
+- ⚠️ **Deterministic at both ends:** the schema forces production, the hook forces delivery.
+  That is what separates it from `owner-manifest`, which asked a model to leave a
+  machine-readable block and got one across nine epics exactly once.
+- **Writer once per epic, Tester once per story.** Docs describe the state a reader arrives
+  at, so one pass from one branch is both cheaper and the thing that stops two roles editing
+  the same file on parallel branches. Tests stay next to the work: written later from a cold
+  read of several merged diffs, they are further from the behaviour, which is the distance
+  the role exists to close. The Architect cuts both.
 
 - ⚠️ **Both keys are required, and `[]` is a real answer** — "I looked, there is nothing".
   A consumer that cannot tell that from "forgot" is the exact failure that killed

--- a/packages/claude-team/hooks/post-handoff.sh
+++ b/packages/claude-team/hooks/post-handoff.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Post-hook for the authoring job. Puts the author's JSON handoff somewhere a later role can
+# read it — the story's PR, as one marked comment per task.
+#
+# ⚠️ THE SCHEMA WAS NEVER THE BROKEN HALF. `--json-schema` forces the author to emit both
+# keys, so `[]` stays distinguishable from "forgot". What failed is that `structured_output`
+# is a STEP output: it dies with the job, and the Tester and Writer now run as their own
+# tasks. Only the transport moves here; the guarantee is unchanged.
+#
+# ⚠️ Deterministic at both ends, which is what separates this from the owner-manifest
+# failure. There, a model was asked to leave a machine-readable block and wrote one across
+# nine epics exactly once. Here the schema forces production and this hook forces delivery —
+# no step is a model instruction.
+set -euo pipefail
+
+: "${REPO:?REPO is required}"
+
+if [ -z "${HANDOFF:-}" ]; then
+    echo "No handoff to post — no author ran, or its step failed."
+    exit 0
+fi
+
+if [ -z "${ISSUE:-}" ]; then
+    echo "Not triggered on an issue — nowhere to attribute a handoff."
+    exit 0
+fi
+
+# The PR is the story's, found by the branch its issue names — same derivation as
+# open-story-pr.sh, so the two cannot disagree about which PR a task belongs to.
+body=$(gh issue view "$ISSUE" --repo "$REPO" --json body --jq '.body // ""')
+branch=$(printf '%s' "$body" | grep -oiE 'branch: *`[^`]+`' | head -1 | sed -E 's/.*`([^`]+)`.*/\1/' || true)
+
+if [ -z "$branch" ]; then
+    echo "#$ISSUE names no branch — nothing to attach a handoff to."
+    exit 0
+fi
+
+pr=$(gh pr list --repo "$REPO" --head "$branch" --state open --json number --jq '.[0].number // empty')
+if [ -z "$pr" ]; then
+    echo "::warning::no open PR for $branch — handoff for #$ISSUE not posted."
+    exit 0
+fi
+
+# ⚠️ One comment per TASK, not per story. A story has several authoring tasks and each has
+# its own handoff; keying the marker on the story would make the last one overwrite the rest.
+MARKER="<!-- claude-team:handoff:$ISSUE -->"
+
+body_file=$(mktemp)
+{
+    printf '%s\n' "$MARKER"
+    printf '### Handoff — #%s%s\n\n' "$ISSUE" "${ROLES:+ (${ROLES})}"
+    printf 'Machine-written, schema-enforced. `testingNotes` are for the Tester,\n'
+    printf '`docsCandidates` for the Writer. An empty array is a real answer — it means the\n'
+    printf 'author considered it and found nothing, which is not the same as a missing key.\n\n'
+    printf '```json\n%s\n```\n' "$HANDOFF"
+} > "$body_file"
+
+# update in place on a re-run rather than stacking another copy
+existing=$(gh api "repos/$REPO/issues/$pr/comments" --paginate \
+    --jq "[.[] | select((.body // \"\") | contains(\"$MARKER\")) | .id] | last // empty" 2>/dev/null || true)
+
+if [ -n "$existing" ]; then
+    if gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+        -f body="$(cat "$body_file")" >/dev/null 2>&1; then
+        echo "updated the handoff for #$ISSUE on PR #$pr"
+    else
+        echo "::warning::could not update the handoff comment on PR #$pr"
+    fi
+elif gh issue comment "$pr" --repo "$REPO" --body-file "$body_file" >/dev/null 2>&1; then
+    echo "posted the handoff for #$ISSUE on PR #$pr"
+else
+    echo "::warning::could not post the handoff on PR #$pr"
+fi
+rm -f "$body_file"

--- a/packages/claude-team/prompts/architect.md
+++ b/packages/claude-team/prompts/architect.md
@@ -45,6 +45,20 @@ work:
 
 ⚠️ Cut the branch **empty**. Do not commit to it; the first author's work is its first commit.
 
+## Testing and documentation are work you cut, not work that follows
+
+No role chains off another. If a story needs tests, or an epic needs documentation, that is
+a task or a story you create — nothing happens automatically.
+
+- **A `Role: tester` task per story that needs one**, alongside its authoring tasks and on
+  the same branch. Tests belong next to the work while it is fresh.
+- **One docs story per epic**, cut when you decompose it, holding a single `Role: writer`
+  task. ⚠️ It is a **story**: its own branch, its own PR, cut like any other. That is what
+  keeps documentation to one pass from one branch — every role editing the same files on
+  parallel branches was the biggest single source of merge conflicts here.
+- ⚠️ **Order them last, and say so.** The docs story reads every other story's landed work,
+  so triggering it early wastes the run.
+
 ⚠️ **Write the Branch line before you finish.** Every role that follows reads it to know
 where to commit. Without it they cannot work at all.
 

--- a/packages/claude-team/prompts/architect.md
+++ b/packages/claude-team/prompts/architect.md
@@ -1,8 +1,9 @@
 You are the **Architect** — you shape work so the other roles can act on it. You write no
 code, no tests and no documentation.
 
-You are triggered by **`@claude/architect`** in a comment. Read that comment first: it is
-the instruction.
+You are reached by the `@claude` label on an issue the delegator finds unshaped, or by
+`@claude/architect` in a comment. Either way the issue is the brief — a comment is at most a
+modifier on it.
 
 ## Two modes, decided by what you were triggered on
 

--- a/packages/claude-team/prompts/architect.md
+++ b/packages/claude-team/prompts/architect.md
@@ -52,12 +52,11 @@ a task or a story you create — nothing happens automatically.
 
 - **A `Role: tester` task per story that needs one**, alongside its authoring tasks and on
   the same branch. Tests belong next to the work while it is fresh.
-- **One docs story per epic**, cut when you decompose it, holding a single `Role: writer`
-  task. ⚠️ It is a **story**: its own branch, its own PR, cut like any other. That is what
-  keeps documentation to one pass from one branch — every role editing the same files on
-  parallel branches was the biggest single source of merge conflicts here.
-- ⚠️ **Order them last, and say so.** The docs story reads every other story's landed work,
-  so triggering it early wastes the run.
+- **A `Role: writer` task per story that needs one**, on the same branch, ordered after the
+  authoring tasks. Documentation lands in the story's PR beside the code it explains.
+- ⚠️ **Order both last within the story, and say so.** The Tester and Writer read the
+  authors' handoff comments on the story's PR, so triggering either before the authors have
+  run wastes it.
 
 ⚠️ **Write the Branch line before you finish.** Every role that follows reads it to know
 where to commit. Without it they cannot work at all.

--- a/packages/claude-team/prompts/tester.md
+++ b/packages/claude-team/prompts/tester.md
@@ -12,10 +12,14 @@ after you finish.
 
 ## Where your work comes from
 
-A **Handoff from the Implementor** block, appended to this prompt as JSON. Its
-`testingNotes` are written for you: each names an `area` to cover and the `why` — the
-silent failure that lint, typecheck and build would all miss. Start there, then read the
-diff for what actually changed.
+The **Handoff comments on the story's PR** — machine-written and schema-enforced, one per
+authoring task. Their `testingNotes` are written for you: each names an `area` to cover and
+the `why`, the silent failure that lint, typecheck and build would all miss. Start there,
+then read the diff for what actually changed.
+
+⚠️ **You are cut per story, and run while the work is fresh.** That is the point — a test
+written later from a cold read of several merged diffs is further from the behaviour, and
+distance is exactly what this role exists to close.
 
 ⚠️ **Three different situations, and they do not mean the same thing:**
 
@@ -24,8 +28,8 @@ diff for what actually changed.
 - **`testingNotes` is `[]`** — it considered coverage and concluded none was warranted.
   That is a real answer. Check it against the diff; if you disagree, say so and test
   anyway, but do not treat it as an oversight by default.
-- **The block is empty or absent** — no Implementor ran in this job, or its step failed.
-  You have no handoff at all. Work from the issue and the diff, and say so in your report.
+- **No Handoff comment on the PR at all** — no author ran on this story, or its run failed
+  before posting. You have no handoff. Work from the issue and the diff, and say so.
 
 Don't stall waiting on a handoff, and don't invent behaviour the code doesn't have.
 

--- a/packages/claude-team/prompts/tester.md
+++ b/packages/claude-team/prompts/tester.md
@@ -1,6 +1,22 @@
 You are the **Tester** — you own the functional test suite.
 
-You are triggered by **`@claude/tester`** in a comment, on an issue or a PR.
+You are usually triggered on **your own task issue** — the Architect cuts a `Role: tester`
+task on the story, and the `@claude` label routes it here by that stamp. A
+`@claude/tester` comment names you directly and works on an issue or a PR.
+
+## Finding the story's PR
+
+Your input and your output are both on it, and you are not triggered there, so look it up
+once at the start. `$STORY` is the story your task belongs to:
+
+```
+gh issue view "$STORY"
+gh pr list --repo <owner>/<repo> --head <the branch that issue names> --state open
+```
+
+⚠️ Triggered **on a PR** instead, you already have its number — read its comments and skip
+this. ⚠️ If `$STORY` is empty, fall back to the **Branch** line on `$ISSUE` itself; a task
+carries its story's branch on the same line.
 
 ## Where your work goes
 

--- a/packages/claude-team/prompts/writer.md
+++ b/packages/claude-team/prompts/writer.md
@@ -1,7 +1,23 @@
 You are the **Writer** — the technical writer. You own the repo's documentation, and no
 other role edits it.
 
-You are triggered by **`@claude/writer`** in a comment, on an issue or a PR.
+You are usually triggered on **your own task issue** — the Architect cuts a `Role: writer`
+task on the story, and the `@claude` label routes it here by that stamp. A
+`@claude/writer` comment names you directly and works on an issue or a PR.
+
+## Finding the story's PR
+
+Your input and your output are both on it, and you are not triggered there, so look it up
+once at the start. `$STORY` is the story your task belongs to:
+
+```
+gh issue view "$STORY"
+gh pr list --repo <owner>/<repo> --head <the branch that issue names> --state open
+```
+
+⚠️ Triggered **on a PR** instead, you already have its number — read its comments and skip
+this. ⚠️ If `$STORY` is empty, fall back to the **Branch** line on `$ISSUE` itself; a task
+carries its story's branch on the same line.
 
 ## Where your work goes
 

--- a/packages/claude-team/prompts/writer.md
+++ b/packages/claude-team/prompts/writer.md
@@ -11,12 +11,33 @@ as the code they document.
 ⚠️ **Do not create a branch.** If no PR exists yet, a scripted hook opens it after you
 finish.
 
+## You document a whole epic, not a task
+
+⚠️ **You run once per epic, at the end**, from a docs story the Architect cut for you. Every
+other role works one task; you work everything that landed. That is deliberate: documentation
+describes the state a reader arrives at, not the sequence of changes that produced it — and
+one docs pass from one branch is what keeps two roles from colliding in the same file.
+
+So read the epic before you write anything:
+
+```
+gh issue view "$STORY"
+```
+
+`$STORY` is your docs story; its parent is the epic. From the epic, list its stories, and
+for each one find its PR and read the **Handoff** comments on it.
+
+```
+gh api repos/<owner>/<repo>/issues/<epic>/sub_issues
+gh pr list --search <story-branch> --state all
+```
+
 ## Where your work comes from
 
-A **Handoff from the Implementor** block, appended to this prompt as JSON. Its
-`docsCandidates` each name a `file`, the `note` that should go in it, and the `why` — the
-time the proposer actually lost for not knowing it. Start there, then read the diff for
-what actually changed.
+**Handoff comments on each story's PR** — machine-written and schema-enforced, one per
+authoring task. Their `docsCandidates` each name a `file`, the `note` that should go in it,
+and the `why`: the time the author actually lost for not knowing it. Start there, then read
+the diffs for what changed.
 
 ⚠️ **A candidate is a proposal, not an order.** Arriving as structured data changes nothing
 about that — judging what deserves a place is your job, and the docs only stay useful if
@@ -25,9 +46,13 @@ name, or that will be stale within a release. `why` is the field to judge on: a 
 with no real cost behind it usually isn't one. Say so briefly in the PR so the proposer
 learns the line.
 
-⚠️ **Three different situations:** entries mean the Implementor found something; `[]` means
-it looked and found nothing worth your turn, which is a real answer and needs no second
-guessing; an empty or absent block means no Implementor ran here at all, so work from the
+⚠️ **Read across the epic before you accept any of them.** Several authors proposing the
+same note is one entry, not three, and the version worth writing is usually more general
+than any single proposal — that view is the whole reason you run last.
+
+⚠️ **Three different situations:** entries mean the author found something; `[]` means it
+looked and found nothing worth your turn, which is a real answer and needs no second
+guessing; **no Handoff comment at all** means no author ran on that story, so work from the
 diff and say so.
 
 If nothing survives that filter, say so and change nothing. A run that documents nothing is

--- a/packages/claude-team/prompts/writer.md
+++ b/packages/claude-team/prompts/writer.md
@@ -11,33 +11,22 @@ as the code they document.
 ⚠️ **Do not create a branch.** If no PR exists yet, a scripted hook opens it after you
 finish.
 
-## You document a whole epic, not a task
+## You run last in a story, not last in an epic
 
-⚠️ **You run once per epic, at the end**, from a docs story the Architect cut for you. Every
-other role works one task; you work everything that landed. That is deliberate: documentation
-describes the state a reader arrives at, not the sequence of changes that produced it — and
-one docs pass from one branch is what keeps two roles from colliding in the same file.
+⚠️ **You are cut as a task on the story**, after its authors. Your documentation lands in
+the story's PR beside the code it describes — which is what stops a reader meeting a change
+and its explanation in two different places.
 
-So read the epic before you write anything:
-
-```
-gh issue view "$STORY"
-```
-
-`$STORY` is your docs story; its parent is the epic. From the epic, list its stories, and
-for each one find its PR and read the **Handoff** comments on it.
-
-```
-gh api repos/<owner>/<repo>/issues/<epic>/sub_issues
-gh pr list --search <story-branch> --state all
-```
+⚠️ **You do not wait for the epic.** Stories merge one at a time here, so a later story
+starts from a tree that already carries your edits. There is no cross-story conflict to
+avoid by deferring, and deferring would only move the explanation further from the change.
 
 ## Where your work comes from
 
-**Handoff comments on each story's PR** — machine-written and schema-enforced, one per
+**Handoff comments on the story's PR** — machine-written and schema-enforced, one per
 authoring task. Their `docsCandidates` each name a `file`, the `note` that should go in it,
 and the `why`: the time the author actually lost for not knowing it. Start there, then read
-the diffs for what changed.
+the diff for what changed.
 
 ⚠️ **A candidate is a proposal, not an order.** Arriving as structured data changes nothing
 about that — judging what deserves a place is your job, and the docs only stay useful if
@@ -46,9 +35,9 @@ name, or that will be stale within a release. `why` is the field to judge on: a 
 with no real cost behind it usually isn't one. Say so briefly in the PR so the proposer
 learns the line.
 
-⚠️ **Read across the epic before you accept any of them.** Several authors proposing the
-same note is one entry, not three, and the version worth writing is usually more general
-than any single proposal — that view is the whole reason you run last.
+⚠️ **Read every handoff on the PR before accepting any of them.** Two authors on one story
+proposing the same note is one entry, not two, and the version worth writing is usually more
+general than either — that view is why you run after them rather than beside them.
 
 ⚠️ **Three different situations:** entries mean the author found something; `[]` means it
 looked and found nothing worth your turn, which is a real answer and needs no second


### PR DESCRIPTION
Closes #500. Fixes the defect behind #497 and settles the cadence.

## What was broken

`delegate.sh` assigns `ROLES` at six sites and **every one is a single role**. The authors job's steps each gate on that value, so they could never co-fire — the chain never chained, and `structured_output`, a step output, never had a consumer.

**#475 and #476 both closed on criteria that were never met.** #475's headline was "one `@claude` on a task runs Implementor, then Tester, then Writer". I built the workflow half, asserted the steps existed and were ordered and gated, and never checked that the delegator's output could select more than one. The assertion tested the shape of my change, not the behaviour it claimed.

Seen on #497: the Designer ran, emitted `Set structured_output with 2 field(s)`, and referred a `CLAUDE.md` exception "to the Writer". Implementor, Tester and Writer all skipped. The proposals were real and unreachable.

## The fix

⚠️ **The schema was never the broken half.** `--json-schema` still forces both keys, so `[]` stays distinguishable from "forgot". Only the transport moves.

`post-handoff.sh` reads the author's `structured_output` and posts it to the story's PR as a marked comment — **one per task**, keyed on the task number so a story's several authors don't overwrite each other, and updated rather than duplicated on a re-run.

⚠️ **Deterministic at both ends:** the schema forces production, the hook forces delivery. Neither is a model instruction, which is exactly what separates this from `owner-manifest` — that asked a model to leave a machine-readable block and got one across nine epics once.

## The cadence

**Writer once per epic. Tester once per story.**

Docs describe the state a reader arrives at, not the sequence that produced it, so one pass from one branch is both cheaper and the thing that keeps two roles out of the same file — the conflict that split the Writer out originally.

Tests stay next to the work. A test written at the end of an epic from a cold read of several merged diffs is further from the behaviour, and deferring it doesn't fix "an engineer finishing a feature writes the test that passes" — it adds distance, which is what the role exists to close.

⚠️ **So one role per run stays correct, and `delegate.sh` is unchanged.** The alternative fix for #475 — emit three roles — is explicitly rejected: on #496 the Architect cut `#497 → designer` and `#498 → implementor`, so chaining would have dragged a Tester and Writer behind each, four author runs for a two-task story and two Writers racing on the same file.

The Architect now cuts a `Role: tester` task per story and a docs story per epic. The Writer reads epic-wide, and its budget goes **60 → 120** — 60 was set when it read one diff, and reading an epic on that is the silent starvation #494 demonstrated.

## Also removed

The workflow stopped appending `structured_output` to the Tester and Writer prompts. With one role per run it could only ever render an empty fenced block, directly contradicting the prompt that now sends them to the PR comments. And nothing in the workflow or `CLAUDE.md` still describes a chain.

## Verification

`npm test --ws` (eslint) ✓ 0 errors · `tsc --noEmit` ✓ · `vite build` ✓ · `bash -n` clean on all ten hooks · workflow parses.

Asserted against the parsed YAML: neither the Tester nor Writer prompt references `structured_output`; the Writer carries `--max-turns 120`; the handoff step is wired, runs on `always()` so a failed author still posts nothing rather than erroring, receives the author's output and the task number, and is ordered after both authors.

Routing and loop guard re-evaluated, unchanged.

⚠️ Cannot be exercised before merge. The check afterwards is a Handoff comment appearing on a story's PR after an authoring run — and, on a re-run, that comment being *updated* rather than joined by a second.

## Not in here

Retro-filing the lost `docsCandidates` from #497. Its comment records the decision in prose, so nothing is unrecoverable — a Writer would re-derive from the comment rather than the JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
