### PR TITLE
Give each task its own branch and PR into the story branch

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -648,19 +648,15 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         run: "$RUNNER_TEMP/agent-bin/finish-pr.sh"
-      - name: Open the story PR
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
-        run: "$RUNNER_TEMP/agent-bin/open-story-pr.sh"
       - name: Persist the author's handoff
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          # where it is posted: the story's ISSUE, which always exists. The story's PR does
+          # not, until the first task PR merges into its branch.
+          STORY: ${{ needs.delegate.outputs.story }}
           ROLES: ${{ steps.roles.outputs.list }}
           # whichever author ran — they are alternatives and emit the same schema, so `||`
           # takes the one that produced output. Empty when neither ran or the step failed,
@@ -815,3 +811,14 @@ jobs:
           PROJECT_OWNER: "@me"
           PROJECT_NUMBER: "4"
         run: "$RUNNER_TEMP/agent-bin/close-merged-work.sh"
+      # ⚠️ The story's PR opens HERE, not in an authoring run. Under sub-branching the story
+      # branch is empty until a task PR merges into it, and GitHub will not open a PR with no
+      # commits between base and head — so the first task merge is the earliest moment it can
+      # exist. Runs for every merged PR and no-ops unless the base is a story branch.
+      - name: Open the story PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: "$RUNNER_TEMP/agent-bin/open-story-pr.sh"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,24 +369,35 @@ one per task, updated rather than duplicated on a re-run.
 [`packages/claude-team`](packages/claude-team/README.md); this repo extends it with
 per-role overlays in `.github/agent-prompts/`.
 
-| level | branch | PR | is |
+| level | branch | its PR targets | closed by |
 |---|---|---|---|
-| **Epic** | no | **no** | a cross-story product goal; a grouping, nothing more |
-| **Story** | **one** | **exactly one** | a sub-issue of an epic — the unit that ships |
-| **Task** | no | no | a sub-issue of a story; work that lands on the story's branch |
+| **Epic** | none | — | its stories closing |
+| **Story** | `<story#>-…`, cut by the Architect | `mainline` | its PR merging |
+| **Task** | `<task#>-…`, cut by its author off the story branch | the **story** branch | its own PR merging |
 
 - Architect cuts the story's branch off `mainline`, empty, and records it in the story as a
-  **Branch** line.
-- Architect stamps that same line onto every task, plus a **Role** line naming who picks it
-  up — routing is a shell script that reads the stamp rather than judging it.
-- The **first author to run** — Implementor, Tester or Writer — opens the story's PR, via
-  `open-story-pr.sh`. All three carry the hook; whichever runs first wins.
-- Every role after that commits to the same branch. **No role cuts its own.**
+  **Branch** line. It stamps that **same** line onto every task — it always names the
+  *story's* branch, never a branch for the task — plus a **Role** line naming who picks it
+  up. Routing is a shell script that reads the stamp rather than judging it.
+- Each author cuts `<task#>-…` off the story branch, works there, and opens a PR **into**
+  the story branch. Merging that closes the task and lands the work on the story.
+- The **story's** PR opens on the first task merge, via `open-story-pr.sh` — ⚠️ from
+  `merge_housekeeping`, not from an authoring run. The story branch is empty until a task
+  lands on it, and GitHub will not open a PR with no commits between base and head.
 
-⚠️ One PR per story, growing, is the point. The maintainer reviews the story landing as a
-whole — code, tests and docs — instead of one PR per role.
-⚠️ A story PR targets `mainline`, so its `Closes #<story>` works normally. Tasks are closed
-by the merge hook parsing the body, not by GitHub.
+⚠️ **Tasks used to share the story's branch, and that was a race.** The concurrency group is
+keyed on issue number, so two tasks are in *different* groups and could commit to the same
+branch simultaneously. Sub-branching fixes it structurally rather than by triggering runs one
+at a time.
+⚠️ One story PR, growing, is still the point — the maintainer reviews the story landing as a
+whole rather than one PR per role. It just accumulates by merge now, not by direct commit.
+⚠️ A story PR targets `mainline`, so its `Closes #<story>` works normally. **A task PR does
+not** — GitHub ignores closing keywords on a non-default base, so `close-merged-work.sh`
+parsing the body is the only thing that closes a task.
+⚠️ That hook no longer expands a closed issue's open sub-issues. It did when tasks had no
+PRs and a story's merge was the only thing that could close them; now a task still open when
+its story merges is a real signal — abandoned, or its PR never landed — and closing it would
+hide the case worth seeing.
 ⚠️ `pull_request` events run the workflow from the PR's **base** branch, so workflow fixes
 do not reach an in-flight story until `mainline` is merged into it.
 ⚠️ An epic has no branch, so nothing to merge in and nothing to keep current. That was the
@@ -394,7 +405,7 @@ main cost of the old epic-integration-branch model.
 
 
 **Budgets.** `sonnet` throughout except the Implementor, which runs `opus` — it is the only
-role whose output the maintainer must review line by line. Architect 100 turns, Writer 60,
+role whose output the maintainer must review line by line. Architect 100 turns,
 Security 40, the rest 80. Implementor and Tester run `npm ci` as a step; nobody else builds.
 
 **Allowlists union, they don't replace.** A role's `claude_args --allowedTools` is merged with

--- a/packages/claude-team/hooks/close-merged-work.sh
+++ b/packages/claude-team/hooks/close-merged-work.sh
@@ -5,9 +5,10 @@ issues=$(gh pr view "$PR" --repo "$REPO" --json closingIssuesReferences \
   --jq '.closingIssuesReferences[].number')
 
 # ⚠️ GitHub only acts on closing keywords when a PR targets the DEFAULT
-# branch. Every sub-issue PR goes into an epic branch instead, so its
-# "Closes #N" is inert and closingIssuesReferences comes back empty — the
-# intent is in the body, GitHub just never linked it. Parse it ourselves.
+# branch. A task's PR targets its STORY's branch, so its "Closes #<task>" is
+# inert and closingIssuesReferences comes back empty — the intent is in the
+# body, GitHub just never linked it. Parse it ourselves. This is the only
+# thing that closes a task.
 if [ -z "$issues" ]; then
   issues=$(gh pr view "$PR" --repo "$REPO" --json body --jq \
     '[.body // "" | scan("(?i)(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#([0-9]+)")[]] | unique | .[]')
@@ -21,20 +22,11 @@ if [ -z "$issues" ]; then
   exit 0
 fi
 
-# ⚠️ Closing a story closes its tasks by definition, so derive them instead of trusting the
-# PR body. open-story-pr.sh lists the tasks with closing keywords, but it writes that body
-# ONCE when the PR opens — a task the Architect cuts afterwards is nowhere in it and would
-# be left open by a merge that plainly finished it. One level only: a story's children are
-# its tasks, and nothing recurses into an epic.
-for issue in $issues; do
-  kids=$(gh api "repos/$REPO/issues/$issue/sub_issues" \
-    --jq '.[] | select(.state == "open") | .number' 2>/dev/null || true)
-  if [ -n "$kids" ]; then
-    echo "#$issue has open sub-issues:" $kids
-    issues=$(printf '%s\n%s\n' "$issues" "$kids")
-  fi
-done
-issues=$(printf '%s\n' $issues | sort -un)
+# ⚠️ NO SUB-ISSUE EXPANSION. This used to close a closed issue's open children, because a
+# story's tasks had no PRs of their own and the story's merge was the only thing that could
+# close them. Every task now closes via its own PR merging into the story branch, so a task
+# still open when its story merges is a real signal — abandoned, or its PR never landed —
+# and swallowing it would hide exactly the case worth seeing.
 
 for issue in $issues; do
   if [ "$(gh issue view "$issue" --repo "$REPO" --json state --jq '.state')" = "OPEN" ]; then

--- a/packages/claude-team/hooks/delegate.sh
+++ b/packages/claude-team/hooks/delegate.sh
@@ -128,9 +128,14 @@ fi
 
 # ---- 5. a task or a story with a branch: use the stamped role
 if [ -n "$branch" ]; then
-    # ⚠️ The story is not simply the parent. A task's parent IS its story, but a story's
-    # parent is its epic. A branch is named `<story#>-<summary>`, so the number it starts
-    # with is the story — self for a story, the parent for a task.
+    # ⚠️ THE BRANCH LINE ALWAYS NAMES THE STORY'S BRANCH, on a story and on its tasks alike,
+    # so the number it starts with is the story — self for a story, the parent's for a task.
+    # That holds under sub-branching too: a task's own branch is `<task#>-…`, cut off the
+    # story branch and merged back into it, but the line still records the story's.
+    #
+    # ⚠️ DO NOT "fix" this by walking the issue tree. Deriving a task as "an issue whose
+    # parent has a parent" assumes every story sits under an epic, and they do not — #496 is
+    # parentless, so that walk resolves each of its tasks to itself. Tried, measured, reverted.
     STORY=$(printf '%s' "$branch" | grep -oE '^[0-9]+' || true)
     [ -n "$STORY" ] || STORY="${parent:-$NUMBER}"
 

--- a/packages/claude-team/hooks/open-story-pr.sh
+++ b/packages/claude-team/hooks/open-story-pr.sh
@@ -1,95 +1,75 @@
 #!/usr/bin/env bash
-# Post-hook for every authoring role. Opens the story's PR the first time it finds one
-# missing, so the story is reviewable as it accumulates rather than arriving whole.
+# Runs on every merged PR. Opens the STORY's PR the first time a task PR lands on a story
+# branch, so the story is reviewable as it accumulates rather than arriving whole.
 #
-# One story, one branch, one PR. An epic has neither — if this is triggered on an epic
-# there is no Branch line and it no-ops. A task carries its *story's* Branch line, so a
-# task run finds the story's PR already open and does nothing.
+# ⚠️ IT RUNS HERE, NOT IN AN AUTHORING RUN, and that is forced rather than chosen. Under
+# sub-branching an author commits to its own task branch, so the story branch stays empty
+# until a task PR merges into it — and GitHub will not open a PR with no commits between
+# base and head. The first task merge is the earliest moment the story's PR can exist.
 #
-# The branch comes from the issue body's Branch line, which the Architect writes:
-#
-#   **Branch: `250-volume-milestone`**
+# `BASE` is the merged PR's base ref. A task PR's base is the story branch; a story PR's
+# base is the default branch. So a story branch base means "a task just landed".
 set -euo pipefail
 
 : "${REPO:?REPO is required}"
 
-if [ -z "${ISSUE:-}" ]; then
-    echo "Not triggered on an issue — no story to open a PR for."
-    exit 0
-fi
-
-body=$(gh issue view "$ISSUE" --repo "$REPO" --json body --jq '.body // ""')
-branch=$(printf '%s' "$body" | grep -oiE 'branch: *`[^`]+`' | head -1 | sed -E 's/.*`([^`]+)`.*/\1/')
-
-if [ -z "$branch" ]; then
-    echo "#$ISSUE names no branch — an epic, or a story the Architect hasn't cut yet."
-    exit 0
-fi
-
 default=$(gh repo view "$REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')
 
-if [ "$branch" = "$default" ]; then
-    echo "#$ISSUE targets $default directly — no story branch."
+if [ -z "${BASE:-}" ] || [ "$BASE" = "$default" ]; then
+    echo "Merged into ${BASE:-?} — not a story branch, nothing to open."
     exit 0
 fi
 
-existing=$(gh pr list --repo "$REPO" --head "$branch" --state open --json number --jq '.[0].number // empty')
+# ⚠️ A story branch is named `<story#>-<summary>`. The number it starts with is the story,
+# which is the same derivation delegate.sh uses — the two must not disagree about which
+# issue a branch belongs to.
+STORY=$(printf '%s' "$BASE" | grep -oE '^[0-9]+' || true)
+if [ -z "$STORY" ]; then
+    echo "::warning::base $BASE does not start with an issue number — cannot resolve its story."
+    exit 0
+fi
+
+existing=$(gh pr list --repo "$REPO" --head "$BASE" --state open --json number --jq '.[0].number // empty')
 if [ -n "$existing" ]; then
-    echo "PR #$existing already open for $branch."
+    echo "PR #$existing already open for $BASE."
     exit 0
 fi
 
-if ! git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-    echo "::warning::branch $branch does not exist on origin — the Architect may not have cut it."
+if [ "$(gh api "repos/$REPO/compare/$default...$BASE" --jq '.ahead_by' 2>/dev/null || echo 0)" -eq 0 ]; then
+    echo "$BASE is not ahead of $default — nothing to open a PR for."
     exit 0
 fi
-
-# nothing to PR yet: the author pushed no commits, so let the next run open it
-git fetch origin "$branch" --quiet
-if [ "$(git rev-list --count "origin/$default..origin/$branch")" -eq 0 ]; then
-    echo "$branch has no commits yet — nothing to open a PR for."
-    exit 0
-fi
-
-# ⚠️ THE PR CLOSES THE STORY, NOT THE TRIGGERING ISSUE. Writing `Closes #<task>` here is
-# what sank the model once already: the first task's PR announced itself finished, CI went
-# green, and merging was the obvious move — closing the branch with the story's other tasks
-# unstarted. A branch is named `<story#>-<summary>`, so the number it starts with is the
-# story: itself when a story triggered the run, its parent when a task did.
-STORY=$(printf '%s' "$branch" | grep -oE '^[0-9]+' || true)
-[ -n "$STORY" ] || STORY="$ISSUE"
 
 title=$(gh issue view "$STORY" --repo "$REPO" --json title --jq '.title')
 tasks=$(gh api "repos/$REPO/issues/$STORY/sub_issues" \
-    --jq '.[] | "\(.number)\t\(.title)"' 2>/dev/null || true)
+    --jq '.[] | "\(.number)\t\(.state)\t\(.title)"' 2>/dev/null | grep -E '^[0-9]+	' || true)
 
 body_file=$(mktemp)
 {
-    printf 'Story PR for `%s`.\n\n' "$branch"
-    printf '⚠️ **This PR stays open until the story is complete.** Every role working the story\n'
-    printf 'commits to this branch, so it grows as the story lands — code, tests and docs\n'
-    printf 'together — rather than arriving as several PRs. One task looking finished is not a\n'
-    printf 'signal to merge.\n\n'
+    printf 'Story PR for `%s`.\n\n' "$BASE"
+    printf '⚠️ **This PR stays open until the story is complete.** Each task lands here by its\n'
+    printf 'own PR into this branch, so it grows as the story does — code, tests and docs\n'
+    printf 'together — rather than arriving as several. One task merging is not a signal to\n'
+    printf 'merge this.\n\n'
     printf 'Closes #%s\n' "$STORY"
 
     if [ -n "$tasks" ]; then
         printf '\n### Tasks\n\n'
-        printf '%s\n' "$tasks" | while IFS=$'\t' read -r n t; do
-            printf -- '- #%s — %s\n' "$n" "$t"
+        printf '%s\n' "$tasks" | while IFS=$'\t' read -r n st t; do
+            mark=$([ "$st" = "closed" ] && printf 'x' || printf ' ')
+            printf -- '- [%s] #%s — %s\n' "$mark" "$n" "$t"
         done
-        # ⚠️ The tasks need their own closing keywords. close-merged-work.sh only falls back
-        # to parsing the body when `closingIssuesReferences` is EMPTY, and a story PR targets
-        # the default branch — so GitHub populates it with the story and the parse never runs.
-        # Listing the tasks without keywords would leave every one of them open on merge.
-        printf '\nMerging closes them too:'
-        printf '%s\n' "$tasks" | cut -f1 | while read -r n; do printf ' closes #%s' "$n"; done
-        printf '\n'
+        # ⚠️ Each task is closed by its OWN PR merging into this branch, so this list needs
+        # no closing keywords — and must not carry them. Repeating them here would make the
+        # story's merge re-close tasks that are already done, and would close any that were
+        # abandoned rather than finished.
+        printf '\nEach is closed by its own PR merging into this branch.\n'
     fi
 } > "$body_file"
 
-if gh pr create --repo "$REPO" --base "$default" --head "$branch" --title "$title" --body-file "$body_file" >/dev/null 2>&1; then
-    echo "opened the story PR for $branch"
+if gh pr create --repo "$REPO" --base "$default" --head "$BASE" --title "$title" --body-file "$body_file" >/dev/null 2>&1; then
+    echo "opened the story PR for $BASE"
 else
-    echo "::warning::could not open the story PR for $branch — open it by hand."
+    echo "::warning::could not open the story PR for $BASE — open it by hand."
 fi
 rm -f "$body_file"

--- a/packages/claude-team/hooks/post-handoff.sh
+++ b/packages/claude-team/hooks/post-handoff.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Post-hook for the authoring job. Puts the author's JSON handoff somewhere a later role can
-# read it — the story's PR, as one marked comment per task.
+# read it — the STORY'S ISSUE, as one marked comment per task.
+#
+# ⚠️ The issue, not the story's PR. Under sub-branching the story branch is empty until the
+# first task PR merges into it, so its PR does not exist while the first author is running.
+# The issue always exists, and `$STORY` already points at it.
 #
 # ⚠️ THE SCHEMA WAS NEVER THE BROKEN HALF. `--json-schema` forces the author to emit both
 # keys, so `[]` stays distinguishable from "forgot". What failed is that `structured_output`
@@ -25,21 +29,8 @@ if [ -z "${ISSUE:-}" ]; then
     exit 0
 fi
 
-# The PR is the story's, found by the branch its issue names — same derivation as
-# open-story-pr.sh, so the two cannot disagree about which PR a task belongs to.
-body=$(gh issue view "$ISSUE" --repo "$REPO" --json body --jq '.body // ""')
-branch=$(printf '%s' "$body" | grep -oiE 'branch: *`[^`]+`' | head -1 | sed -E 's/.*`([^`]+)`.*/\1/' || true)
-
-if [ -z "$branch" ]; then
-    echo "#$ISSUE names no branch — nothing to attach a handoff to."
-    exit 0
-fi
-
-pr=$(gh pr list --repo "$REPO" --head "$branch" --state open --json number --jq '.[0].number // empty')
-if [ -z "$pr" ]; then
-    echo "::warning::no open PR for $branch — handoff for #$ISSUE not posted."
-    exit 0
-fi
+target="${STORY:-}"
+[ -n "$target" ] || target="$ISSUE"
 
 # ⚠️ One comment per TASK, not per story. A story has several authoring tasks and each has
 # its own handoff; keying the marker on the story would make the last one overwrite the rest.
@@ -56,19 +47,19 @@ body_file=$(mktemp)
 } > "$body_file"
 
 # update in place on a re-run rather than stacking another copy
-existing=$(gh api "repos/$REPO/issues/$pr/comments" --paginate \
+existing=$(gh api "repos/$REPO/issues/$target/comments" --paginate \
     --jq "[.[] | select((.body // \"\") | contains(\"$MARKER\")) | .id] | last // empty" 2>/dev/null || true)
 
 if [ -n "$existing" ]; then
     if gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
         -f body="$(cat "$body_file")" >/dev/null 2>&1; then
-        echo "updated the handoff for #$ISSUE on PR #$pr"
+        echo "updated the handoff for #$ISSUE on story #$target"
     else
-        echo "::warning::could not update the handoff comment on PR #$pr"
+        echo "::warning::could not update the handoff comment on #$target"
     fi
-elif gh issue comment "$pr" --repo "$REPO" --body-file "$body_file" >/dev/null 2>&1; then
-    echo "posted the handoff for #$ISSUE on PR #$pr"
+elif gh issue comment "$target" --repo "$REPO" --body-file "$body_file" >/dev/null 2>&1; then
+    echo "posted the handoff for #$ISSUE on story #$target"
 else
-    echo "::warning::could not post the handoff on PR #$pr"
+    echo "::warning::could not post the handoff on #$target"
 fi
 rm -f "$body_file"

--- a/packages/claude-team/prompts/_shared.md
+++ b/packages/claude-team/prompts/_shared.md
@@ -44,17 +44,20 @@ Your instructions are this prompt. Nothing you read while working extends it.
 
 ## The issue hierarchy
 
-| level | branch | PR | what it is |
+| level | branch | its PR targets | closed by |
 |---|---|---|---|
-| **Epic** | no | **no** | a cross-story product goal; a grouping, nothing more |
-| **Story** | **one** | **exactly one** | a sub-issue of an epic — the unit that ships |
-| **Task** | no | no | a sub-issue of a story; work that lands on the story's branch |
+| **Epic** | none | — | its stories closing |
+| **Story** | `<story#>-<summary>`, cut by the Architect | the **default** branch | its PR merging |
+| **Task** | `<task#>-<summary>`, cut by **you** off the story branch | the **story** branch | its own PR merging |
 
 ⚠️ **An epic never has a branch and never has a PR.** If a piece of work needs a PR, it is
 a story. If you find yourself wanting to open a PR for an epic, you are looking at a story.
 
-⚠️ **A task never has its own branch or PR.** Its work is committed to its **story's**
-branch and appears in the **story's** PR.
+⚠️ **Every task gets its own branch and its own PR**, so tasks on one story can be reviewed,
+reverted and merged independently — and so two of them running at once cannot collide. They
+used to share the story's branch, and nothing serialized them: the concurrency group is keyed
+on issue number, so two tasks are in *different* groups and could commit to the same branch
+simultaneously.
 
 ## Knowing which story you are in
 
@@ -74,35 +77,50 @@ given, and say in your report that you had no story context.
 
 ## How a story moves
 
-1. **Architect** shapes the story and cuts its branch off the default branch.
-2. The **first author to run** — Implementor, Tester or Writer — opens the story's PR.
-3. **Every role after that commits to the same branch.** No role cuts its own.
-4. The maintainer reviews one PR as it accumulates and merges it.
+1. **Architect** shapes the story, cuts its branch off the default branch, and creates its
+   tasks — each stamped with the role that should pick it up.
+2. Each **task** is triggered on its own. Its author cuts a branch off the story branch,
+   works there, and opens a PR **into the story branch**.
+3. Merging that task PR closes the task and lands its work on the story branch.
+4. The **story's** PR, targeting the default branch, accumulates all of it. The maintainer
+   reviews and merges the story as a whole.
 
-⚠️ **The story's PR is not yours to finish.** It belongs to the story and closes when the
-story does — it says `Closes #<story>`, never `Closes #<your task>`. Finishing your task
-does not finish the PR, so do not describe it as ready, complete, or good to merge; other
-tasks are still landing on the same branch. Report what *your task* did and leave the PR's
-state to the story.
+## Your branch
 
-⚠️ **Do not create a branch.** Check out the story's existing branch:
+Your task's issue names its **story's** branch on a **Branch** line — that is what you base
+on and merge back into, not where you commit.
 
 ```
 git fetch origin <story-branch>
-git checkout -B <story-branch> origin/<story-branch>
+git checkout -b <task#>-<kebab-summary> origin/<story-branch>
 ```
 
-The story's issue names its branch on a **Branch** line. A task's issue names its story's
-branch on the same line — a task commits there, not somewhere of its own.
+⚠️ **Cut it off the story branch, never off the default branch.** Your task usually depends
+on work already merged into the story, and basing on the default branch silently drops it.
 
-⚠️ If the branch does not exist, stop and say so in a comment. Do not invent one: the
-Architect creating it is what keeps one story to one branch.
+⚠️ **If the story branch does not exist, stop and say so in a comment.** Do not invent one —
+the Architect creating it is what keeps one story to one branch.
+
+⚠️ **Open your PR against the story branch**, not the default branch:
+
+```
+gh pr create --base <story-branch> --head <task#>-<kebab-summary> --title "…" --body "…"
+```
+
+⚠️ **Write `Closes #<your task>` in that PR's body.** GitHub will not act on it — closing
+keywords only fire when a PR targets the *default* branch — so a scripted hook parses the
+body on merge and closes it. Without the line, nothing closes your task.
+
+⚠️ **The story's PR is not yours.** It belongs to the story and closes when the story does.
+Finishing your task does not finish it, so do not describe it as ready or good to merge —
+other tasks are still landing. Report what *your task* did.
 
 ## House rules
 
 - Never push to the default branch. It deploys.
-- You may open a PR, push to the story branch, and comment. You may not merge, edit
-  workflow files or secrets, or run destructive git.
+- You may cut your task branch, push to it, open its PR, and comment. You may not merge,
+  push to the story branch or the default branch, edit workflow files or secrets, or run
+  destructive git.
 - Pass the repo's gate before proposing a PR.
 - Ask when a change is ambiguous, irreversible, or reaches outside the PR.
 - Create issues and PRs **unlabeled**. A role labels only the PR it opens, and a scripted

--- a/packages/claude-team/prompts/architect.md
+++ b/packages/claude-team/prompts/architect.md
@@ -51,10 +51,10 @@ work:
 No role chains off another. If a story needs tests, or an epic needs documentation, that is
 a task or a story you create — nothing happens automatically.
 
-- **A `Role: tester` task per story that needs one**, alongside its authoring tasks and on
-  the same branch. Tests belong next to the work while it is fresh.
-- **A `Role: writer` task per story that needs one**, on the same branch, ordered after the
-  authoring tasks. Documentation lands in the story's PR beside the code it explains.
+- **A `Role: tester` task per story that needs one**, alongside its authoring tasks. Tests
+  belong next to the work while it is fresh.
+- **A `Role: writer` task per story that needs one**, ordered after the authoring tasks.
+  Documentation lands on the story branch by its own PR, like every other task.
 - ⚠️ **Order both last within the story, and say so.** The Tester and Writer read the
   authors' handoff comments on the story's PR, so triggering either before the authors have
   run wastes it.
@@ -68,6 +68,10 @@ where to commit. Without it they cannot work at all.
 **Branch: `<the story's branch>`**
 **Role: <implementor|tester|writer|designer>**
 ```
+
+⚠️ **The Branch line always names the STORY's branch**, on every task. It is what the author
+bases its own branch on and merges back into — never a branch for the task itself. You cut
+one branch per story and no more; the authors cut their own.
 
 ⚠️ **The role stamp is load-bearing.** Routing is a shell script that reads this line — it
 does not judge which role should pick a task up. You answer that once, here, with the code

--- a/packages/claude-team/prompts/designer.md
+++ b/packages/claude-team/prompts/designer.md
@@ -6,12 +6,12 @@ You are reached either by the delegator routing a task stamped `Role: designer`,
 
 ## Where your work goes
 
-Read the issue's **Branch** line and commit there. On a **task**, that line names its
-*story's* branch — your work lands in the story's PR alongside every other role's.
+Your task's **Branch** line names its *story's* branch. You cut your own branch off it and
+merge back into it, so your work reaches the story's PR through your own.
 
-⚠️ **Do not create a branch, and do not open a PR if one already exists for the story.** A
-scripted hook opens it on whichever author runs first. If you are that first author, the
-hook opens it after you finish; you do not need to.
+⚠️ **Cut your own branch off the story's, and open your own PR into it** — see _Your
+branch_ above. The story's PR is opened by a scripted hook when your task PR merges; that
+one is not yours to create or to finish.
 
 ## What you own
 

--- a/packages/claude-team/prompts/implementor.md
+++ b/packages/claude-team/prompts/implementor.md
@@ -9,12 +9,12 @@ across. See _What you own_.
 
 ## Where your work goes
 
-Read the issue's **Branch** line and commit there. On a **task**, that line names its
-*story's* branch — your work lands in the story's PR alongside every other role's.
+Your task's **Branch** line names its *story's* branch. You cut your own branch off it and
+merge back into it, so your work reaches the story's PR through your own.
 
-⚠️ **Do not create a branch, and do not open a PR if one already exists for the story.** A
-scripted hook opens it on whichever author runs first. If you are that first author, the
-hook opens it after you finish; you do not need to.
+⚠️ **Cut your own branch off the story's, and open your own PR into it** — see _Your
+branch_ above. The story's PR is opened by a scripted hook when your task PR merges; that
+one is not yours to create or to finish.
 
 ## What you own
 

--- a/packages/claude-team/prompts/tester.md
+++ b/packages/claude-team/prompts/tester.md
@@ -4,31 +4,29 @@ You are usually triggered on **your own task issue** — the Architect cuts a `R
 task on the story, and the `@claude` label routes it here by that stamp. A
 `@claude/tester` comment names you directly and works on an issue or a PR.
 
-## Finding the story's PR
+## Where to read the handoffs
 
-Your input and your output are both on it, and you are not triggered there, so look it up
-once at the start. `$STORY` is the story your task belongs to:
+They are comments on the **story's issue**, `$STORY` — not on a PR:
 
 ```
-gh issue view "$STORY"
-gh pr list --repo <owner>/<repo> --head <the branch that issue names> --state open
+gh issue view "$STORY" --comments
 ```
 
-⚠️ Triggered **on a PR** instead, you already have its number — read its comments and skip
-this. ⚠️ If `$STORY` is empty, fall back to the **Branch** line on `$ISSUE` itself; a task
-carries its story's branch on the same line.
+⚠️ The story's issue, because it always exists. Its PR does not until the first task PR
+merges into the story branch, so a handoff written during the first task would have nowhere
+to go. ⚠️ If `$STORY` is empty, fall back to the **Branch** line on `$ISSUE`.
 
 ## Where your work goes
 
 The same place the Implementor's did: the story's branch, named on the issue's **Branch**
 line. Your tests land in the story's PR beside the code they cover.
 
-⚠️ **Do not create a branch.** If no PR exists yet for the story, a scripted hook opens it
-after you finish.
+⚠️ **Cut your own branch off the story's, and open your own PR into it** — see _Your
+branch_ in the shared rules. Your tests lands on the story branch when that PR merges.
 
 ## Where your work comes from
 
-The **Handoff comments on the story's PR** — machine-written and schema-enforced, one per
+The **Handoff comments on the story's issue** — machine-written and schema-enforced, one per
 authoring task. Their `testingNotes` are written for you: each names an `area` to cover and
 the `why`, the silent failure that lint, typecheck and build would all miss. Start there,
 then read the diff for what actually changed.
@@ -44,8 +42,8 @@ distance is exactly what this role exists to close.
 - **`testingNotes` is `[]`** — it considered coverage and concluded none was warranted.
   That is a real answer. Check it against the diff; if you disagree, say so and test
   anyway, but do not treat it as an oversight by default.
-- **No Handoff comment on the PR at all** — no author ran on this story, or its run failed
-  before posting. You have no handoff. Work from the issue and the diff, and say so.
+- **No Handoff comment on the story at all** — no author ran, or its run failed before
+  posting. You have no handoff. Work from the issue and the diff, and say so.
 
 Don't stall waiting on a handoff, and don't invent behaviour the code doesn't have.
 

--- a/packages/claude-team/prompts/writer.md
+++ b/packages/claude-team/prompts/writer.md
@@ -5,27 +5,25 @@ You are usually triggered on **your own task issue** — the Architect cuts a `R
 task on the story, and the `@claude` label routes it here by that stamp. A
 `@claude/writer` comment names you directly and works on an issue or a PR.
 
-## Finding the story's PR
+## Where to read the handoffs
 
-Your input and your output are both on it, and you are not triggered there, so look it up
-once at the start. `$STORY` is the story your task belongs to:
+They are comments on the **story's issue**, `$STORY` — not on a PR:
 
 ```
-gh issue view "$STORY"
-gh pr list --repo <owner>/<repo> --head <the branch that issue names> --state open
+gh issue view "$STORY" --comments
 ```
 
-⚠️ Triggered **on a PR** instead, you already have its number — read its comments and skip
-this. ⚠️ If `$STORY` is empty, fall back to the **Branch** line on `$ISSUE` itself; a task
-carries its story's branch on the same line.
+⚠️ The story's issue, because it always exists. Its PR does not until the first task PR
+merges into the story branch, so a handoff written during the first task would have nowhere
+to go. ⚠️ If `$STORY` is empty, fall back to the **Branch** line on `$ISSUE`.
 
 ## Where your work goes
 
 The story's branch, named on the issue's **Branch** line — your changes land in the same PR
 as the code they document.
 
-⚠️ **Do not create a branch.** If no PR exists yet, a scripted hook opens it after you
-finish.
+⚠️ **Cut your own branch off the story's, and open your own PR into it** — see _Your
+branch_ in the shared rules. Your documentation lands on the story branch when that PR merges.
 
 ## You run last in a story, not last in an epic
 
@@ -39,7 +37,7 @@ avoid by deferring, and deferring would only move the explanation further from t
 
 ## Where your work comes from
 
-**Handoff comments on the story's PR** — machine-written and schema-enforced, one per
+**Handoff comments on the story's issue** — machine-written and schema-enforced, one per
 authoring task. Their `docsCandidates` each name a `file`, the `note` that should go in it,
 and the `why`: the time the author actually lost for not knowing it. Start there, then read
 the diff for what changed.
@@ -51,7 +49,7 @@ name, or that will be stale within a release. `why` is the field to judge on: a 
 with no real cost behind it usually isn't one. Say so briefly in the PR so the proposer
 learns the line.
 
-⚠️ **Read every handoff on the PR before accepting any of them.** Two authors on one story
+⚠️ **Read every handoff on the story before accepting any of them.** Two authors on one story
 proposing the same note is one entry, not two, and the version worth writing is usually more
 general than either — that view is why you run after them rather than beside them.
 


### PR DESCRIPTION
Closes #502.

## Why it needed doing

⚠️ **It was a race, not just awkward.** The concurrency group is `claude-<issue-or-pr-number>`, so two tasks on one story are different issue numbers, land in **different groups**, and could commit to the same branch simultaneously. Nothing serialized them except you triggering runs one at a time.

## The model

| level | branch | its PR targets | closed by |
|---|---|---|---|
| **Epic** | none | — | its stories closing |
| **Story** | `<story#>-…`, cut by the Architect | `mainline` | its PR merging |
| **Task** | `<task#>-…`, cut by its author off the story branch | the **story** branch | its own PR merging |

Tester and Writer follow the identical process — own task, own branch, own PR into the story branch — triggered by you when the authoring work is done.

## Two hooks moved, both forced rather than chosen

**`open-story-pr.sh` runs from `merge_housekeeping` now.** The story branch is empty until a task lands on it, and GitHub will not open a PR with no commits between base and head — so the first task merge is the earliest moment the story's PR *can* exist. It gates on the merged PR's base ref.

**`post-handoff.sh` posts to the story's ISSUE, not its PR** — same reason. During the first task there is no story PR to post to. The issue always exists and `$STORY` already points at it.

## One behaviour deliberately removed

`close-merged-work.sh` no longer expands a closed issue's open sub-issues. That was added in #485 because tasks had no PRs and a story's merge was the only thing that could close them. Now a task still open when its story merges is a **real signal** — abandoned, or its PR never landed — and closing it silently would hide exactly the case worth seeing.

Its body-parse fallback becomes load-bearing in exchange: ⚠️ a task PR targets a non-default base, so GitHub ignores its `Closes #<task>` entirely, and the hook is the **only** thing that closes a task. That code was written for the retired epic-branch model and is now the mechanism the hierarchy depends on.

## A wrong turn worth recording

⚠️ **`delegate.sh` needed no change, and I broke it before establishing that.**

I switched story resolution to a parent walk, assuming a `<task#>-…` branch would no longer name its story. Two things were wrong. The **Branch** line on a task names the *story's* branch and always did — it is what the author bases on and merges into, so the existing prefix derivation survives untouched. And the walk assumed every story sits under an epic: **#496 has no parent**, so it resolved each of that story's tasks to *itself*.

Caught by running it against the real tree rather than reasoning about it. Reverted, and the reason is now a comment at the line so the next person doesn't repeat it.

## Verification

`npm test --ws` (eslint) ✓ 0 errors · `tsc --noEmit` ✓ · `vite build` ✓ · `bash -n` clean on all ten hooks · workflow parses.

**`delegate.sh` against the live issue tree** — task #497 → `story=496`, task #498 → `story=496`, story #496 → `story=496`. All correct, including the parentless-story case that broke the walk.

**`open-story-pr.sh` base gating, real `gh`:**

| merged base | result |
|---|---|
| `mainline` | not a story branch, no-op |
| `496-move-complete-phase-button` | found PR #499 already open — correct |
| `some-hand-cut-branch` | warns, cannot resolve a story |
| empty | no-op |

**Structure:** `open-story-pr.sh` is in `merge_housekeeping` and gone from the authors job; `post-handoff.sh` receives `$STORY` and writes to `issues/$target`; both hooks derive a story from a branch with the identical expression, so they cannot disagree.

**Sweep:** nothing in any prompt or overlay still says a task has no branch or PR.

Routing and loop guard re-evaluated, unchanged.

⚠️ Verify will not run — the path filter excludes workflows, docs and `packages/claude-team`.

⚠️ Cannot be exercised before merge. Afterwards the check is: an author run opens a PR into the story branch rather than committing to it, and merging that PR closes the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
