### PR TITLE
Move a Writer's task to In Progress like every other role

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -469,8 +469,13 @@ jobs:
       - if: contains(steps.roles.outputs.list, 'tester')
         run: npx playwright install --with-deps chromium
 
+      # ⚠️ ANY role that ran, not the three that build. This shared the `npm ci` gate, which
+      # is correct there — the Writer compiles nothing — and wrong here: a Writer's task is as
+      # much in progress as any other, so it sat in its original column for the whole run and
+      # then jumped to Done on merge. The two conditions look alike and mean different things;
+      # "does this role build" is not "is this role working". Keep them separate.
       - name: Move the issue to In Progress
-        if: contains(steps.roles.outputs.list, 'implementor') || contains(steps.roles.outputs.list, 'designer') || contains(steps.roles.outputs.list, 'tester')
+        if: steps.roles.outputs.list != ''
         env:
           # ⚠️ PROJECTS_TOKEN is safe here and only here: step env is per-step, so the model
           # steps below cannot read it. See the Owner post-mortem in CLAUDE.md.


### PR DESCRIPTION
Closes #552. The Writer now behaves like the Implementor and Designer for board status.

## The cause

The board step shared the `npm ci` gate:

```
contains(list, 'implementor') || contains(list, 'designer') || contains(list, 'tester')
```

⚠️ Correct for the **install** — the Writer compiles nothing, so skipping it saves the run. Wrong for the **board**, where a Writer's task sat in its original column for its whole run and then jumped straight to Done on merge.

The Tester was already in that list, so this was never "roles that write code" — just an omission.

## The fix

The board step gates on `steps.roles.outputs.list != ''` — any role that ran.

⚠️ **The two conditions stay separate.** They looked identical and mean different things: *does this role build* is not *is this role working*. A future role could easily be one and not the other, and merging them would make that a silent bug.

## Verification

Evaluated the real condition per role:

| role | moves to In Progress |
|---|---|
| implementor | ✅ |
| designer | ✅ |
| tester | ✅ |
| **writer** | ✅ (was ❌) |
| no role resolved | ❌ correct |

`npm ci` and the playwright install are **unchanged** — confirmed still gated on the original three, so a Writer-only run still skips both.

`nx run-many --target=test` ✓ 6 projects · workflow parses ✓.

⚠️ Cannot be exercised before merge. Afterwards, a Writer task should leave its column the moment it is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
