### PR TITLE
Epics are the maintainer's to create; an ambiguous issue is a story

### DIFF
--- a/.claude/skills/file-bug/SKILL.md
+++ b/.claude/skills/file-bug/SKILL.md
@@ -8,8 +8,8 @@ GitHub issue (unlabeled) that an Implementor can pick up and fix without further
 
 The bug: $ARGUMENTS
 
-Bugs skip the Manager and Researcher entirely — there is no epic, no decomposition and no
-integration branch. You do the grounding here, and the issue you file is the whole handoff.
+Bugs skip the Architect entirely — there is no epic and no decomposition. You do the
+grounding here, and the issue you file is the whole handoff.
 
 Do NOT fix the bug. The deliverable is the issue.
 

--- a/.claude/skills/plan-feature-light/SKILL.md
+++ b/.claude/skills/plan-feature-light/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-feature-light
-description: Sketch a feature's proposal and research path, and file it as one GitHub issue for a Researcher agent to decompose in-repo.
+description: Sketch a feature's proposal and research path, and file it as one GitHub issue for the Architect to decompose in-repo.
 ---
 
 Sketch a feature's big-picture proposal and — the part that matters most — a **research
@@ -66,22 +66,11 @@ turn into a sized breakdown — no more.
 - **Proposal** — the high-level shape (§3).
 - **Constraints** — standing + feature-specific.
 - **Research path** — the reading list + questions (§2). *This is the heart of the issue.*
-- **Integration branch** — the epic's feature branch (cut below) and the branch-per-epic flow.
 - **Your task** — the block below, addressed to the assignee agent.
 
-**Then cut the epic's feature branch — always.** This issue *is* the epic (the agent's sub-issues
-link to it as native sub-issues), so it gets one integration branch that all that work targets, not
-`mainline` — the feature lands together and merges as a single PR. Capture the issue number, then:
-
-```
-git checkout mainline && git pull --ff-only
-git checkout -b <issue#>-<kebab-summary>
-git push -u origin <issue#>-<kebab-summary>
-```
-
-The branch is empty (off `mainline`) until the first sub-issue PR merges in. After cutting it,
-`gh issue edit` the issue to fill the concrete branch name into its **Integration branch** section
-and the *Your task* block.
+⚠️ **Do not cut a branch, and do not create an epic on your own initiative.** An epic has
+neither a branch nor a PR, and epics are the maintainer's to create — propose it and stop for
+agreement. A story owns a branch, cut by the Architect when that story is triggered.
 
 ### The "Your task" block (include in the issue, addressed to the GitHub agent)
 
@@ -103,11 +92,9 @@ and the *Your task* block.
 > repo, i.e. `$GITHUB_REPOSITORY`). If that API is unavailable, fall back to a
 > `Part of #<this-issue-number>` line in each body.
 >
-> **Target the epic's feature branch.** A branch `<issue#>-<kebab-summary>` has been cut off
-> `mainline` for this epic (its name is in the *Integration branch* section above). Every sub-issue
-> you create must carry a **Base branch** note telling its worker to *branch off that branch and open
-> the PR against it, not `mainline`; rebase onto it once the prerequisite sub-issue has landed there.*
-> Land the prerequisite sub-issue into the branch first.
+> **Do not cut or reference any branch.** An epic has none. Each **story** you create gets its
+> branch from the Architect when that story is first triggered, and each of its tasks cuts its
+> own off that. Say which stories are blocked on which, and leave branching alone.
 >
 > ⚠️ When your index comment or any issue body references sub-issues by number, use their **real
 > issue numbers** (assigned after creation), never ordinals like #1…#7 — GitHub auto-links `#N` to
@@ -140,7 +127,7 @@ and the *Your task* block.
 ## 5. Close with a one-liner for the maintainer
 
 After creating it, post the issue link **and the epic's feature-branch name** in your response
-and remind the maintainer: review / iterate, then label it **`@claude/researcher`** and comment
+and remind the maintainer: review / iterate, then apply the **`@claude`** label, which routes it to the Architect, and comment
 **`@claude`** to start the research + decomposition — the label tier gets the full turn budget, while an `@claude` comment
 runs on the smaller poke budget and can time out on real research. The agent's sub-issues will
 target the feature branch, not `mainline`. The agent will then **create the sub-issues

--- a/.claude/skills/plan-feature/SKILL.md
+++ b/.claude/skills/plan-feature/SKILL.md
@@ -28,8 +28,8 @@ is `mainline`. See CLAUDE.md for architecture and conventions.
 
 The overall goal and why, the shared constraints, and a short codebase map of where the
 relevant code lives. This is the review artifact — it's what the maintainer reads to
-decide whether the decomposition is right. Include an **Integration branch** section naming
-the epic's feature branch and the branch-per-epic flow (see §4).
+decide whether the decomposition is right. ⚠️ **No branch section** — an epic has neither a
+branch nor a PR.
 
 ## 3. Decompose into sub-issues sized for a bounded-turn worker
 
@@ -74,59 +74,34 @@ implemented without that context.
 Order them so prerequisites come first, and say plainly which are independent (safe to
 start in parallel) and which are blocked on an earlier child.
 
-## 4. Create the issues and the epic's feature branch
+## 4. Propose the epic — do not create it
 
-Create the **epic first**, cut its feature branch, then each sub-issue, then link them:
+⚠️ **Epics are the maintainer's to create.** You never file one on your own initiative. Put
+the epic body from §2 in your response, say plainly that it is a proposal, and **stop for
+agreement**. If they say go, create it then and not before.
 
-1. **Epic** — `gh issue create --title "<epic title>" --body "<parent body from §2>"` (no
-   labels). Capture its number from the returned URL.
-2. **Cut the epic's feature branch — always.** Every epic gets one integration branch; sub-issue
-   work targets it, not `mainline`, so the whole feature lands together and merges to `mainline`
-   as a single PR. From the epic number:
+⚠️ **An epic has no branch and no PR.** Do not cut one. A story owns a branch and a PR
+against `mainline`; a task cuts its own off the story's and PRs back into it. If you find
+yourself wanting an integration branch, you are looking at the retired model.
+
+Once the maintainer agrees:
+
+1. **Epic** — `gh issue create --title "Epic: <title>" --body "<the body from §2>"`, no
+   labels. ⚠️ The `Epic:` prefix is load-bearing: it is how every later run classifies the
+   issue, and a scripted hook applies the `epic` label from it.
+2. **Stories** — one `gh issue create` per story, no labels, each body built from the
+   `.github/ISSUE_TEMPLATE/claude-task.yml` headings.
+3. **Link each story to the epic** as a native sub-issue. ⚠️ The REST API wants the child's
+   integer database `id`, not its issue number:
    ```
-   git checkout mainline && git pull --ff-only
-   git checkout -b <epic#>-<kebab-summary>
-   git push -u origin <epic#>-<kebab-summary>
+   gh api repos/{owner}/{repo}/issues/<child-number> --jq .id
+   gh api --method POST repos/{owner}/{repo}/issues/<epic-number>/sub_issues -F sub_issue_id=<that-id>
    ```
-   Cut from current `mainline`; it stays empty until the first sub-issue PR merges in. Then give the
-   **epic body** an **Integration branch** section: name the branch, say each sub-issue branches off
-   it and PRs **into** it, land the prerequisite child first, and note that if the `@claude` action
-   opens a sub-issue PR against `mainline` by default, the maintainer retargets the PR's base to the
-   epic branch (GitHub → the PR → Edit → base dropdown).
-3. **Sub-issues** — one `gh issue create` per child (no labels), body built from the
-   `.github/ISSUE_TEMPLATE/claude-task.yml` headings:
-   - **Summary** — what needs to happen and why
-   - **Where the code lives** — specific, verified paths
-   - **What to change** — concrete requirements, bulleted
-   - **Patterns to follow** — an existing file to mirror
-   - **Out of scope** — what not to touch; prevents over-engineering
-   - **Acceptance criteria** — a short checklist
-   - **CLAUDE.md Updates (Optional)** — anything that will need updating in CLAUDE.md
+4. Add the epic and every story to the project:
+   `gh project item-add 4 --owner "@me" --url <url>`.
 
-   ⚠️ Every child body must also carry a **Base branch** note: *branch off `<epic#>-<kebab-summary>`
-   and open your PR against it, not `mainline`; rebase onto it once the prerequisite child has landed
-   there.* A worker sees only its own issue, so this can't be left implicit.
-4. **Link each sub-issue as a native GitHub sub-issue of the epic** so they show in its
-   Sub-issues list — a `Part of #N` text line is *not* sufficient. The REST API wants the
-   child's integer database `id`, **not** its issue number:
-   - `gh api repos/{owner}/{repo}/issues/<child-number> --jq .id` → the child's id
-   - `gh api --method POST repos/{owner}/{repo}/issues/<epic-number>/sub_issues -F sub_issue_id=<that-id>`
-
-   `gh api` fills `{owner}/{repo}` from the current repo. If the sub-issues API is
-   unavailable, fall back to a `Part of #<epic-number>` line in each child body.
-
-⚠️ When the epic body lists its children, reference them by their **real issue numbers** (e.g.
-`#231`), added after the children exist — never as ordinals like "#1…#7". GitHub auto-links `#N` to
-whatever issue/PR already holds that number, so low ordinals silently point at ancient PRs.
-
-Carry these standing constraints into every sub-issue's Out of scope:
-
-- Don't hand-edit generated files (`routeTree.gen.ts`).
-- Don't add lodash; use `packages/app/src/utils/func.ts`.
-- Don't rename anything under `packages/kb/data/**` — it changes derived ids.
-
-Don't ask a worker to run builds. The **Verify** workflow runs the gate on the PR, and
-`npm ci` plus the package builds would eat most of a run's turn budget.
+⚠️ **Do not cut any branch here.** The Architect cuts a story's branch when that story is
+triggered — see `packages/claude-team/prompts/architect.md`.
 
 ### Handoff for cheap follow-ups
 
@@ -152,11 +127,10 @@ cadence is already wired for every run.
 
 ## 5. Close with a plan of attack
 
-After creating them, post the summary in your response: the epic link, the epic's **feature
-branch** name (and the reminder that sub-issue PRs target it, retargeting off `mainline` if
-needed), then each sub-issue's title + link, which are independent vs. blocked and on what, and
-the order to work them. The issues are **unlabeled drafts** — the maintainer reviews and iterates,
-then starts one by **labelling it `@claude/implementor` and commenting `@claude`**. Labels only
+After creating them, post the summary in your response: the epic link, then each story's title
++ link, which are independent vs. blocked and on what, and the order to work them. The issues
+are **unlabeled drafts** — the maintainer reviews and iterates, then starts one by **applying
+the `@claude` label**, which routes it to the Architect. Labels only
 mark ownership; the comment is what starts a run.
 
 ## Boundaries

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -28,6 +28,9 @@ state, not from something a model was asked to leave behind.
 - ⚠️ **A maintainer's comment is the only override**, and it is judged by the model rather
   than matched by the script. A regex for the word misfires on an ordinary sentence — "a
   story under the Claude Team epic" — and a false positive decomposes a story into stories.
+- ⚠️ **Epics are the maintainer's to create.** No role files one on its own initiative and
+  none promotes an issue into one. A role may *propose* an epic and stop; the decision is
+  not delegated. Ambiguity resolves to a story, always.
 - A story owns one branch and one PR against the default branch, and it accumulates.
 - A task is a slice of a story with its own branch and its own PR **into the story branch**.
 

--- a/packages/claude-team/prompts/architect.md
+++ b/packages/claude-team/prompts/architect.md
@@ -8,13 +8,21 @@ modifier on it.
 ## Two modes, and the default is STORY
 
 `$KIND` says which, derived from the issue itself: an `epic` label, or a title beginning
-"Epic". ⚠️ **An unprocessed issue is a story.** That is the default and it is almost always
-right — the maintainer marks the exceptions.
+"Epic". ⚠️ **An unprocessed issue is a STORY.** Not a maybe — a story. That is the default,
+and ambiguity resolves to it every time.
 
-⚠️ **The triggering comment is the only thing that overrides `$KIND`.** If the maintainer
-says it is an epic, it is, whatever the label and title currently say. Nothing else does: do
-not infer an epic from an issue merely having sub-issues, because a story has those too —
-they are its tasks.
+⚠️ **EPICS ARE THE MAINTAINER'S TO CREATE. You never create one**, and you never promote an
+issue into one. If work looks too large for a story, say so and stop — proposing it is
+useful, deciding it is not yours.
+
+⚠️ **Reshaping an issue toward an epic needs a signal, not an impression.** Two qualify: the
+markers in `$KIND`, or the maintainer saying so in the triggering comment. An issue merely
+looking big, vague or unfinished is **not** one — nor is having sub-issues, since a story has
+those too; they are its tasks.
+
+⚠️ **"The maintainer said so" means they said so.** The word "epic" appearing in a sentence
+is not an instruction — "a story under the Claude Team epic" is a story. If you are weighing
+whether they meant it, they did not: treat it as a story and raise the question.
 
 **On an epic** — shape the goal. An epic is a cross-story product outcome, not a task list.
 Rewrite it so a reader knows what "done" looks like and why it matters, and say what is in


### PR DESCRIPTION
Closes #532. **Epics are yours to create.** No agent files one on its own initiative, none promotes an issue into one, and a role that thinks something warrants an epic proposes it and stops.

## The Architect's classification tightens

- An unprocessed issue is a **story** — not a maybe. Ambiguity resolves to it every time.
- Reshaping toward an epic needs a **signal, not an impression**: the `epic` label, an `Epic` title, or the maintainer actually saying so.
- ⚠️ Looking big, vague or unfinished is **not** a signal. Nor is having sub-issues — a story has those too, they are its tasks.
- ⚠️ "The maintainer said so" means they said so. `"a story under the Claude Team epic"` is a story. If it is being weighed, the answer is story.

## ⚠️ The planning skills were worse than loose

Both described the **retired epic-integration-branch model in full**, and anyone following either today would have rebuilt exactly what #503 dismantled:

| skill | said |
|---|---|
| `plan-feature` §4 | "Create the **epic first**", then *"Cut the epic's feature branch — **always**"*, with sub-issue PRs targeting it and the maintainer retargeting bases by hand |
| `plan-feature-light` | the same, plus a *Base branch* note on every child telling its worker to PR into the epic branch |

`plan-feature` now proposes the epic and stops for agreement, then creates the epic and its **stories** — no branch, since an epic has none. `plan-feature-light` likewise.

## Two retired role names, still live in the skills

- `file-bug` deferred to *"the Manager and Researcher"* — both merged into the Architect in #467.
- `plan-feature-light` told you to label **`@claude/researcher`** — a handle that has not existed since #467, and would route nowhere.

Both now point at the Architect and the `@claude` label.

## Verification

`npm test --ws` ✓ 0 errors · hooks compile ✓.

Swept and clean: no `integration branch` / `epic's feature branch` / `branch-per-epic` / `retarget` language outside the one line that names it as retired; no `Manager` or `Researcher`; nothing instructing an agent to create an epic unprompted.

⚠️ Nothing here changes a hook — it is prompts and skills, so the first Architect run after merge is the test. On a plainly-titled issue it should shape a story and say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
