### PR TITLE
Move the portable team model into claude-team

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,44 +365,28 @@ one per task, updated rather than duplicated on a re-run.
   fire-and-forget call while lint, tsc and build stay green — is only caught by a test
   written to distrust the change.
 
-**Epic → story → task.** The team definition lives in
-[`packages/claude-team`](packages/claude-team/README.md); this repo extends it with
-per-role overlays in `.github/agent-prompts/`.
+**Epic → story → task.** ⚠️ **The model itself lives in
+[`packages/claude-team/README.md`](packages/claude-team/README.md)** — the hierarchy, how a
+story moves, routing, the handoff contract and the hooks. It is portable and this file must
+not restate it; two copies drift, and they already had. What follows is only how *this repo*
+applies it.
 
-| level | branch | its PR targets | closed by |
-|---|---|---|---|
-| **Epic** | none | — | its stories closing |
-| **Story** | `<story#>-…`, cut by the Architect | `mainline` | its PR merging |
-| **Task** | `<task#>-…`, cut by its author off the story branch | the **story** branch | its own PR merging |
+- **Default branch** `mainline`. A story's PR targets it and a merge ships to prod, so the
+  story PR is the last gate before deploy.
+- **Overlays** live in `.github/agent-prompts/` — `_shared.md` plus an optional
+  `<role>.md`, appended to the package's prompt of the same name.
+- **Board.** Issues and PRs go on project #4 (`gh project item-add 4 --owner "@me"`);
+  `set-issue-status.sh` and `close-merged-work.sh` move them, and are the only steps holding
+  `PROJECTS_TOKEN`.
+- **The front door is the `@claude` label.** ⚠️ It and every `@claude/<role>` label must
+  exist in the repo — the front door triggers nothing if absent, and a missing role label
+  makes the stamp hook warn and skip.
 
-- Architect cuts the story's branch off `mainline`, empty, and records it in the story as a
-  **Branch** line. It stamps that **same** line onto every task — it always names the
-  *story's* branch, never a branch for the task — plus a **Role** line naming who picks it
-  up. Routing is a shell script that reads the stamp rather than judging it.
-- Each author cuts `<task#>-…` off the story branch, works there, and opens a PR **into**
-  the story branch. Merging that closes the task and lands the work on the story.
-- The **story's** PR opens on the first task merge, via `open-story-pr.sh` — ⚠️ from
-  `merge_housekeeping`, not from an authoring run. The story branch is empty until a task
-  lands on it, and GitHub will not open a PR with no commits between base and head.
-
-⚠️ **Tasks used to share the story's branch, and that was a race.** The concurrency group is
-keyed on issue number, so two tasks are in *different* groups and could commit to the same
-branch simultaneously. Sub-branching fixes it structurally rather than by triggering runs one
-at a time.
-⚠️ One story PR, growing, is still the point — the maintainer reviews the story landing as a
-whole rather than one PR per role. It just accumulates by merge now, not by direct commit.
-⚠️ A story PR targets `mainline`, so its `Closes #<story>` works normally. **A task PR does
-not** — GitHub ignores closing keywords on a non-default base, so `close-merged-work.sh`
-parsing the body is the only thing that closes a task.
-⚠️ That hook no longer expands a closed issue's open sub-issues. It did when tasks had no
-PRs and a story's merge was the only thing that could close them; now a task still open when
-its story merges is a real signal — abandoned, or its PR never landed — and closing it would
-hide the case worth seeing.
-⚠️ `pull_request` events run the workflow from the PR's **base** branch, so workflow fixes
-do not reach an in-flight story until `mainline` is merged into it.
-⚠️ An epic has no branch, so nothing to merge in and nothing to keep current. That was the
-main cost of the old epic-integration-branch model.
-
+⚠️ Workflow changes to any of this **cannot be tested before merge**: `issues` and
+`issue_comment` both run the workflow from the default branch, so a PR branch's version is
+never the one that fires. Diagnose a suspicious run by `num_turns` in its log — a dead run
+reports success and leaves the action's placeholder comment behind, which reads exactly like
+a real reply.
 
 **Budgets.** `sonnet` throughout except the Implementor, which runs `opus` — it is the only
 role whose output the maintainer must review line by line. Architect 100 turns,

--- a/packages/claude-team/README.md
+++ b/packages/claude-team/README.md
@@ -10,50 +10,125 @@ its packages or its conventions — if it does, it belongs in the consumer's ove
 
 ## The issue hierarchy
 
-| level | branch | PR | what it is |
+| level | branch | its PR targets | closed by |
 |---|---|---|---|
-| **Epic** | no | **no** | a cross-story product goal; a grouping, nothing more |
-| **Story** | **one** | **exactly one** | a sub-issue of an epic — the unit that ships |
-| **Task** | no | no | a sub-issue of a story; divided work that lands on the story's branch |
+| **Epic** | none | — | its stories closing |
+| **Story** | `<story#>-<summary>`, cut by the Architect | the **default** branch | its PR merging |
+| **Task** | `<task#>-<summary>`, cut by its author off the story branch | the **story** branch | its own PR merging |
 
 - An epic never has a branch and never has a PR. If something needs a PR, it is a story.
-- A story owns one branch and one PR against the default branch.
-- A task is a slice of a story. Its work is committed to the **story's** branch and shows
-  up in the **story's** PR.
+- A story owns one branch and one PR against the default branch, and it accumulates.
+- A task is a slice of a story with its own branch and its own PR **into the story branch**.
+
+⚠️ **The Branch line always names the STORY's branch** — on the story and on every one of
+its tasks. It is what an author bases on and merges back into, never a branch for the task
+itself. Anything deriving a story from a branch name reads that prefix.
+
+⚠️ **Tasks must not share one branch.** They did once, and it was a race: if a consumer keys
+its concurrency group on issue number, two tasks are in *different* groups and can commit to
+the same branch at the same time. Sub-branching removes the possibility rather than relying
+on runs being triggered one at a time.
 
 ## How a story moves
 
-1. **Architect** shapes the story and cuts its branch off the default branch.
-2. The **first author to run** — Implementor or Designer, Tester, Writer — opens the story's PR.
-3. **Every subsequent role commits to that same branch.** No role cuts its own.
-4. The maintainer reviews one PR as it accumulates each role's contribution, and merges.
+1. **Architect** shapes the story, cuts its branch off the default branch, and creates its
+   tasks — each stamped with the role that should pick it up.
+2. Each **task** is triggered on its own. Its author cuts a branch off the story branch,
+   works there, and opens a PR into the story branch.
+3. Merging that task PR closes the task and lands its work on the story.
+4. The **story's** PR accumulates all of it. The maintainer reviews and merges the story as
+   a whole.
 
-⚠️ This is the point of the design: one PR per story, growing, instead of one PR per role.
-A reviewer sees the story land as a whole.
+⚠️ **The story's PR opens on the first task merge, from the merge hook — not from an
+authoring run.** The story branch is cut empty, and GitHub will not open a PR with no
+commits between base and head, so the first task landing is the earliest moment it can
+exist.
+
+⚠️ **A task PR's closing keyword does nothing on its own.** GitHub honours `Closes #N` only
+when a PR targets the **default** branch, and a task PR targets the story branch. The merge
+hook parsing the body is the only thing that closes a task — which is why an author must
+write the line even though GitHub ignores it.
+
+⚠️ **A task still open when its story merges is a signal, not a gap.** Nothing closes it
+implicitly: it was abandoned, or its PR never landed. An earlier version closed a merged
+issue's open children, which hid exactly the case worth seeing.
+
+⚠️ **`pull_request` events run the workflow from the PR's base branch**, so a workflow fix
+does not reach an in-flight story until the default branch is merged into it.
+
+## Routing
+
+**A label on an issue is the front door.** Applying it starts a run, and `delegate.sh` reads
+the issue's state to pick the role. The same label named in a comment does the same. A
+`@claude/<role>` handle in a comment names the role outright and skips the inspection — the
+way to override a bad guess.
+
+⚠️ **Routing is a shell script, never a model.** It is all readable state; the one call that
+needs judgement — which author owns a task — is answered once by the Architect and written
+into the task as a `Role:` line.
+
+⚠️ **The role stamp is a record, not a route.** Roles stamp `@claude/<role>` as they start,
+so the labels read as "these agents have been here". Nothing routes off them.
+
+⚠️ **Guard the loop.** Every stamp is another `labeled` event. Gate the trigger on the label
+name being *exactly* the front-door label, and exclude bot actors. Both hold independently.
+(A third guard comes free: a stamp applied with `GITHUB_TOKEN` does not start a workflow run
+at all.)
 
 ## Roles
 
-| role | trigger | works on | writes |
-|---|---|---|---|
-| Architect | `@claude/architect` | epic or story | the issue, a story's branch, and its tasks |
-| Implementor | `@claude/implementor` | story or task | code, outside the design system |
-| Designer | `@claude/designer` | story or task | code, inside the design system |
-| Tester | `@claude/tester` | story or task | tests |
-| Writer | `@claude/writer` | story or task | documentation |
-| Security | none — runs on merge | the merged PR | issues it files |
+| role | picked up from | writes |
+|---|---|---|
+| Architect | an epic or an unshaped story | the issue, a story's branch, and its tasks |
+| Implementor | a task stamped `Role: implementor` | code, outside the design system |
+| Designer | a task stamped `Role: designer` | code, inside the design system |
+| Tester | a task stamped `Role: tester`, one per story | tests |
+| Writer | a task stamped `Role: writer`, one per story | documentation |
+| Security | every merge, plus its handle on a PR | issues it files |
 
-**The handle in a comment picks the role.** Labels record which roles have been here; they
-route nothing. A bare `@claude` does nothing, so a half-typed handle cannot start the wrong
-agent.
+⚠️ **Implementor and Designer split on the package a change touches, not on judgement**, so
+the boundary can be checked rather than negotiated. A task spanning both is two tasks, and
+only the Architect can cut it in two.
+
+⚠️ **The Tester and Writer are tasks the Architect cuts**, ordered after the authoring ones.
+No role chains off another — nothing runs that a maintainer did not trigger.
+
+## The handoff between authors
+
+An author's step carries `--json-schema`, so its final message is a contract: `testingNotes`
+for the Tester, `docsCandidates` for the Writer. A hook posts it to the **story's issue** as
+one comment per task; the Tester and Writer read it there.
+
+- ⚠️ **Both keys are required and `[]` is a real answer** — "I looked, there is nothing",
+  which a consumer can act on. A missing key says nothing at all. That distinction is the
+  entire reason this is a schema and not a prose section.
+- ⚠️ **The story's issue, not its PR.** The PR does not exist until the first task merges,
+  so a handoff written during the first task would have nowhere to go.
+- ⚠️ **Deterministic at both ends:** the schema forces the author to produce it, the hook
+  forces delivery. Neither is a model instruction. Asking a model to leave a
+  machine-readable block for a later role is the version that fails.
+- A candidate is a proposal, never an order. Rejecting all of them is a correct outcome.
 
 ## Prompt composition
 
-A role's prompt is `prompts/<role>.md` (this package) concatenated with the consumer's
-overlay. The base says how the role behaves and how the hierarchy works; the overlay says
-what the repo's gate is, where its code lives, and any house rules.
+A role's prompt is `prompts/_shared.md` then `prompts/<role>.md` from this package, followed
+by the consumer's overlay in the same order. The base says how the role behaves and how the
+hierarchy works; the overlay says what the repo's gate is, where its code lives, and any
+house rules.
 
-⚠️ Keep the split honest. A rule that would be true in any repo belongs in the base; a rule
-that names a command, a path or a package belongs in the overlay.
+⚠️ **Shared first, and that ordering is load-bearing.** `_shared.md` opens by overriding the
+host action's own prompt, which for comment events states repeatedly that the model's
+instructions are the triggering comment. Ours arrives after all of that, so the override has
+to be the first thing in it.
+
+⚠️ **Keep the split honest.** A rule that would be true in any repo belongs in the base; a
+rule that names a command, a path or a package belongs in the overlay.
+
+⚠️ **`trigger_phrase` must be the role's exact handle.** It gates nothing when a prompt is
+supplied, but the action extracts everything *after* it as "the user request" and yields
+that as the final content block, which the CLI scans for a slash command. Set to a bare
+front-door label, `@claude/<role> do X` extracts as `/<role> do X` and is swallowed as an
+unknown slash command — the run reports success having never called the model.
 
 ## Hooks
 
@@ -62,14 +137,24 @@ forgotten by a model that ran out of turns or simply skipped it.
 
 | hook | when | does |
 |---|---|---|
+| `acknowledge.sh` | the router job, first | reacts 👀 so the trigger is visibly received |
+| `delegate.sh` | the router job | picks the role from issue state — routing is scripted, not judged |
 | `stamp-role-label.sh` | pre, every role | stamps `@claude/<role>` on the triggering issue or PR |
-| `acknowledge.sh` | pre, every role | reacts 👀 so the trigger is visibly received |
-| `delegate.sh` | pre, every role | picks the role(s) from issue state — routing is scripted, not judged |
 | `set-issue-status.sh` | pre, authors | sets the issue's board Status; the column is an input |
 | `file-sub-issues.sh` | post, Architect | parents stories to their epic, tasks to their story |
-| `open-story-pr.sh` | post, authors | opens the story's PR if it has none |
 | `finish-pr.sh` | post, authors | labels the PR and ensures it closes its issue |
+| `post-handoff.sh` | post, authors | posts the JSON handoff to the story's issue |
+| `log-to-epic.sh` | post, authors | rewrites one rolling work-log comment on the epic |
+| `open-story-pr.sh` | **on merge** | opens the story's PR once a task has landed on its branch |
 | `close-merged-work.sh` | on merge | closes the PR's issues and files them on the board |
 
 ⚠️ These were prompt instructions until a model skipped them. A scripted step costs no
 turns and cannot be forgotten.
+
+⚠️ **A scripted hook fed by model-written input is still model-driven.** Derive a hook's
+input from something the model must produce for another reason, or from state it cannot
+avoid creating — never from a block it was merely asked to leave behind.
+
+⚠️ **`gh api` prints its error body to stdout**, so `--jq` never runs and a 404 lands in the
+variable. The parent endpoint 404s for anything unparented, which is most issues. Filter
+captures to digits and read anything else as absent.


### PR DESCRIPTION
Closes #504. You were right that #503's `CLAUDE.md` changes belonged in the package — and the package was in worse shape than the diff suggested.

## The README described a system nobody runs

It still said, verbatim:

- `| **Task** | no | no | … work that lands on the story's branch |`
- "A task … Its work is committed to the **story's** branch"
- "The **first author to run** … opens the story's PR"
- "**Every subsequent role commits to that same branch.** No role cuts its own."

All four false as of #503. Also "The handle in a comment picks the role… A bare `@claude` does nothing" — false since #485. Its hooks table was three behind: `post-handoff.sh` and `log-to-epic.sh` missing, `open-story-pr.sh` listed as `post, authors` when it runs on merge, `acknowledge.sh`/`delegate.sh` as `pre, every role` when they have been their own job since #485.

⚠️ **A portable package documenting a model nobody runs is worse than one documenting nothing.** A second repo adopting it would build the thing this repo just spent a night dismantling.

## What moved

The README now carries the model, with the platform constraints that *shape* it rather than just the rules:

- GitHub will not open a PR with no commits between base and head — which is *why* the story PR opens on the first task merge rather than by preference.
- Closing keywords fire only when a PR targets the default branch — which is why an author writes `Closes #<task>` that GitHub ignores, and why the merge hook is the only thing that closes a task.
- `pull_request` events run the workflow from the base branch.
- `trigger_phrase` must be the exact handle, or the extracted user request begins with `/` and the run dies as an unknown slash command reporting success.
- Tasks sharing one branch is a race unless something serializes them.

The root file keeps only this repo's application: `mainline`, the overlay path, the board and its token, which labels must exist, and that none of it can be tested before merge.

## Verification

`npm test --ws` (eslint) ✓ 0 errors · `tsc --noEmit` ✓ · workflow parses.

Asserted mechanically:

- **The README names nothing BrewDocs-specific** — swept for the repo name, `mainline`, every package path, `npm ci`, `vite`, `eslint`, `tsc`, the project number, Storybook and Playwright. Clean apart from the two lines that deliberately say BrewDocs is the first consumer.
- **Nothing in it still describes the pre-#503 model** — swept for each of the five stale claims above.
- **The hooks table matches the hooks that exist** — 10 on disk, 10 documented, no phantoms.
- **No portable claim is duplicated back into the root file** — checked five of the load-bearing ones.

## ⚠️ Known, and I would take it next

This PR moves the block #503 touched. Measuring the rest of the root file, four more sections are largely the same portable model:

| section | lines | carrying repo specifics |
|---|---|---|
| `Backlog work is scripted` | 64 | 6% |
| `Labels are a record` | 13 | 8% |
| `The handoff between authors` | 44 | 7% |
| `Routing` | 86 | 26% |

The first three are ~93% portable, and the README I just wrote now covers the same ground — so **this PR trades one duplication for another** in those three sections. That is a real cost and it is the drift problem, not a fix for it.

I did not fold them in because collapsing ~120 lines of accumulated ⚠️ notes needs each one audited against the README first, and doing that unaudited is how the knowledge those notes exist to preserve gets quietly dropped. Worth its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
