### PR TITLE
Default an unprocessed issue to a story, and make an epic say so

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -165,6 +165,7 @@ jobs:
     outputs:
       roles: ${{ steps.route.outputs.roles }}
       story: ${{ steps.route.outputs.story }}
+      kind: ${{ steps.route.outputs.kind }}
       defaulted: ${{ steps.route.outputs.defaulted }}
       reason: ${{ steps.route.outputs.reason }}
     steps:
@@ -251,6 +252,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          # epic or story, derived from the label and the title. An unprocessed issue is a
+          # story; this is the default the Architect works from, and the triggering comment
+          # is the only thing that overrides it.
+          KIND: ${{ needs.delegate.outputs.kind }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # ⚠️ THE EXACT HANDLE, and this is load-bearing. trigger_phrase does NOT gate
@@ -278,6 +283,15 @@ jobs:
           # the Architect is triggered ON the story, so the story is the issue itself
           STORY: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
         run: "$RUNNER_TEMP/agent-bin/log-to-story.py"
+      # ⚠️ Derived from the title the Architect had to write anyway. A `gh` call it was
+      # merely asked to remember is the shape that fails.
+      - name: Label an epic from its title
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+        run: "$RUNNER_TEMP/agent-bin/sync-epic-label.py"
       - name: File the story's sub-issues
         # ⚠️ `issues` must be here as well as `issue_comment`. The label is now the primary
         # way an Architect run starts, and keyed to comments alone this hook — the thing that

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -20,6 +20,14 @@ state, not from something a model was asked to leave behind.
 | **Task** | `<task#>-<summary>`, cut by its author off the story branch | the **story** branch | its own PR merging |
 
 - An epic never has a branch and never has a PR. If something needs a PR, it is a story.
+- ⚠️ **An unprocessed issue is a STORY.** An epic has to say so — by an `epic` label or a
+  title beginning "Epic" — and the Architect leaves both markers behind so nothing re-derives
+  it next run. Deliberately NOT inferred from having sub-issues: a story has those too, they
+  are its tasks. The old inference only held because a shaped story also had a branch, so an
+  unshaped story with tasks read as an epic.
+- ⚠️ **A maintainer's comment is the only override**, and it is judged by the model rather
+  than matched by the script. A regex for the word misfires on an ordinary sentence — "a
+  story under the Claude Team epic" — and a false positive decomposes a story into stories.
 - A story owns one branch and one PR against the default branch, and it accumulates.
 - A task is a slice of a story with its own branch and its own PR **into the story branch**.
 
@@ -173,6 +181,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 | `delegate.py` | the router job | picks the role from issue state — routing is scripted, not judged |
 | `stamp-role-label.py` | pre, every role | stamps `@claude/<role>` on the triggering issue or PR |
 | `set-issue-status.py` | pre, authors | sets the issue's board Status; the column is an input |
+| `sync-epic-label.py` | post, Architect | applies the `epic` label to an issue titled as one |
 | `file-sub-issues.py` | post, Architect | parents stories to their epic, tasks to their story |
 | `finish-pr.py` | post, authors | labels the PR and ensures it closes its issue |
 | `post-handoff.py` | post, authors | posts the JSON handoff to the story's issue |

--- a/packages/claude-team/hooks/delegate.py
+++ b/packages/claude-team/hooks/delegate.py
@@ -29,7 +29,7 @@ IS_PR = os.environ.get("IS_PR", "false") == "true"
 if not team.REPO:
     team.fail("REPO is required")
 
-ROLES = STORY = REASON = ""
+ROLES = STORY = REASON = KIND = ""
 DEFAULTED = False
 
 
@@ -38,9 +38,13 @@ def emit() -> None:
     if out:
         with open(out, "a", encoding="utf-8") as handle:
             handle.write(
-                f"roles={ROLES}\nstory={STORY}\ndefaulted={str(DEFAULTED).lower()}\nreason={REASON}\n"
+                f"roles={ROLES}\nstory={STORY}\nkind={KIND}\n"
+                f"defaulted={str(DEFAULTED).lower()}\nreason={REASON}\n"
             )
-    print(f"roles={ROLES} story={STORY or 'none'} defaulted={str(DEFAULTED).lower()} — {REASON}")
+    print(
+        f"roles={ROLES} story={STORY or 'none'} kind={KIND or 'n/a'} "
+        f"defaulted={str(DEFAULTED).lower()} — {REASON}"
+    )
 
 
 def unroutable(reason: str) -> None:
@@ -121,14 +125,18 @@ branch = team.branch_line(body)
 kids = len(team.sub_issues(NUMBER))
 parent = team.parent(NUMBER)
 
-# ---- 3 & 4. nothing shaped yet, or an epic holding stories -> architect
+# ---- 3. nothing shaped yet -> architect, told whether to treat it as an epic or a story
+#
+# An unprocessed issue is a STORY. An epic has to say so, by its `epic` label or an "Epic"
+# title — see team.is_epic. This used to infer an epic from having sub-issues, which was
+# wrong: a story has those too, and the inference only held because a shaped story also had
+# a branch.
 if not branch:
     ROLES = "architect"
-    REASON = (
-        f"#{NUMBER} has {kids} sub-issues and no branch — an epic"
-        if kids
-        else f"#{NUMBER} has no branch and no sub-issues — needs shaping"
-    )
+    KIND = "epic" if team.is_epic(NUMBER) else "story"
+    REASON = f"#{NUMBER} has no branch — shaping it as {'an epic' if KIND == 'epic' else 'a story'}"
+    if kids:
+        REASON += f" (it already has {kids} sub-issue(s))"
     emit()
     raise SystemExit(0)
 

--- a/packages/claude-team/hooks/sync-epic-label.py
+++ b/packages/claude-team/hooks/sync-epic-label.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Post-hook for the Architect. Applies the `epic` label to an issue whose title says it is
+one, and never removes it.
+
+DERIVED FROM THE TITLE, which the Architect must write anyway. Asking the model to also
+remember a `gh` call is the shape that fails — the manifest it was told to leave got written
+once across nine epics. A title it cannot avoid producing is a reliable trigger; an
+instruction it can skip is not.
+
+Only ever adds. If the maintainer labelled or titled something an epic, that is the
+classification and this run keeps it.
+"""
+
+import os
+
+import team
+
+ISSUE = os.environ.get("ISSUE", "")
+
+if not team.REPO:
+    team.fail("REPO is required")
+
+if not ISSUE:
+    print("Not triggered on an issue — nothing to label.")
+    raise SystemExit(0)
+
+data = team.issue(ISSUE, "title", "labels")
+title = data.get("title") or ""
+
+if not team.titled_epic(title):
+    print(f'#{ISSUE} is not titled as an epic — leaving its labels alone.')
+    raise SystemExit(0)
+
+if any((l.get("name") or "").lower() == team.EPIC_LABEL for l in data.get("labels", [])):
+    print(f"#{ISSUE} is already labelled {team.EPIC_LABEL}.")
+    raise SystemExit(0)
+
+if team.gh("api", f"repos/{team.REPO}/issues/{ISSUE}/labels",
+           "-f", f"labels[]={team.EPIC_LABEL}") is not None:
+    print(f"#{ISSUE} -> {team.EPIC_LABEL}")
+else:
+    team.warn(f"could not label #{ISSUE} — does the '{team.EPIC_LABEL}' label exist in this repo?")

--- a/packages/claude-team/hooks/team.py
+++ b/packages/claude-team/hooks/team.py
@@ -112,6 +112,36 @@ def role_stamp(body: str) -> str:
     return found.group(1).lower() if found else ""
 
 
+EPIC_LABEL = "epic"
+
+
+def titled_epic(title: str) -> bool:
+    """True when a title announces itself as an epic — `Epic: …`, `Epic —`, `Epic` alone."""
+    return bool(re.match(r"\s*epic\b", title or "", re.IGNORECASE))
+
+
+def is_epic(number: str | int) -> bool:
+    """Classify an issue. An unprocessed issue is a STORY; an epic has to say so.
+
+    Two markers, either of which is enough: the `epic` label, or a title beginning "Epic".
+    Both are durable — they survive the run, so nothing has to re-derive the classification
+    next time.
+
+    Deliberately NOT inferred from having sub-issues. A story has those too — they are its
+    tasks — so that inference only ever worked because a shaped story also had a branch, and
+    it read an unshaped story with tasks as an epic.
+
+    A maintainer saying "this is an epic" in a comment is not read here. A regex for the word
+    misfires on an ordinary sentence like "a story under the Claude Team epic", and a false
+    positive makes the Architect decompose a story into sub-stories. The model weighs the
+    comment against this default instead.
+    """
+    data = issue(number, "title", "labels")
+    if any((l.get("name") or "").lower() == EPIC_LABEL for l in data.get("labels", [])):
+        return True
+    return titled_epic(data.get("title") or "")
+
+
 def story_from_branch(branch: str) -> str:
     """A story branch is `<story#>-<summary>`, so the leading number names the story.
 

--- a/packages/claude-team/prompts/architect.md
+++ b/packages/claude-team/prompts/architect.md
@@ -5,12 +5,25 @@ You are reached by the `@claude` label on an issue the delegator finds unshaped,
 `@claude/architect` in a comment. Either way the issue is the brief — a comment is at most a
 modifier on it.
 
-## Two modes, decided by what you were triggered on
+## Two modes, and the default is STORY
+
+`$KIND` says which, derived from the issue itself: an `epic` label, or a title beginning
+"Epic". ⚠️ **An unprocessed issue is a story.** That is the default and it is almost always
+right — the maintainer marks the exceptions.
+
+⚠️ **The triggering comment is the only thing that overrides `$KIND`.** If the maintainer
+says it is an epic, it is, whatever the label and title currently say. Nothing else does: do
+not infer an epic from an issue merely having sub-issues, because a story has those too —
+they are its tasks.
 
 **On an epic** — shape the goal. An epic is a cross-story product outcome, not a task list.
 Rewrite it so a reader knows what "done" looks like and why it matters, and say what is in
 and what is deliberately out. Break it into **stories**, each one shippable with its own PR.
 ⚠️ Do **not** cut a branch: epics have none.
+
+⚠️ **Leave an epic saying it is one.** Title it `Epic: <…>`, and never strip an existing
+`Epic` prefix or `epic` label — those are the classification, and removing one silently
+demotes the issue on its next run. The label is applied for you, from the title.
 
 **On a story** — the maintainer has usually written a few lines of intent. Turn that into
 work:
@@ -56,8 +69,8 @@ a task or a story you create — nothing happens automatically.
 - **A `Role: writer` task per story that needs one**, ordered after the authoring tasks.
   Documentation lands on the story branch by its own PR, like every other task.
 - ⚠️ **Order both last within the story, and say so.** The Tester and Writer read the
-  authors' handoff comments on the story's PR, so triggering either before the authors have
-  run wastes it.
+  authors' handoff comments on the story's **issue**, so triggering either before the authors
+  have run wastes it.
 
 ⚠️ **Write the Branch line before you finish.** Every role that follows reads it to know
 where to commit. Without it they cannot work at all.


### PR DESCRIPTION
Closes #528.

**An unprocessed issue is a STORY.** An epic has to declare itself — by an `epic` label or a title beginning "Epic" — and the Architect leaves both markers behind so nothing re-derives the classification next run.

## ⚠️ The old rule was already wrong

It read "no branch **and** sub-issues" as an epic. But a story has sub-issues too — they are its tasks. That inference only ever held because a shaped story also had a *branch*, so an unshaped story with tasks classified as an epic.

Live proof, before and after, against real issues:

| issue | title | old | new |
|---|---|---|---|
| #496 | plain, **2 tasks** | would read as *epic* | **story** ✓ |
| #520 | `Epic: Finish summary story` | epic | epic ✓ |
| #465 | `Epic: Claude Team …` | epic | epic ✓ |
| #484 | plain | "needs shaping" (ambiguous) | **story** ✓ |

Note none of the existing epics carry the `epic` label today — they are title-only, and all three still classify correctly.

## Split by what can actually be derived

**Label and title → the script.** Read by `team.is_epic()`, reaching the Architect as `$KIND`.

**"I'll be explicit in the comment" → the model.** ⚠️ A regex for `epic` misfires on an ordinary sentence — *"a story under the Claude Team epic"* — and a false positive makes the Architect decompose a story into sub-stories. `_shared.md` already frames a trigger comment as a modifier on the work, so the model weighs it against the script's default. That is the one thing that overrides `$KIND`.

## The label is applied from the title

`sync-epic-label.py` reads the title the Architect had to write anyway and applies the label. ⚠️ A `gh` call the model is merely *asked* to remember is the shape that failed for the sub-issue manifest — written once across nine epics. It only ever adds, so a title or label you set is never stripped.

## Verification

`npm test --ws` ✓ 0 errors · `tsc --noEmit` ✓ · all hooks compile · workflow parses · routing harness unchanged.

Classification and delegation exercised against **live issues** (the table above). `sync-epic-label.py` checked on its two no-op paths — a non-epic title leaves labels alone, no issue exits clean.

Also fixes a stale line in `architect.md` still sending the Tester and Writer to the story's **PR** for handoffs; #503 moved those to the story's **issue**.

⚠️ Cannot be exercised before merge. Afterwards: `@claude` on a plain issue should shape a story, and on a `Epic:`-titled one should shape an epic and leave it labelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
