### PR TITLE
Open the PR for stranded work, and correct the closing-reference claim

### DIFF
--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -58,10 +58,18 @@ authoring run.** The story branch is cut empty, and GitHub will not open a PR wi
 commits between base and head, so the first task landing is the earliest moment it can
 exist.
 
-⚠️ **A task PR's closing keyword does nothing on its own.** GitHub honours `Closes #N` only
-when a PR targets the **default** branch, and a task PR targets the story branch. The merge
-hook parsing the body is the only thing that closes a task — which is why an author must
-write the line even though GitHub ignores it.
+⚠️ **A task PR's closing keyword links but does not close.** Two behaviours, easy to
+conflate — and they were, wrongly, until measured:
+
+- **Linking works at any base.** A keyword in the body populates `closingIssuesReferences`
+  whatever the PR targets: #536 → [521], #542 → [522], #443 → [441], all into story branches.
+- **Auto-closing needs the default branch.** A task PR targets its story's branch, so GitHub
+  never closes it. The merge hook does.
+
+An author writes the line for both reasons, and the hook's body-parse is a net for a keyword
+GitHub did not link — not the mechanism. ⚠️ There is also **no public GraphQL mutation** for
+linking a PR to an issue: introspection shows only `createLinkedBranch` and `addSubIssue`,
+and the UI's "link an issue" control edits the PR body. The keyword *is* the API.
 
 ⚠️ **A task still open when its story merges is a signal, not a gap.** Nothing closes it
 implicitly: it was abandoned, or its PR never landed. An earlier version closed a merged

--- a/packages/claude-team/hooks/close-merged-work.py
+++ b/packages/claude-team/hooks/close-merged-work.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
 """Runs on every merged PR. Closes the issues it finished and files them on the board.
 
-GitHub only acts on closing keywords when a PR targets the DEFAULT branch. A task's PR
-targets its STORY's branch, so its `Closes #<task>` is inert and closingIssuesReferences
-comes back empty — the intent is in the body, GitHub just never linked it. Parsing it here
-is the only thing that closes a task.
+TWO BEHAVIOURS, NOT ONE — this said they were the same and was half wrong.
+
+  linking       a closing keyword in the body links the issue at ANY base. Measured on
+                real PRs into story branches: #536 -> [521], #542 -> [522], #443 -> [441].
+                closingIssuesReferences IS populated, so the primary path below finds it.
+  auto-closing  GitHub only CLOSES on merge when the PR targets the DEFAULT branch. A
+                task PR targets its story's branch, so nothing closes it on its own —
+                which is why this hook exists.
+
+The body parse below is a net for a PR whose keyword GitHub did not link, not the
+mechanism. It is currently unreachable here; kept because a missing close is silent and
+costs an issue that never reaches Done.
 
 NO SUB-ISSUE EXPANSION. This used to close a closed issue's open children, because a story's
 tasks had no PRs of their own and the story's merge was the only thing that could close them.

--- a/packages/claude-team/hooks/finish-pr.py
+++ b/packages/claude-team/hooks/finish-pr.py
@@ -57,10 +57,10 @@ if not pr:
     # So before accepting "nothing to finish", check whether this run actually produced
     # commits. If it did, say so loudly and leave the recovery command on the issue.
     stranded = ""
+    default = (
+        team.gh_json("repo", "view", team.REPO, "--json", "defaultBranchRef") or {}
+    ).get("defaultBranchRef", {}).get("name") or ""
     if branch and branch != "HEAD":
-        default = (
-            team.gh_json("repo", "view", team.REPO, "--json", "defaultBranchRef") or {}
-        ).get("defaultBranchRef", {}).get("name") or ""
         if default:
             ahead = subprocess.run(
                 ["git", "rev-list", "--count", f"origin/{default}..HEAD"],
@@ -73,22 +73,54 @@ if not pr:
         print("This run opened no PR — nothing to finish.")
         raise SystemExit(0)
 
-    team.warn(
-        f"This run produced {stranded} but opened no PR. The work is not lost — it is on a "
-        f"branch the process does not expect."
-    )
+    # ⚠️ OPEN THE PR, do not describe how to. This used to warn and leave a recovery
+    # command, which is better than the silence it replaced but still left real work
+    # sitting where nobody looks until someone read the comment.
+    #
+    # ⚠️ A PR, never a push. In the case that prompted this the branches had diverged, so
+    # a push would have failed or needed force. A PR is non-destructive, reviewable, and
+    # the shape the process wants anyway — work reaches a story branch through one.
+    #
+    # Base: the story branch the issue names, when it exists and is not what we are on;
+    # otherwise the default branch. The host action generates its own branch name from
+    # the issue title, which can never match a name the Architect already chose, so this
+    # is the case prevention cannot reach.
+    base = ""
     if ISSUE:
-        team.gh(
-            "issue", "comment", ISSUE, "--repo", team.REPO,
-            "--body",
-            f"🔔 **This run produced {stranded} but opened no PR.**\n\n"
-            f"The work is not lost. It is on `{branch}`, which is not where the process "
-            f"looks — see #530.\n\n"
-            f"To recover it onto a branch that is:\n\n"
-            f"```\ngit fetch origin {branch}\n"
-            f"git push origin origin/{branch}:refs/heads/<the-branch-you-wanted>\n```",
+        named = team.branch_line(team.issue_body(ISSUE))
+        if named and named != branch and team.gh(
+            "api", f"repos/{team.REPO}/branches/{named}"
+        ) is not None:
+            base = named
+    if not base:
+        base = default
+
+    title = (team.issue(ISSUE, "title").get("title") if ISSUE else "") or f"Work from {branch}"
+    body = (
+        f"Opened automatically: this run left {stranded} with no PR of its own.\n\n"
+        f"The host action generates its own branch name, which cannot match a branch the "
+        f"Architect already named — see #530. The work is sound; only its PR was missing.\n"
+        + (f"\nCloses #{ISSUE}\n" if ISSUE else "")
+    )
+
+    if team.gh(
+        "pr", "create", "--repo", team.REPO, "--base", base, "--head", branch,
+        "--title", title, "--body", body,
+    ) is None:
+        team.warn(
+            f"This run produced {stranded} and I could not open a PR for it. "
+            f"Recover with: git push origin origin/{branch}:refs/heads/<the-branch-you-wanted>"
         )
-    raise SystemExit(0)
+        raise SystemExit(0)
+
+    found = team.gh_json(
+        "pr", "list", "--repo", team.REPO, "--head", branch, "--state", "open", "--json", "number"
+    )
+    if not found:
+        team.warn(f"Opened a PR from {branch} but could not read it back to finish it.")
+        raise SystemExit(0)
+    pr = str(found[0]["number"])
+    print(f"opened PR #{pr} from {branch} into {base} — it had {stranded} and none of its own")
 
 for role in ROLES.split():
     if team.gh("pr", "edit", pr, "--repo", team.REPO, "--add-label", f"@claude/{role}") is not None:


### PR DESCRIPTION
Closes #550. Two fixes, both surfaced by one run on story #516.

## 1. Recover stranded work, don't just describe how

⚠️ **#534's check fired in production for the first time, and worked.** It warned on #516 and left a recovery command; #514's equivalent had been silent. That part is a real improvement.

But it exposed the gap #530 predicted, which **prevention cannot reach**:

```
Architect cut:     516-gravity-actuals                    ← the story branch
Action generated:  516-gravity-derive-ogfg-actuals-from   ← where the commit went
```

`{{entityNumber}}-{{description}}` gives the right *shape*, which resolves every task run. It can never match a name the Architect already chose, so a run on a **story** keeps diverging.

**The hook already knows the answer** — the issue's `Branch:` line. It now opens the PR.

⚠️ **A PR, not a push.** In the real case the branches had diverged, so a push would have failed or needed `--force`. A PR is non-destructive, reviewable, and the shape the process wants anyway. Base is the story branch the issue names when it exists and differs from the head; otherwise the default branch.

## 2. A claim that was half false

`close-merged-work.py` and the package `CLAUDE.md` both said a task PR's `Closes #N` is inert **and** that `closingIssuesReferences` comes back empty. Measured against real PRs into story branches:

| PR | base | closingIssuesReferences |
|---|---|---|
| #536 | `516-gravity-actuals` | **[521]** |
| #542 | `517-add-srm-to-notes` | **[522]** |
| #443 | `441-srm-vitals-alignment` | **[441]** |

**Linking works at any base. Only auto-closing on merge needs the default branch.** Two behaviours, conflated into one and never tested — so the body-parse fallback was documented as *the mechanism* while being unreachable. It stays as a net; the comment now says what it actually is.

⚠️ Also recorded: **there is no public GraphQL mutation for linking a PR to an issue.** Introspection shows only `createLinkedBranch` and `addSubIssue`; the UI's "link an issue" control edits the PR body. The keyword *is* the API.

## Verification

`nx run-many --target=test` ✓ 6 projects · `tsc --noEmit` ✓ · hooks compile ✓.

The clean path still behaves: a run with no commits reports `This run opened no PR — nothing to finish.` The open-a-PR path is exercised for real by **#549**, which is precisely what the hook now does automatically — same head, same base, opened by hand because the hook could not yet.

⚠️ Verify will not run — the path filter excludes `packages/claude-team`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
