### PR TITLE
Show each story's tasks in trigger order

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -270,6 +270,14 @@ jobs:
             --allowedTools "Read,Edit,Write,Bash(gh:*),Bash(git:*)"
             --max-turns 100
 
+      - name: Update the story's task order
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # the Architect is triggered ON the story, so the story is the issue itself
+          STORY: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+        run: "$RUNNER_TEMP/agent-bin/log-to-story.sh"
       - name: File the story's sub-issues
         # ⚠️ `issues` must be here as well as `issue_comment`. The label is now the primary
         # way an Architect run starts, and keyed to comments alone this hook — the thing that
@@ -663,6 +671,13 @@ jobs:
           # which the hook treats as "nothing to post" rather than an error.
           HANDOFF: ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output }}
         run: "$RUNNER_TEMP/agent-bin/post-handoff.sh"
+      - name: Update the story's task order
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          STORY: ${{ needs.delegate.outputs.story }}
+        run: "$RUNNER_TEMP/agent-bin/log-to-story.sh"
       - name: Update the epic's work log
         if: always()
         env:
@@ -815,6 +830,19 @@ jobs:
       # branch is empty until a task PR merges into it, and GitHub will not open a PR with no
       # commits between base and head — so the first task merge is the earliest moment it can
       # exist. Runs for every merged PR and no-ops unless the base is a story branch.
+      # ⚠️ Ordered AFTER close-merged-work.sh: it reads task state, and the task this PR
+      # just closed is only closed once that hook has run.
+      - name: Update the story's task order
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # a task PR's base is its story's branch, named <story#>-<summary>
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          STORY=$(printf '%s' "$BASE" | grep -oE '^[0-9]+' || true)
+          export STORY
+          "$RUNNER_TEMP/agent-bin/log-to-story.sh"
       - name: Open the story PR
         if: always()
         env:

--- a/packages/claude-team/README.md
+++ b/packages/claude-team/README.md
@@ -93,6 +93,13 @@ only the Architect can cut it in two.
 ⚠️ **The Tester and Writer are tasks the Architect cuts**, ordered after the authoring ones.
 No role chains off another — nothing runs that a maintainer did not trigger.
 
+⚠️ **Trigger order is derived, never stamped.** Tasks sort by `(phase, issue number)`: phase
+from the `Role:` stamp — authors, then tests, then docs — and number within a phase, because
+the Architect creates them in the order it intends. A task is ready once everything before it
+is closed, so the first open task is the one to trigger. Both inputs are things the Architect
+must produce for other reasons; a third stamp naming an order would be a third line it could
+skip.
+
 ## The handoff between authors
 
 An author's step carries `--json-schema`, so its final message is a contract: `testingNotes`
@@ -144,6 +151,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 | `file-sub-issues.sh` | post, Architect | parents stories to their epic, tasks to their story |
 | `finish-pr.sh` | post, authors | labels the PR and ensures it closes its issue |
 | `post-handoff.sh` | post, authors | posts the JSON handoff to the story's issue |
+| `log-to-story.sh` | post, Architect + authors + on merge | rewrites one comment on the story listing its tasks in trigger order |
 | `log-to-epic.sh` | post, authors | rewrites one rolling work-log comment on the epic |
 | `open-story-pr.sh` | **on merge** | opens the story's PR once a task has landed on its branch |
 | `close-merged-work.sh` | on merge | closes the PR's issues and files them on the board |

--- a/packages/claude-team/hooks/log-to-story.sh
+++ b/packages/claude-team/hooks/log-to-story.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Keeps ONE rolling comment on a story listing its tasks in the order they should be
+# triggered, with what is done, what is ready, and what is waiting on something earlier.
+#
+# Every task is triggered by hand, so "which one next" is a question the maintainer asks
+# constantly. log-to-epic.sh answers it only for a story that sits under an epic; a
+# standalone story had no board at all.
+#
+# ⚠️ NOTHING HERE IS WRITTEN BY A MODEL. Order is derived from two things the Architect must
+# produce for other reasons:
+#
+#   phase   from the `Role:` stamp — an author precedes the tester, which precedes the
+#           writer. That is the cadence it already cuts to.
+#   number  within a phase, because it creates tasks in the order it intends them to run.
+#
+# A third stamp naming an order would be a third line it could skip, which is the
+# owner-manifest failure. These two cannot be skipped without breaking routing itself.
+set -euo pipefail
+
+: "${REPO:?REPO is required}"
+
+MARKER='<!-- claude-team:storylog -->'
+
+if [ -z "${STORY:-}" ]; then
+    echo "No story in scope — nothing to order."
+    exit 0
+fi
+
+kids=$(gh api "repos/$REPO/issues/$STORY/sub_issues" \
+    --jq '.[] | "\(.number)\t\(.state)\t\(.title)"' 2>/dev/null | grep -E '^[0-9]+	' || true)
+
+if [ -z "$kids" ]; then
+    echo "#$STORY has no tasks — nothing to order."
+    exit 0
+fi
+
+role_of() {
+    gh issue view "$1" --repo "$REPO" --json body --jq '.body // ""' 2>/dev/null \
+        | grep -oiE 'role: *`?[a-z]+`?' | head -1 \
+        | sed -E 's/.*[Rr]ole: *`?([a-z]+)`?.*/\1/' || true
+}
+
+# phase: authors first, then tests, then docs. An unstamped task sorts with the authors —
+# routing defaults it to an author too, so the two stay consistent.
+phase_of() {
+    case "$1" in
+        tester) printf '2' ;;
+        writer) printf '3' ;;
+        *)      printf '1' ;;
+    esac
+}
+
+ordered=$(
+    printf '%s\n' "$kids" | while IFS=$'\t' read -r n st t; do
+        r=$(role_of "$n")
+        printf '%s\t%s\t%s\t%s\t%s\n' "$(phase_of "$r")" "$n" "$st" "${r:-—}" "$t"
+    done | sort -t$'\t' -k1,1n -k2,2n
+)
+
+# ⚠️ Ready/waiting falls out of the same order rather than being tracked separately: a task
+# is ready when everything before it is closed. So the first open task IS the one to trigger.
+next=$(printf '%s\n' "$ordered" | awk -F'\t' '$3=="open" {print; exit}')
+
+body_file=$(mktemp)
+{
+    printf '%s\n' "$MARKER"
+    printf '## Tasks, in trigger order\n\n'
+    if [ -n "$next" ]; then
+        printf '**Trigger next — #%s**  \n%s  \n`Role: %s`\n\n' \
+            "$(printf '%s' "$next" | cut -f2)" \
+            "$(printf '%s' "$next" | cut -f5)" \
+            "$(printf '%s' "$next" | cut -f4)"
+    else
+        printf '_Every task is closed — the story is ready to review._\n\n'
+    fi
+
+    # ⚠️ Stateless on purpose. A `seen_open` flag would be set inside the pipeline's
+    # subshell and reset on every iteration, so every open row would read "ready". The
+    # first open task is already known — compare against it instead of tracking state.
+    next_n=$(printf '%s' "$next" | cut -f2)
+    printf '| | task | role | state |\n|---|---|---|---|\n'
+    printf '%s\n' "$ordered" | while IFS=$'\t' read -r ph n st r t; do
+        if [ "$st" = "closed" ]; then
+            mark='✅ done'
+        elif [ "$n" = "$next_n" ]; then
+            mark='⬜ **ready**'
+        else
+            mark='⏸ waiting'
+        fi
+        printf '| %s | #%s %s | `%s` | %s |\n' "$ph" "$n" "$t" "$r" "$mark"
+    done
+
+    printf '\nOrder is derived — authors, then tests, then docs; by issue number within each.\n'
+    printf 'Rewritten automatically whenever a task changes state.\n'
+} > "$body_file"
+
+existing=$(gh api "repos/$REPO/issues/$STORY/comments" --paginate \
+    --jq "[.[] | select((.body // \"\") | contains(\"$MARKER\")) | .id] | last // empty" 2>/dev/null || true)
+
+if [ -n "$existing" ]; then
+    if gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+        -f body="$(cat "$body_file")" >/dev/null 2>&1; then
+        echo "updated the task order on story #$STORY"
+    else
+        echo "::warning::could not update the task order on #$STORY"
+    fi
+elif gh issue comment "$STORY" --repo "$REPO" --body-file "$body_file" >/dev/null 2>&1; then
+    echo "posted the task order on story #$STORY"
+else
+    echo "::warning::could not post the task order on #$STORY"
+fi
+rm -f "$body_file"

--- a/packages/claude-team/prompts/architect.md
+++ b/packages/claude-team/prompts/architect.md
@@ -80,6 +80,12 @@ fresh in front of you.
 ⚠️ **A task you cannot cleanly assign should be split, not guessed at.** If a task spans two
 roles' territory, that is a sign it is two tasks.
 
+⚠️ **Create tasks in the order they should be run.** That order is read, not just described:
+a hook lists the story's tasks by `(phase, issue number)` and names the next one to trigger,
+where phase comes from the `Role:` stamp — authors, then tests, then docs. Within a phase,
+the number you created them in *is* the order. If one author's task must land before
+another's, create it first.
+
 ⚠️ **Implementor vs Designer is decided by the package, not by judgement.** A task whose
 changes fall inside the design-system package is `designer`; everything else is
 `implementor`. Read the paths rather than reasoning about which side a change "really"


### PR DESCRIPTION
Closes #506.

Every task is triggered by hand and nothing said in what order. `log-to-epic.sh` answers it, but only for a story under an epic — ⚠️ **#496 has no parent, so the story you are actually working had no board at all.**

## What you get

A rolling comment on the story, rendered here against the real #496:

> ## Tasks, in trigger order
>
> **Trigger next — #497**
> Add a complete-phase action to BrewTimer
> `Role: designer`
>
> | | task | role | state |
> |---|---|---|---|
> | 1 | #497 Add a complete-phase action to BrewTimer | `designer` | ⬜ **ready** |
> | 1 | #498 Wire the phase-complete action into the Brew Timer | `implementor` | ⏸ waiting |

## Nothing in it is written by a model

Order is `(phase, issue number)`:

- **phase** from the existing `Role:` stamp — authors, then tests, then docs.
- **number** within a phase, because the Architect creates tasks in the order it intends them to run.

⚠️ **No new stamp, deliberately.** A third line naming an order is a third line the Architect can skip — the `owner-manifest` failure. Both inputs here are things it must already produce, and it cannot skip either without breaking routing itself.

**Ready and waiting fall out of the same order** rather than being tracked separately: a task is ready when everything before it is closed, so the first open task *is* the one to trigger.

## Where it runs

At each point story state changes: after the Architect creates the tasks (the first moment an order exists), after an authoring run, and on merge when a task closes.

⚠️ On merge it is ordered **after** `close-merged-work.sh` — it reads task state, and the task that PR just closed is only closed once that hook has run. Asserted in the step order.

## A bug caught while writing it

⚠️ The table marked **every** open row "ready". The `seen_open` flag lived inside a pipeline's subshell, so it reset on every iteration. The first open task is already known, so each row now compares against it rather than tracking state — stateless, and it cannot regress the same way.

## Verification

`npm test --ws` (eslint) ✓ 0 errors · `tsc --noEmit` ✓ · `bash -n` clean on all 11 hooks · workflow parses.

**Rendered against live GitHub**, not stubs: story #496 produces the table above, with the designer task correctly ahead of the implementor one. Also exercised the two no-op paths — a task with no sub-issues (`#497 has no tasks`), and no story in scope — both exit 0 without writing.

**Structure:** the hook is wired into all three jobs; in `merge_housekeeping` the step order is `Close and file the PR's issues → Update the story's task order → Open the story PR`. All 11 hooks are documented in the README, none phantom.

Routing and loop guard re-evaluated, unchanged.

⚠️ Verify will not run — the path filter excludes workflows, docs and `packages/claude-team`.

⚠️ Cannot be exercised before merge. Afterwards, triggering anything on a story should leave the comment above on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
