### PR TITLE
Move the remaining portable model out of root CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,126 +244,30 @@ chained run's comment says `@claude/implementor`).
 `issue_comment` both always run the workflow from the default branch, so a PR branch's version
 is never the one that fires.
 
-**Backlog work is scripted, never prompted.** Hooks in `packages/claude-team/hooks/` run around each
-model step.
+**The mechanics are in the package.** Hooks and the traps each was written around, the
+handoff contract, labels-as-record, routing and its loop guard all live in
+[`packages/claude-team/README.md`](packages/claude-team/README.md). ⚠️ Do not restate them
+here — two copies drift, and they did: this file documented a sub-issue expansion that #503
+had already removed, and the package README described the pre-#503 branching model for a
+whole session without anyone noticing.
 
-- `stamp-role-label.sh` — pre, every role. Stamps `@claude/<role>` on the issue or PR.
-- `file-sub-issues.sh` — post, Architect. Parents stories to their epic and tasks to their
-  story, and copies its
-  milestone down. **Discovers** them — a bot-authored issue, numbered above the epic, whose
-  body references it as `epic #N` or `story #N`. Honours an old `owner-manifest` comment
-  too, unioned.
-- `acknowledge.sh` — the **delegate** job, first step of every run. Reacts 👀 so a trigger is
-  visibly received before any model runs. ⚠️ It reacts via `issues/comments/<id>`, so it is
-  handed a `COMMENT_ID` only for `issue_comment` — a review comment's id belongs to the
-  *pulls* collection and would react to an unrelated comment. Empty falls back to the issue
-  or PR itself.
-- `delegate.sh` — the **delegate** job, and the gate every role hangs off. Picks the role(s)
-  from issue state and emits them; routing is a shell script, never a model. ⚠️ A missing
-  `Role:` stamp defaults to Implementor and says so — wrong is recoverable, silent is not.
-- `set-issue-status.sh` — pre, Implementor and Tester. Moves the triggering issue to
-  **In Progress** on project #4, so the board reflects reality when work starts rather than
-  only when it merges. Skips a closed issue, so a re-run never resurrects finished work.
-- `finish-pr.sh` — post, Implementor / Tester / Writer. Labels the PR the run opened with
-  its role, and appends `Closes #<issue>` if the model didn't write one.
-- `open-story-pr.sh` — post, every authoring role. Opens the story's PR when its branch has
-  none and has commits. Reads the branch from the issue's **Branch** line.
-- `log-to-epic.sh` — post, authors job. Rewrites **one** rolling work-log comment on the
-  epic: what is open across every story, what just ran, and **what to pick up next** named
-  with its `Role:` stamp so the maintainer can assign without opening anything.
-  ⚠️ Entirely derived from GitHub state — no model writes any part of it, which is the
-  whole reason it can be trusted as a status board. ⚠️ One comment, rewritten, not one per
-  run: an epic with ten tasks × three roles would otherwise bury itself in thirty comments.
-- `close-merged-work.sh` — on merge, for **every** merged PR, not just an agent's. It was
-  gated on a `@claude/*` label or a Bot author and so skipped the maintainer's own PRs,
-  which are unlabeled by convention — eight issues closed via GitHub's native keywords
-  while the board was never updated. Nothing it does needs the PR to be an agent's, and it
-  exits early on one that closes no issue. Closes the PR's issues and files them on the
-  board.
-  ⚠️ It also closes a closed issue's **open sub-issues**: `open-story-pr.sh` lists the
-  tasks with closing keywords, but that body is written once when the PR opens, so a task
-  cut afterwards is nowhere in it.
+What is BrewDocs-specific:
 
-⚠️ **`gh api` prints its error body to STDOUT, so `--jq` never runs and a 404 lands in your
-variable.** `repos/…/issues/<n>/parent` 404s for anything unparented — most issues — so an
-unguarded capture returns `{"message":"No parent issue found",…}` and the caller treats that
-blob as an issue number. `delegate.sh` and `log-to-epic.sh` both filter captures to digits
-and read anything else as absent. Any new hook reading that endpoint must do the same.
+- ⚠️ **`PROJECTS_TOKEN` appears in `close-merged-work.sh` and `set-issue-status.sh`, and
+  nowhere else.** It is a long-lived classic PAT needing `project` **and** `read:org` (a
+  fine-grained token cannot reach user-owned Projects v2), covering every project the
+  maintainer owns. It is safe only because both are *scripted* steps and step env is
+  per-step — the model step in the same job cannot read it. ⚠️ Never add it to a job whose
+  model step holds `Bash(gh:*)`.
+- The board is **project #4**: `gh project item-add 4 --owner "@me" --url <url>`.
+- The handoff schema is
+  [`packages/claude-team/schemas/handoff.json`](packages/claude-team/schemas/handoff.json);
+  a workflow step compacts and inlines it, and **fails the run** if the file ever gains a
+  single quote.
+- ⚠️ **`@claude/security` on issues Security files is this repo's one exception to "create
+  issues unlabeled"** — it marks provenance so a finding stands out in a queue. Every other
+  label is applied by a hook to something a role opened.
 
-⚠️ These were prompt instructions until a model skipped them. A label trail is worthless if
-a run can forget to stamp it, and the merge hook is the only backlog behaviour that worked
-on its first attempt — everything model-driven took three.
-⚠️ **A scripted hook fed by model-written input is still model-driven.** Sub-issue filing
-read a machine-readable manifest the decomposing role was told to leave; across nine epics it
-wrote one exactly once, and the hook logged `No owner-manifest — nothing to file` and did
-nothing. Moving the instruction from "call the API" to "write a JSON block" only moved
-where it got skipped. Derive the input from something the model must produce **for another
-reason** — here the **Branch** line, which the story PR already depends on.
-⚠️ **A prose marker cannot be the only marker in a repo whose issues quote its own
-conventions.** The first version matched a branch line plus `epic #N` and adopted a
-meta-issue that quoted the convention verbatim as an example. The author check
-(`.user.type == "Bot"`) is what makes it sound — with the consequence, accepted, that a
-hand-written sub-issue is never auto-parented.
-⚠️ `PROJECTS_TOKEN` appears only in `close-merged-work.sh` and `set-issue-status.sh`, both scripted steps. Step env is per-step, so a model step in the same job cannot read it. It is a long-lived
-classic PAT (`project` + `read:org`) covering every project the maintainer owns, secret
-masking covers logs only, and a role holding `Bash(gh:*)` could publish it in a comment.
-
-**Labels are a record, not a route.** Each role stamps its own as it starts, so the labels
-read as "these agents have been here". The maintainer clears them as a check-off.
-
-- `stamp-role-label.sh` stamps the issue or PR that **triggered** the run.
-- A role that **opens** a PR labels it itself (`gh pr create --label "@claude/<role>"`) — the
-  triggering stamp cannot reach a PR that did not exist yet.
-- ⚠️ Two carve-outs from "create things unlabeled": a role's PR is labelled by
-  `finish-pr.sh`, and Security labels the issues it files. Nothing else, and never
-  someone else's.
-- ⚠️ `Closes #<issue>` stays a prompt instruction *and* a hook. The model writing it puts
-  the link where a human reads it; the hook is the net, because a missing keyword loses the
-  close and the board move with nothing to signal it.
-
-**The handoff between authors is a JSON contract**, and it travels by comment. The author's
-step carries `--json-schema`, so its final message must match
-[`packages/claude-team/schemas/handoff.json`](packages/claude-team/schemas/handoff.json) —
-`testingNotes` for the Tester, `docsCandidates` for the Writer. The action exposes it as
-`structured_output`, and `post-handoff.sh` posts it to the story's PR as a marked comment,
-one per task, updated rather than duplicated on a re-run.
-
-- ⚠️ **The transport was the broken half, not the schema** (#500). It used to be appended to
-  the Tester's and Writer's prompts from the same job — but `delegate.sh` emits ONE role, so
-  those steps never co-fired and no consumer ever saw it. #475 and #476 both closed on
-  criteria that were never met. A comment survives the run; a step output does not.
-- ⚠️ **Deterministic at both ends:** the schema forces production, the hook forces delivery.
-  That is what separates it from `owner-manifest`, which asked a model to leave a
-  machine-readable block and got one across nine epics exactly once.
-- **Tester and Writer are cut per story**, as tasks ordered after the authoring ones, so
-  tests and docs land in the story's PR beside the code. ⚠️ An epic-wide Writer was tried
-  and dropped: the merge-conflict argument for it does not hold here, because stories merge
-  one at a time, so a later story already carries the previous one's docs. Deferring would
-  only put the explanation further from the change.
-
-- ⚠️ **Both keys are required, and `[]` is a real answer** — "I looked, there is nothing".
-  A consumer that cannot tell that from "forgot" is the exact failure that killed
-  `owner-manifest`: prose sections a later role has to find and parse are optional in
-  practice. A schema is not.
-- ⚠️ **An empty/absent block means no Implementor ran** (a Tester-only trigger, or its step
-  failed) — different again from `[]`. All three prompts spell out the three cases.
-- ⚠️ **The schema lives in `packages/claude-team`, but `--json-schema` takes inline JSON,
-  not a path.** A workflow step compacts the file with `jq -c` and injects it, the same way
-  `load-prompt` carries prompts. That step **fails the run** if the file contains a single
-  quote, since the value is wrapped in single quotes inside `claude_args` — and
-  `claude_args` is parsed line by line, so it must also stay one line.
-- ⚠️ `docsCandidates[].file` is a free string, never an enum of this repo's paths — the
-  roles are portable and must not encode one repository's layout.
-- ⚠️ A candidate is a proposal, not an order; arriving as structured data changes nothing
-  about that. The files only stay useful if the Writer says no to what restates the diff or
-  goes stale within a release, and rejecting every candidate stays a correct outcome.
-- `why` is the field that decides an entry — no real cost behind it, no entry.
-- Documentation is split out because `CLAUDE.md` was the biggest single source of merge
-  conflicts: every role edited it, so parallel branches collided on prose neither was
-  really working on. Testing is split out because an engineer finishing a feature writes
-  the test that passes, and this repo's actual failure mode — a save that throws inside a
-  fire-and-forget call while lint, tsc and build stay green — is only caught by a test
-  written to distrust the change.
 
 **Epic → story → task.** ⚠️ **The model itself lives in
 [`packages/claude-team/README.md`](packages/claude-team/README.md)** — the hierarchy, how a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ is never the one that fires.
 
 **The mechanics are in the package.** Hooks and the traps each was written around, the
 handoff contract, labels-as-record, routing and its loop guard all live in
-[`packages/claude-team/README.md`](packages/claude-team/README.md). ⚠️ Do not restate them
+[`packages/claude-team/CLAUDE.md`](packages/claude-team/CLAUDE.md). ⚠️ Do not restate them
 here — two copies drift, and they did: this file documented a sub-issue expansion that #503
 had already removed, and the package README described the pre-#503 branching model for a
 whole session without anyone noticing.
@@ -270,7 +270,7 @@ What is BrewDocs-specific:
 
 
 **Epic → story → task.** ⚠️ **The model itself lives in
-[`packages/claude-team/README.md`](packages/claude-team/README.md)** — the hierarchy, how a
+[`packages/claude-team/CLAUDE.md`](packages/claude-team/CLAUDE.md)** — the hierarchy, how a
 story moves, routing, the handoff contract and the hooks. It is portable and this file must
 not restate it; two copies drift, and they already had. What follows is only how *this repo*
 applies it.

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -1,0 +1,218 @@
+# packages/claude-team
+
+Package-specific guidance. See [`README.md`](README.md) for what this package is and how a
+repo consumes it, and the repo-root `CLAUDE.md` for this repo's own application of it.
+
+**Purpose.** A portable Claude/GitHub role team: the prompts each role runs on, the scripted
+hooks around them, and the handoff contract between them. Consumed by pointing a workflow at
+these files; extended by a per-role overlay in the consuming repo.
+**Where.** `prompts/_shared.md` + `prompts/<role>.md`, `hooks/*.sh`, `schemas/handoff.json`.
+**Invariants.** Nothing here names a consuming repo, its branches, its gate or its packages.
+Routing is a script, never a model. Every hook is deterministic and derives its input from
+state, not from something a model was asked to leave behind.
+
+## The issue hierarchy
+
+| level | branch | its PR targets | closed by |
+|---|---|---|---|
+| **Epic** | none | — | its stories closing |
+| **Story** | `<story#>-<summary>`, cut by the Architect | the **default** branch | its PR merging |
+| **Task** | `<task#>-<summary>`, cut by its author off the story branch | the **story** branch | its own PR merging |
+
+- An epic never has a branch and never has a PR. If something needs a PR, it is a story.
+- A story owns one branch and one PR against the default branch, and it accumulates.
+- A task is a slice of a story with its own branch and its own PR **into the story branch**.
+
+⚠️ **The Branch line always names the STORY's branch** — on the story and on every one of
+its tasks. It is what an author bases on and merges back into, never a branch for the task
+itself. Anything deriving a story from a branch name reads that prefix.
+
+⚠️ **Tasks must not share one branch.** They did once, and it was a race: if a consumer keys
+its concurrency group on issue number, two tasks are in *different* groups and can commit to
+the same branch at the same time. Sub-branching removes the possibility rather than relying
+on runs being triggered one at a time.
+
+## How a story moves
+
+1. **Architect** shapes the story, cuts its branch off the default branch, and creates its
+   tasks — each stamped with the role that should pick it up.
+2. Each **task** is triggered on its own. Its author cuts a branch off the story branch,
+   works there, and opens a PR into the story branch.
+3. Merging that task PR closes the task and lands its work on the story.
+4. The **story's** PR accumulates all of it. The maintainer reviews and merges the story as
+   a whole.
+
+⚠️ **The story's PR opens on the first task merge, from the merge hook — not from an
+authoring run.** The story branch is cut empty, and GitHub will not open a PR with no
+commits between base and head, so the first task landing is the earliest moment it can
+exist.
+
+⚠️ **A task PR's closing keyword does nothing on its own.** GitHub honours `Closes #N` only
+when a PR targets the **default** branch, and a task PR targets the story branch. The merge
+hook parsing the body is the only thing that closes a task — which is why an author must
+write the line even though GitHub ignores it.
+
+⚠️ **A task still open when its story merges is a signal, not a gap.** Nothing closes it
+implicitly: it was abandoned, or its PR never landed. An earlier version closed a merged
+issue's open children, which hid exactly the case worth seeing.
+
+⚠️ **`pull_request` events run the workflow from the PR's base branch**, so a workflow fix
+does not reach an in-flight story until the default branch is merged into it.
+
+## Routing
+
+**A label on an issue is the front door.** Applying it starts a run, and `delegate.sh` reads
+the issue's state to pick the role. The same label named in a comment does the same. A
+`@claude/<role>` handle in a comment names the role outright and skips the inspection — the
+way to override a bad guess.
+
+⚠️ **Routing is a shell script, never a model.** It is all readable state; the one call that
+needs judgement — which author owns a task — is answered once by the Architect and written
+into the task as a `Role:` line.
+
+⚠️ **The role stamp is a record, not a route.** Roles stamp `@claude/<role>` as they start,
+so the labels read as "these agents have been here". Nothing routes off them.
+
+⚠️ **Guard the loop.** Every stamp is another `labeled` event. Gate the trigger on the label
+name being *exactly* the front-door label, and exclude bot actors. Both hold independently.
+(A third guard comes free: a stamp applied with `GITHUB_TOKEN` does not start a workflow run
+at all.)
+
+## Roles
+
+| role | picked up from | writes |
+|---|---|---|
+| Architect | an epic or an unshaped story | the issue, a story's branch, and its tasks |
+| Implementor | a task stamped `Role: implementor` | code, outside the design system |
+| Designer | a task stamped `Role: designer` | code, inside the design system |
+| Tester | a task stamped `Role: tester`, one per story | tests |
+| Writer | a task stamped `Role: writer`, one per story | documentation |
+| Security | every merge, plus its handle on a PR | issues it files |
+
+⚠️ **Implementor and Designer split on the package a change touches, not on judgement**, so
+the boundary can be checked rather than negotiated. A task spanning both is two tasks, and
+only the Architect can cut it in two.
+
+⚠️ **The Tester and Writer are tasks the Architect cuts**, ordered after the authoring ones.
+No role chains off another — nothing runs that a maintainer did not trigger.
+
+⚠️ **Per story, not per epic** — for the Writer too. An epic-wide documentation pass sounds
+cheaper, and its usual justification is that one branch touching the docs avoids conflicts.
+That only holds if stories land in parallel; where they merge one at a time, a later story
+already carries the previous one's docs, and deferring only moves the explanation further
+from the change it explains.
+
+⚠️ **Trigger order is derived, never stamped.** Tasks sort by `(phase, issue number)`: phase
+from the `Role:` stamp — authors, then tests, then docs — and number within a phase, because
+the Architect creates them in the order it intends. A task is ready once everything before it
+is closed, so the first open task is the one to trigger. Both inputs are things the Architect
+must produce for other reasons; a third stamp naming an order would be a third line it could
+skip.
+
+## The handoff between authors
+
+An author's step carries `--json-schema`, so its final message is a contract: `testingNotes`
+for the Tester, `docsCandidates` for the Writer. A hook posts it to the **story's issue** as
+one comment per task; the Tester and Writer read it there.
+
+- ⚠️ **Both keys are required and `[]` is a real answer** — "I looked, there is nothing",
+  which a consumer can act on. A missing key says nothing at all. That distinction is the
+  entire reason this is a schema and not a prose section.
+- ⚠️ **The story's issue, not its PR.** The PR does not exist until the first task merges,
+  so a handoff written during the first task would have nowhere to go.
+- ⚠️ **Deterministic at both ends:** the schema forces the author to produce it, the hook
+  forces delivery. Neither is a model instruction. Asking a model to leave a
+  machine-readable block for a later role is the version that fails.
+- A candidate is a proposal, never an order. Rejecting all of them is a correct outcome.
+- ⚠️ **Three states, not two.** Entries mean the author found something; `[]` means it looked
+  and found nothing; **no handoff comment at all** means no author ran, or its run failed
+  before posting. A consumer that collapses the last two will treat a failed run as a clean
+  one.
+- `docsCandidates[].file` is a **free string**, never an enum of a repo's paths — these roles
+  are portable and must not encode one repository's layout.
+
+⚠️ **The transport is the half that breaks, not the schema.** It was first appended to the
+consuming roles' prompts from the same job — which only works if those roles run in that job.
+They do not, so nothing ever received it and the feature shipped dead. A comment outlives its
+run; a step output does not.
+
+⚠️ **`--json-schema` takes inline JSON, not a path.** The schema is a file in this package, so
+a workflow step has to compact it to one line and inject it. Two hazards worth asserting
+rather than discovering: the value is wrapped in single quotes, so the file must contain none,
+and the argument list is parsed line by line, so it must stay on one line.
+
+## Prompt composition
+
+A role's prompt is `prompts/_shared.md` then `prompts/<role>.md` from this package, followed
+by the consumer's overlay in the same order. The base says how the role behaves and how the
+hierarchy works; the overlay says what the repo's gate is, where its code lives, and any
+house rules.
+
+⚠️ **Shared first, and that ordering is load-bearing.** `_shared.md` opens by overriding the
+host action's own prompt, which for comment events states repeatedly that the model's
+instructions are the triggering comment. Ours arrives after all of that, so the override has
+to be the first thing in it.
+
+⚠️ **Keep the split honest.** A rule that would be true in any repo belongs in the base; a
+rule that names a command, a path or a package belongs in the overlay.
+
+⚠️ **`trigger_phrase` must be the role's exact handle.** It gates nothing when a prompt is
+supplied, but the action extracts everything *after* it as "the user request" and yields
+that as the final content block, which the CLI scans for a slash command. Set to a bare
+front-door label, `@claude/<role> do X` extracts as `/<role> do X` and is swallowed as an
+unknown slash command — the run reports success having never called the model.
+
+## Hooks
+
+Deterministic steps that run around each model step, so backlog bookkeeping cannot be
+forgotten by a model that ran out of turns or simply skipped it.
+
+| hook | when | does |
+|---|---|---|
+| `acknowledge.sh` | the router job, first | reacts 👀 so the trigger is visibly received |
+| `delegate.sh` | the router job | picks the role from issue state — routing is scripted, not judged |
+| `stamp-role-label.sh` | pre, every role | stamps `@claude/<role>` on the triggering issue or PR |
+| `set-issue-status.sh` | pre, authors | sets the issue's board Status; the column is an input |
+| `file-sub-issues.sh` | post, Architect | parents stories to their epic, tasks to their story |
+| `finish-pr.sh` | post, authors | labels the PR and ensures it closes its issue |
+| `post-handoff.sh` | post, authors | posts the JSON handoff to the story's issue |
+| `log-to-story.sh` | post, Architect + authors + on merge | rewrites one comment on the story listing its tasks in trigger order |
+| `log-to-epic.sh` | post, authors | rewrites one rolling work-log comment on the epic |
+| `open-story-pr.sh` | **on merge** | opens the story's PR once a task has landed on its branch |
+| `close-merged-work.sh` | on merge | closes the PR's issues and files them on the board |
+
+⚠️ These were prompt instructions until a model skipped them. A scripted step costs no
+turns and cannot be forgotten.
+
+### Traps each hook was written around
+
+- ⚠️ **`acknowledge.sh` reacts via `issues/comments/<id>`**, so hand it a comment id only for
+  an issue comment. A *review* comment's id belongs to the **pulls** collection and would
+  react to an unrelated comment. Empty falls back to the issue or PR itself.
+- ⚠️ **`delegate.sh` defaults a missing `Role:` stamp and says so.** Wrong is recoverable,
+  silent is not — a run that quietly does nothing is indistinguishable from a broken workflow.
+- ⚠️ **The log hooks rewrite ONE comment each, never one per run.** An epic with ten tasks
+  across three roles would otherwise bury itself in thirty comments. They are also derived
+  entirely from GitHub state — no model writes any part of them, which is the only reason
+  they can be trusted as a status board.
+- ⚠️ **`file-sub-issues.sh` cannot key on prose alone.** Its first version matched a branch
+  line plus an `epic #N` reference, and adopted a meta-issue that quoted the convention as an
+  example. Checking the author is a bot is what makes it sound — with the accepted cost that a
+  hand-written sub-issue is never auto-parented.
+- ⚠️ **A role labels only what it opens.** The stamp hook marks the triggering issue or PR;
+  `finish-pr.sh` labels the PR that run created. Nothing labels someone else's work.
+- ⚠️ **`Closes #<issue>` is both a prompt instruction and a hook.** The model writing it puts
+  the link where a human reads it; the hook is the net, because a missing keyword loses the
+  close with nothing to signal it.
+- ⚠️ **Keep long-lived credentials out of any job a model step shares** unless the workflow
+  puts them in *step* env. Step env is per-step, so a scripted step can hold a token the
+  model step beside it cannot read. Secret masking covers logs only — not an API payload a
+  model could write.
+
+⚠️ **A scripted hook fed by model-written input is still model-driven.** Derive a hook's
+input from something the model must produce for another reason, or from state it cannot
+avoid creating — never from a block it was merely asked to leave behind.
+
+⚠️ **`gh api` prints its error body to stdout**, so `--jq` never runs and a 404 lands in the
+variable. The parent endpoint 404s for anything unparented, which is most issues. Filter
+captures to digits and read anything else as absent.

--- a/packages/claude-team/README.md
+++ b/packages/claude-team/README.md
@@ -1,215 +1,44 @@
 # claude-team
 
-The abstract definition of a Claude/GitHub role team: what the roles are, how work is
-shaped, and how changes reach the default branch. A repo **consumes** this by pointing its
-workflow at these prompts and hooks, and **extends** it with a per-role overlay carrying
-its own specifics.
+A portable definition of a Claude/GitHub role team — the prompts each role runs on, and the
+scripted hooks that do the bookkeeping around them. A repo **consumes** it by pointing a
+workflow at these files, and **extends** it with its own per-role overlay.
 
-BrewDocs is the first consumer. Nothing in this directory should name BrewDocs, its gate,
-its packages or its conventions — if it does, it belongs in the consumer's overlay.
+BrewDocs is the first consumer. Nothing here names BrewDocs, its gate or its packages; if it
+does, it belongs in the consumer's overlay.
 
-## The issue hierarchy
+## Entry points
 
-| level | branch | its PR targets | closed by |
-|---|---|---|---|
-| **Epic** | none | — | its stories closing |
-| **Story** | `<story#>-<summary>`, cut by the Architect | the **default** branch | its PR merging |
-| **Task** | `<task#>-<summary>`, cut by its author off the story branch | the **story** branch | its own PR merging |
+- [`prompts/`](prompts/) — [`_shared.md`](prompts/_shared.md) for every role, plus one file
+  per role. A role's prompt is the shared file, then its own, then the consumer's equivalents.
+- [`hooks/`](hooks/) — the scripted steps that run around each model step. Each explains
+  itself in its own header.
+- [`schemas/handoff.json`](schemas/handoff.json) — the contract one author passes to the next.
 
-- An epic never has a branch and never has a PR. If something needs a PR, it is a story.
-- A story owns one branch and one PR against the default branch, and it accumulates.
-- A task is a slice of a story with its own branch and its own PR **into the story branch**.
+## The model
 
-⚠️ **The Branch line always names the STORY's branch** — on the story and on every one of
-its tasks. It is what an author bases on and merges back into, never a branch for the task
-itself. Anything deriving a story from a branch name reads that prefix.
+Work is **epic → story → task**. An epic is a grouping and has no branch. A story owns a
+branch and a PR against the default branch. A task owns a branch cut off the story's and a PR
+back into it — merging that closes the task, and the story's PR accumulates the lot.
 
-⚠️ **Tasks must not share one branch.** They did once, and it was a race: if a consumer keys
-its concurrency group on issue number, two tasks are in *different* groups and can commit to
-the same branch at the same time. Sub-branching removes the possibility rather than relying
-on runs being triggered one at a time.
-
-## How a story moves
-
-1. **Architect** shapes the story, cuts its branch off the default branch, and creates its
-   tasks — each stamped with the role that should pick it up.
-2. Each **task** is triggered on its own. Its author cuts a branch off the story branch,
-   works there, and opens a PR into the story branch.
-3. Merging that task PR closes the task and lands its work on the story.
-4. The **story's** PR accumulates all of it. The maintainer reviews and merges the story as
-   a whole.
-
-⚠️ **The story's PR opens on the first task merge, from the merge hook — not from an
-authoring run.** The story branch is cut empty, and GitHub will not open a PR with no
-commits between base and head, so the first task landing is the earliest moment it can
-exist.
-
-⚠️ **A task PR's closing keyword does nothing on its own.** GitHub honours `Closes #N` only
-when a PR targets the **default** branch, and a task PR targets the story branch. The merge
-hook parsing the body is the only thing that closes a task — which is why an author must
-write the line even though GitHub ignores it.
-
-⚠️ **A task still open when its story merges is a signal, not a gap.** Nothing closes it
-implicitly: it was abandoned, or its PR never landed. An earlier version closed a merged
-issue's open children, which hid exactly the case worth seeing.
-
-⚠️ **`pull_request` events run the workflow from the PR's base branch**, so a workflow fix
-does not reach an in-flight story until the default branch is merged into it.
-
-## Routing
-
-**A label on an issue is the front door.** Applying it starts a run, and `delegate.sh` reads
-the issue's state to pick the role. The same label named in a comment does the same. A
-`@claude/<role>` handle in a comment names the role outright and skips the inspection — the
-way to override a bad guess.
-
-⚠️ **Routing is a shell script, never a model.** It is all readable state; the one call that
-needs judgement — which author owns a task — is answered once by the Architect and written
-into the task as a `Role:` line.
-
-⚠️ **The role stamp is a record, not a route.** Roles stamp `@claude/<role>` as they start,
-so the labels read as "these agents have been here". Nothing routes off them.
-
-⚠️ **Guard the loop.** Every stamp is another `labeled` event. Gate the trigger on the label
-name being *exactly* the front-door label, and exclude bot actors. Both hold independently.
-(A third guard comes free: a stamp applied with `GITHUB_TOKEN` does not start a workflow run
-at all.)
-
-## Roles
+Six roles. One runs per trigger, chosen from the issue's state by a script rather than a model:
 
 | role | picked up from | writes |
 |---|---|---|
-| Architect | an epic or an unshaped story | the issue, a story's branch, and its tasks |
+| Architect | an epic, or an unshaped story | the issue, a story's branch, and its tasks |
 | Implementor | a task stamped `Role: implementor` | code, outside the design system |
 | Designer | a task stamped `Role: designer` | code, inside the design system |
-| Tester | a task stamped `Role: tester`, one per story | tests |
-| Writer | a task stamped `Role: writer`, one per story | documentation |
-| Security | every merge, plus its handle on a PR | issues it files |
+| Tester | a task stamped `Role: tester` | tests |
+| Writer | a task stamped `Role: writer` | documentation |
+| Security | every merge, and on request | issues it files |
 
-⚠️ **Implementor and Designer split on the package a change touches, not on judgement**, so
-the boundary can be checked rather than negotiated. A task spanning both is two tasks, and
-only the Architect can cut it in two.
+Nothing chains: no role starts another, and a person triggers every run.
 
-⚠️ **The Tester and Writer are tasks the Architect cuts**, ordered after the authoring ones.
-No role chains off another — nothing runs that a maintainer did not trigger.
+## Consuming it
 
-⚠️ **Per story, not per epic** — for the Writer too. An epic-wide documentation pass sounds
-cheaper, and its usual justification is that one branch touching the docs avoids conflicts.
-That only holds if stories land in parallel; where they merge one at a time, a later story
-already carries the previous one's docs, and deferring only moves the explanation further
-from the change it explains.
+Per role, a workflow needs to compose the prompt from this package plus your overlay, run the
+hooks around the model step, and pass the role its issue and story numbers as environment
+variables.
 
-⚠️ **Trigger order is derived, never stamped.** Tasks sort by `(phase, issue number)`: phase
-from the `Role:` stamp — authors, then tests, then docs — and number within a phase, because
-the Architect creates them in the order it intends. A task is ready once everything before it
-is closed, so the first open task is the one to trigger. Both inputs are things the Architect
-must produce for other reasons; a third stamp naming an order would be a third line it could
-skip.
-
-## The handoff between authors
-
-An author's step carries `--json-schema`, so its final message is a contract: `testingNotes`
-for the Tester, `docsCandidates` for the Writer. A hook posts it to the **story's issue** as
-one comment per task; the Tester and Writer read it there.
-
-- ⚠️ **Both keys are required and `[]` is a real answer** — "I looked, there is nothing",
-  which a consumer can act on. A missing key says nothing at all. That distinction is the
-  entire reason this is a schema and not a prose section.
-- ⚠️ **The story's issue, not its PR.** The PR does not exist until the first task merges,
-  so a handoff written during the first task would have nowhere to go.
-- ⚠️ **Deterministic at both ends:** the schema forces the author to produce it, the hook
-  forces delivery. Neither is a model instruction. Asking a model to leave a
-  machine-readable block for a later role is the version that fails.
-- A candidate is a proposal, never an order. Rejecting all of them is a correct outcome.
-- ⚠️ **Three states, not two.** Entries mean the author found something; `[]` means it looked
-  and found nothing; **no handoff comment at all** means no author ran, or its run failed
-  before posting. A consumer that collapses the last two will treat a failed run as a clean
-  one.
-- `docsCandidates[].file` is a **free string**, never an enum of a repo's paths — these roles
-  are portable and must not encode one repository's layout.
-
-⚠️ **The transport is the half that breaks, not the schema.** It was first appended to the
-consuming roles' prompts from the same job — which only works if those roles run in that job.
-They do not, so nothing ever received it and the feature shipped dead. A comment outlives its
-run; a step output does not.
-
-⚠️ **`--json-schema` takes inline JSON, not a path.** The schema is a file in this package, so
-a workflow step has to compact it to one line and inject it. Two hazards worth asserting
-rather than discovering: the value is wrapped in single quotes, so the file must contain none,
-and the argument list is parsed line by line, so it must stay on one line.
-
-## Prompt composition
-
-A role's prompt is `prompts/_shared.md` then `prompts/<role>.md` from this package, followed
-by the consumer's overlay in the same order. The base says how the role behaves and how the
-hierarchy works; the overlay says what the repo's gate is, where its code lives, and any
-house rules.
-
-⚠️ **Shared first, and that ordering is load-bearing.** `_shared.md` opens by overriding the
-host action's own prompt, which for comment events states repeatedly that the model's
-instructions are the triggering comment. Ours arrives after all of that, so the override has
-to be the first thing in it.
-
-⚠️ **Keep the split honest.** A rule that would be true in any repo belongs in the base; a
-rule that names a command, a path or a package belongs in the overlay.
-
-⚠️ **`trigger_phrase` must be the role's exact handle.** It gates nothing when a prompt is
-supplied, but the action extracts everything *after* it as "the user request" and yields
-that as the final content block, which the CLI scans for a slash command. Set to a bare
-front-door label, `@claude/<role> do X` extracts as `/<role> do X` and is swallowed as an
-unknown slash command — the run reports success having never called the model.
-
-## Hooks
-
-Deterministic steps that run around each model step, so backlog bookkeeping cannot be
-forgotten by a model that ran out of turns or simply skipped it.
-
-| hook | when | does |
-|---|---|---|
-| `acknowledge.sh` | the router job, first | reacts 👀 so the trigger is visibly received |
-| `delegate.sh` | the router job | picks the role from issue state — routing is scripted, not judged |
-| `stamp-role-label.sh` | pre, every role | stamps `@claude/<role>` on the triggering issue or PR |
-| `set-issue-status.sh` | pre, authors | sets the issue's board Status; the column is an input |
-| `file-sub-issues.sh` | post, Architect | parents stories to their epic, tasks to their story |
-| `finish-pr.sh` | post, authors | labels the PR and ensures it closes its issue |
-| `post-handoff.sh` | post, authors | posts the JSON handoff to the story's issue |
-| `log-to-story.sh` | post, Architect + authors + on merge | rewrites one comment on the story listing its tasks in trigger order |
-| `log-to-epic.sh` | post, authors | rewrites one rolling work-log comment on the epic |
-| `open-story-pr.sh` | **on merge** | opens the story's PR once a task has landed on its branch |
-| `close-merged-work.sh` | on merge | closes the PR's issues and files them on the board |
-
-⚠️ These were prompt instructions until a model skipped them. A scripted step costs no
-turns and cannot be forgotten.
-
-### Traps each hook was written around
-
-- ⚠️ **`acknowledge.sh` reacts via `issues/comments/<id>`**, so hand it a comment id only for
-  an issue comment. A *review* comment's id belongs to the **pulls** collection and would
-  react to an unrelated comment. Empty falls back to the issue or PR itself.
-- ⚠️ **`delegate.sh` defaults a missing `Role:` stamp and says so.** Wrong is recoverable,
-  silent is not — a run that quietly does nothing is indistinguishable from a broken workflow.
-- ⚠️ **The log hooks rewrite ONE comment each, never one per run.** An epic with ten tasks
-  across three roles would otherwise bury itself in thirty comments. They are also derived
-  entirely from GitHub state — no model writes any part of them, which is the only reason
-  they can be trusted as a status board.
-- ⚠️ **`file-sub-issues.sh` cannot key on prose alone.** Its first version matched a branch
-  line plus an `epic #N` reference, and adopted a meta-issue that quoted the convention as an
-  example. Checking the author is a bot is what makes it sound — with the accepted cost that a
-  hand-written sub-issue is never auto-parented.
-- ⚠️ **A role labels only what it opens.** The stamp hook marks the triggering issue or PR;
-  `finish-pr.sh` labels the PR that run created. Nothing labels someone else's work.
-- ⚠️ **`Closes #<issue>` is both a prompt instruction and a hook.** The model writing it puts
-  the link where a human reads it; the hook is the net, because a missing keyword loses the
-  close with nothing to signal it.
-- ⚠️ **Keep long-lived credentials out of any job a model step shares** unless the workflow
-  puts them in *step* env. Step env is per-step, so a scripted step can hold a token the
-  model step beside it cannot read. Secret masking covers logs only — not an API payload a
-  model could write.
-
-⚠️ **A scripted hook fed by model-written input is still model-driven.** Derive a hook's
-input from something the model must produce for another reason, or from state it cannot
-avoid creating — never from a block it was merely asked to leave behind.
-
-⚠️ **`gh api` prints its error body to stdout**, so `--jq` never runs and a 404 lands in the
-variable. The parent endpoint 404s for anything unparented, which is most issues. Filter
-captures to digits and read anything else as absent.
+See [`CLAUDE.md`](CLAUDE.md) for the design decisions, the platform constraints they work
+around, and the failures that shaped them.

--- a/packages/claude-team/README.md
+++ b/packages/claude-team/README.md
@@ -93,6 +93,12 @@ only the Architect can cut it in two.
 ⚠️ **The Tester and Writer are tasks the Architect cuts**, ordered after the authoring ones.
 No role chains off another — nothing runs that a maintainer did not trigger.
 
+⚠️ **Per story, not per epic** — for the Writer too. An epic-wide documentation pass sounds
+cheaper, and its usual justification is that one branch touching the docs avoids conflicts.
+That only holds if stories land in parallel; where they merge one at a time, a later story
+already carries the previous one's docs, and deferring only moves the explanation further
+from the change it explains.
+
 ⚠️ **Trigger order is derived, never stamped.** Tasks sort by `(phase, issue number)`: phase
 from the `Role:` stamp — authors, then tests, then docs — and number within a phase, because
 the Architect creates them in the order it intends. A task is ready once everything before it
@@ -115,6 +121,22 @@ one comment per task; the Tester and Writer read it there.
   forces delivery. Neither is a model instruction. Asking a model to leave a
   machine-readable block for a later role is the version that fails.
 - A candidate is a proposal, never an order. Rejecting all of them is a correct outcome.
+- ⚠️ **Three states, not two.** Entries mean the author found something; `[]` means it looked
+  and found nothing; **no handoff comment at all** means no author ran, or its run failed
+  before posting. A consumer that collapses the last two will treat a failed run as a clean
+  one.
+- `docsCandidates[].file` is a **free string**, never an enum of a repo's paths — these roles
+  are portable and must not encode one repository's layout.
+
+⚠️ **The transport is the half that breaks, not the schema.** It was first appended to the
+consuming roles' prompts from the same job — which only works if those roles run in that job.
+They do not, so nothing ever received it and the feature shipped dead. A comment outlives its
+run; a step output does not.
+
+⚠️ **`--json-schema` takes inline JSON, not a path.** The schema is a file in this package, so
+a workflow step has to compact it to one line and inject it. Two hazards worth asserting
+rather than discovering: the value is wrapped in single quotes, so the file must contain none,
+and the argument list is parsed line by line, so it must stay on one line.
 
 ## Prompt composition
 
@@ -158,6 +180,31 @@ forgotten by a model that ran out of turns or simply skipped it.
 
 ⚠️ These were prompt instructions until a model skipped them. A scripted step costs no
 turns and cannot be forgotten.
+
+### Traps each hook was written around
+
+- ⚠️ **`acknowledge.sh` reacts via `issues/comments/<id>`**, so hand it a comment id only for
+  an issue comment. A *review* comment's id belongs to the **pulls** collection and would
+  react to an unrelated comment. Empty falls back to the issue or PR itself.
+- ⚠️ **`delegate.sh` defaults a missing `Role:` stamp and says so.** Wrong is recoverable,
+  silent is not — a run that quietly does nothing is indistinguishable from a broken workflow.
+- ⚠️ **The log hooks rewrite ONE comment each, never one per run.** An epic with ten tasks
+  across three roles would otherwise bury itself in thirty comments. They are also derived
+  entirely from GitHub state — no model writes any part of them, which is the only reason
+  they can be trusted as a status board.
+- ⚠️ **`file-sub-issues.sh` cannot key on prose alone.** Its first version matched a branch
+  line plus an `epic #N` reference, and adopted a meta-issue that quoted the convention as an
+  example. Checking the author is a bot is what makes it sound — with the accepted cost that a
+  hand-written sub-issue is never auto-parented.
+- ⚠️ **A role labels only what it opens.** The stamp hook marks the triggering issue or PR;
+  `finish-pr.sh` labels the PR that run created. Nothing labels someone else's work.
+- ⚠️ **`Closes #<issue>` is both a prompt instruction and a hook.** The model writing it puts
+  the link where a human reads it; the hook is the net, because a missing keyword loses the
+  close with nothing to signal it.
+- ⚠️ **Keep long-lived credentials out of any job a model step shares** unless the workflow
+  puts them in *step* env. Step env is per-step, so a scripted step can hold a token the
+  model step beside it cannot read. Secret masking covers logs only — not an API payload a
+  model could write.
 
 ⚠️ **A scripted hook fed by model-written input is still model-driven.** Derive a hook's
 input from something the model must produce for another reason, or from state it cannot


### PR DESCRIPTION
Closes #509. Finishes what #505 started — 121 lines out of the root `CLAUDE.md`.

## Audited, not bulk-deleted

These are accumulated post-mortems: each ⚠️ exists because something cost a run, a merge cycle or a night. So every one of the **19 warnings** in the three sections was checked against [`packages/claude-team/README.md`](packages/claude-team/README.md) before anything was removed.

| outcome | count |
|---|---|
| now in the package | **18** |
| deliberately in both | 1 |
| dropped as false | 1 |
| **lost** | **0** |

Six of the eighteen were *already* in the README — pure duplication that #505 created and this removes.

**The one in both is deliberate.** The README states the portable principle: step env is per-step, so a scripted step can hold a credential the model step beside it cannot read. The root applies it to `PROJECTS_TOKEN` — which two scripts hold it, which scopes it needs, and that a fine-grained token cannot reach user-owned Projects v2. The principle travels; the secret does not.

## ⚠️ One was dropped because it was false

The root file still documented `close-merged-work.sh` closing a closed issue's **open sub-issues** — behaviour #503 removed outright. I introduced that staleness by changing the hook without sweeping the root file, which is precisely the drift this split exists to prevent. It is now stated once, in the package, and correctly: a task still open when its story merges is a signal, not a gap.

## What moved that the package did not already have

- `acknowledge.sh` taking a comment id **only** for issue comments — a review comment's id belongs to the *pulls* collection and would react to something unrelated.
- `delegate.sh` defaulting a missing `Role:` stamp **out loud** — wrong is recoverable, silent is not.
- The log hooks rewriting **one** comment rather than one per run, and being derived entirely from state — the only reason they can be trusted as a board.
- `file-sub-issues.sh` needing an author check rather than a prose marker, after its first version adopted a meta-issue that quoted the convention as an example.
- A role labelling only what it opens.
- `Closes #<issue>` being both a prompt instruction and a hook — the model puts the link where a human reads it, the hook is the net.
- The **three** handoff states: entries, `[]`, and no comment at all. Collapsing the last two makes a failed run look clean.
- `--json-schema` taking inline JSON rather than a path, plus the two hazards of inlining it: single quotes in the file break the value, and the argument list is parsed line by line.
- Why the Writer is per story rather than per epic, and when that reasoning would flip.

## Verification

`npm test --ws` (eslint) ✓ 0 errors · `tsc --noEmit` ✓ · workflow parses.

- **The accounting above is produced mechanically**, not asserted — each claim probed against both files by normalised substring, failing the check if any is in neither.
- **No portable claim is stated in both files** — seven of the load-bearing ones verified package-only.
- **The README names nothing BrewDocs-specific** — swept for the repo name, `mainline`, every package path, `npm ci`, `vite`, `eslint`, the project number, `PROJECTS_TOKEN` and `@claude/security`.

Root `CLAUDE.md` 462 → 350 lines; the package README 75 → 215 across both PRs.

⚠️ Verify will not run — the path filter excludes docs and `packages/claude-team`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
