### PR TITLE
Resolve the story for a handle triggered on an issue

### DIFF
--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -77,6 +77,12 @@ the issue's state to pick the role. The same label named in a comment does the s
 `@claude/<role>` handle in a comment names the role outright and skips the inspection — the
 way to override a bad guess.
 
+⚠️ **A handle skips the role decision, not the context.** It still resolves the story — from
+the PR's head branch on a PR, from the issue's **Branch** line on an issue. It did neither on
+an issue once, so a handled role started with no story and paid turns rediscovering what the
+router already had. Resolve it inside the handle branch; do **not** fall through to the
+state-based rules, which would re-judge the role and could pick a different one.
+
 ⚠️ **Routing is a shell script, never a model.** It is all readable state; the one call that
 needs judgement — which author owns a task — is answered once by the Architect and written
 into the task as a `Role:` line.

--- a/packages/claude-team/hooks/delegate.py
+++ b/packages/claude-team/hooks/delegate.py
@@ -97,9 +97,27 @@ for role in ("architect", "implementor", "tester", "writer", "designer", "securi
     if f"@claude/{role}" in COMMENT_BODY:
         ROLES = role
         REASON = f"handle @claude/{role} in the comment"
-        if IS_PR and NUMBER:
-            STORY = resolve_pr_story()
-            REASON += f"; PR #{NUMBER} belongs to story #{STORY or 'unknown'}"
+        # A handle names the role outright, but it should not cost the role its context.
+        # ⚠️ Resolve the story HERE rather than falling through to rule 5 — the
+        # short-circuit is the point of a handle, and rule 5 would re-judge the role
+        # against issue state and could pick a different one.
+        if NUMBER:
+            if IS_PR:
+                STORY = resolve_pr_story()
+                REASON += f"; PR #{NUMBER} belongs to story #{STORY or 'unknown'}"
+            else:
+                # The Branch line names the STORY's branch on a story and on its tasks
+                # alike, so its leading number is the story — the same read rule 5 does.
+                # Without this a handle on an issue emitted no story at all while the
+                # label path on the very same issue resolved one, and the role paid turns
+                # rediscovering what the router already had.
+                #
+                # No fallback to the issue's own number: an issue with no Branch line is
+                # not part of a story, and claiming it is its own would be worse than
+                # empty, which every prompt already handles.
+                STORY = team.story_from_branch(team.branch_line(team.issue_body(NUMBER)))
+                if STORY:
+                    REASON += f"; #{NUMBER} belongs to story #{STORY}"
         emit()
         raise SystemExit(0)
 


### PR DESCRIPTION
A `@claude/<role>` handle on an issue routed the role but emitted no story — while the `@claude` label on the very same issue resolved one. The **Branch** line was in the body the whole time; rule 1 short-circuits before rule 5, which is where that line is read.

Closes #544

## Before and after, measured

Task **#524** — `Role: tester`, `Branch: 517-add-srm-to-notes`:

| trigger | role | `$STORY` before | after |
|---|---|---|---|
| `@claude` label | tester | 517 | 517 |
| `@claude/writer` comment | writer | **none** | **517** |
| `@claude/writer` on PR #534 | writer | 530 | 530 |

## ⚠️ Two things that would have been easy to get wrong

**Resolved inside the handle branch, not by falling through to rule 5.** The short-circuit *is* the point of a handle — rule 5 re-judges the role against issue state and could pick a different one. Proof it still overrides: **#521 is stamped `implementor`**, and a `@claude/tester` handle on it still routes to **tester**, now carrying story 516.

**No fallback to the issue's own number.** Rule 5 has `or (parent or NUMBER)`; copying that here would make an unshaped issue claim to be its own story, which is worse than empty. An empty `$STORY` is a case every prompt already handles.

## Verification

Every acceptance criterion run against **live GitHub**, not asserted:

- Handle on a task issue resolves the same story as the label — #524 → 517, #521 → 516, shown side by side.
- PR path unchanged — #534 gives 530 with and without a handle.
- An issue with no Branch line stays empty rather than failing — #484 and #480 both `story=none`.
- The handle still beats the `Role:` stamp.

`nx run-many --target=test` ✓ **6 projects** · `tsc --noEmit` ✓ · `nx build app` ✓ · hooks compile ✓.

No UI change, so no screenshots.

⚠️ Verify will not run — the path filter excludes `packages/claude-team`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
