### PR TITLE
Stop a run's commits landing on a branch nobody looks at

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -267,6 +267,19 @@ jobs:
           # unknown slash command, so the run returns success in ~150ms having never called
           # the model. Every comment-triggered role was dead this way between #485 and #488.
           trigger_phrase: "@claude/architect"
+          # ⚠️ THE ACTION MAKES ITS OWN BRANCH AND TELLS THE MODEL TO STAY ON IT (#530). For an
+          # issue trigger it always creates one — there is no way to decline in tag mode — and
+          # then injects "You are already on the correct branch. Do not create a new branch",
+          # which contradicts our prompt. Which instruction wins is down to the model, and it
+          # has gone both ways: #497 pushed to the story branch, #514 pushed 44 turns of work
+          # to `claude/issue-514-…` where nothing looks, reporting success.
+          #
+          # Empty prefix + this template makes that branch `<issue#>-<kebab-title>` — our own
+          # shape. For a task that fully resolves it, since an author cuts any `<task#>-…`
+          # branch it likes. It cannot match a story branch the Architect already named, so
+          # finish-pr.py also reports commits stranded on an unexpected branch.
+          branch_prefix: ""
+          branch_name_template: "{{entityNumber}}-{{description}}"
           track_progress: true
           prompt: ${{ steps.prompt.outputs.body }}
           # Read-and-write-issues only; no build tools needed for shaping an epic.
@@ -504,6 +517,19 @@ jobs:
           # unknown slash command, so the run returns success in ~150ms having never called
           # the model. Every comment-triggered role was dead this way between #485 and #488.
           trigger_phrase: "@claude/implementor"
+          # ⚠️ THE ACTION MAKES ITS OWN BRANCH AND TELLS THE MODEL TO STAY ON IT (#530). For an
+          # issue trigger it always creates one — there is no way to decline in tag mode — and
+          # then injects "You are already on the correct branch. Do not create a new branch",
+          # which contradicts our prompt. Which instruction wins is down to the model, and it
+          # has gone both ways: #497 pushed to the story branch, #514 pushed 44 turns of work
+          # to `claude/issue-514-…` where nothing looks, reporting success.
+          #
+          # Empty prefix + this template makes that branch `<issue#>-<kebab-title>` — our own
+          # shape. For a task that fully resolves it, since an author cuts any `<task#>-…`
+          # branch it likes. It cannot match a story branch the Architect already named, so
+          # finish-pr.py also reports commits stranded on an unexpected branch.
+          branch_prefix: ""
+          branch_name_template: "{{entityNumber}}-{{description}}"
           track_progress: true
           prompt: ${{ steps.p_implementor.outputs.body }}
           # Allowlist by *family*, not per-subcommand. Deliberately NOT bare `Bash`: this
@@ -560,6 +586,19 @@ jobs:
           # unknown slash command, so the run returns success in ~150ms having never called
           # the model. Every comment-triggered role was dead this way between #485 and #488.
           trigger_phrase: "@claude/designer"
+          # ⚠️ THE ACTION MAKES ITS OWN BRANCH AND TELLS THE MODEL TO STAY ON IT (#530). For an
+          # issue trigger it always creates one — there is no way to decline in tag mode — and
+          # then injects "You are already on the correct branch. Do not create a new branch",
+          # which contradicts our prompt. Which instruction wins is down to the model, and it
+          # has gone both ways: #497 pushed to the story branch, #514 pushed 44 turns of work
+          # to `claude/issue-514-…` where nothing looks, reporting success.
+          #
+          # Empty prefix + this template makes that branch `<issue#>-<kebab-title>` — our own
+          # shape. For a task that fully resolves it, since an author cuts any `<task#>-…`
+          # branch it likes. It cannot match a story branch the Architect already named, so
+          # finish-pr.py also reports commits stranded on an unexpected branch.
+          branch_prefix: ""
+          branch_name_template: "{{entityNumber}}-{{description}}"
           track_progress: true
           prompt: ${{ steps.p_designer.outputs.body }}
           claude_args: |
@@ -603,6 +642,19 @@ jobs:
           # unknown slash command, so the run returns success in ~150ms having never called
           # the model. Every comment-triggered role was dead this way between #485 and #488.
           trigger_phrase: "@claude/tester"
+          # ⚠️ THE ACTION MAKES ITS OWN BRANCH AND TELLS THE MODEL TO STAY ON IT (#530). For an
+          # issue trigger it always creates one — there is no way to decline in tag mode — and
+          # then injects "You are already on the correct branch. Do not create a new branch",
+          # which contradicts our prompt. Which instruction wins is down to the model, and it
+          # has gone both ways: #497 pushed to the story branch, #514 pushed 44 turns of work
+          # to `claude/issue-514-…` where nothing looks, reporting success.
+          #
+          # Empty prefix + this template makes that branch `<issue#>-<kebab-title>` — our own
+          # shape. For a task that fully resolves it, since an author cuts any `<task#>-…`
+          # branch it likes. It cannot match a story branch the Architect already named, so
+          # finish-pr.py also reports commits stranded on an unexpected branch.
+          branch_prefix: ""
+          branch_name_template: "{{entityNumber}}-{{description}}"
           track_progress: true
           # ⚠️ NO handoff is appended here. Only one role runs per trigger (#500), so an
           # author's `structured_output` is never available to this step — it would always
@@ -650,6 +702,19 @@ jobs:
           # unknown slash command, so the run returns success in ~150ms having never called
           # the model. Every comment-triggered role was dead this way between #485 and #488.
           trigger_phrase: "@claude/writer"
+          # ⚠️ THE ACTION MAKES ITS OWN BRANCH AND TELLS THE MODEL TO STAY ON IT (#530). For an
+          # issue trigger it always creates one — there is no way to decline in tag mode — and
+          # then injects "You are already on the correct branch. Do not create a new branch",
+          # which contradicts our prompt. Which instruction wins is down to the model, and it
+          # has gone both ways: #497 pushed to the story branch, #514 pushed 44 turns of work
+          # to `claude/issue-514-…` where nothing looks, reporting success.
+          #
+          # Empty prefix + this template makes that branch `<issue#>-<kebab-title>` — our own
+          # shape. For a task that fully resolves it, since an author cuts any `<task#>-…`
+          # branch it likes. It cannot match a story branch the Architect already named, so
+          # finish-pr.py also reports commits stranded on an unexpected branch.
+          branch_prefix: ""
+          branch_name_template: "{{entityNumber}}-{{description}}"
           track_progress: true
           # ⚠️ NO handoff appended — same reason as the Tester. The Writer reads the Handoff
           # comments on its own story's PR, on its own trigger.

--- a/packages/claude-team/hooks/finish-pr.py
+++ b/packages/claude-team/hooks/finish-pr.py
@@ -49,7 +49,45 @@ if not pr and ISSUE:
         pr = str(match["number"])
 
 if not pr:
-    print("This run opened no PR — nothing to finish.")
+    # ⚠️ "No PR" is not automatically "nothing happened". The host action creates its own
+    # branch for an issue trigger and tells the model to stay on it, contradicting our
+    # prompt — and when the model obeys it, a run's work lands somewhere nobody looks. It
+    # happened on a 44-turn run that reported success (#530). Silence there cost days.
+    #
+    # So before accepting "nothing to finish", check whether this run actually produced
+    # commits. If it did, say so loudly and leave the recovery command on the issue.
+    stranded = ""
+    if branch and branch != "HEAD":
+        default = (
+            team.gh_json("repo", "view", team.REPO, "--json", "defaultBranchRef") or {}
+        ).get("defaultBranchRef", {}).get("name") or ""
+        if default:
+            ahead = subprocess.run(
+                ["git", "rev-list", "--count", f"origin/{default}..HEAD"],
+                capture_output=True, text=True, check=False,
+            ).stdout.strip()
+            if ahead.isdigit() and int(ahead) > 0:
+                stranded = f"{ahead} commit(s) on `{branch}`"
+
+    if not stranded:
+        print("This run opened no PR — nothing to finish.")
+        raise SystemExit(0)
+
+    team.warn(
+        f"This run produced {stranded} but opened no PR. The work is not lost — it is on a "
+        f"branch the process does not expect."
+    )
+    if ISSUE:
+        team.gh(
+            "issue", "comment", ISSUE, "--repo", team.REPO,
+            "--body",
+            f"🔔 **This run produced {stranded} but opened no PR.**\n\n"
+            f"The work is not lost. It is on `{branch}`, which is not where the process "
+            f"looks — see #530.\n\n"
+            f"To recover it onto a branch that is:\n\n"
+            f"```\ngit fetch origin {branch}\n"
+            f"git push origin origin/{branch}:refs/heads/<the-branch-you-wanted>\n```",
+        )
     raise SystemExit(0)
 
 for role in ROLES.split():


### PR DESCRIPTION
Closes #530. Two halves, because neither is sufficient alone.

## Prevention

`branch_prefix: ""` and `branch_name_template: "{{entityNumber}}-{{description}}"` on all five authoring model steps. The action's own branch becomes `<issue#>-<kebab-title>` instead of `claude/issue-<n>-<timestamp>` — **our shape**.

⚠️ For a **task** that resolves it completely: an author cuts any `<task#>-…` branch it likes, so the action's name is as good as one it would have chosen. The conflict simply stops existing.

⚠️ For a run on a **story** it cannot match a branch the Architect already named — `514-nx-docs` vs `514-update-docs-to-refer-to`. Same shape, different name. Hence the second half.

Security is excluded — it authors nothing.

## Detection

`finish-pr.py` treated "no PR" as "nothing happened":

```
This run opened no PR — nothing to finish.
```

Accurate, and exactly what it printed on #514 while 44 turns of work sat on another branch. It now checks whether the run produced commits *before* accepting that, and if it did, warns and leaves the recovery command on the issue.

⚠️ **"No PR" and "nothing happened" are different states**, and they were indistinguishable. That is what made #514 look like a failed run for a day.

## Verification

Both paths exercised, not asserted:

| state | output |
|---|---|
| clean tree, no commits | `This run opened no PR — nothing to finish.` |
| branch 1 commit ahead | `::warning::This run produced 1 commit(s) on \`530-branch-conflict\` but opened no PR. The work is not lost — it is on a branch the process does not expect.` |

`npm test --ws` ✓ 0 errors · hooks compile ✓ · workflow parses ✓ · all five authoring steps carry the prefix and template, security carries neither.

⚠️ Cannot be exercised before merge — and `pull_request` events run from the base branch, so this reaches an in-flight run only once it is on `mainline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
