### PR TITLE
Always cut a Writer task; let the Writer decide there is nothing to do

### DIFF
--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -121,6 +121,14 @@ only the Architect can cut it in two.
 ⚠️ **The Tester and Writer are tasks the Architect cuts**, ordered after the authoring ones.
 No role chains off another — nothing runs that a maintainer did not trigger.
 
+⚠️ **The Writer's task is cut on EVERY story, unconditionally; the Tester's is judged.** The
+asymmetry is about when the evidence exists. Tests have a trigger the Architect can see while
+shaping — new behaviour. Documentation's trigger is `docsCandidates` in the authors'
+handoffs, which do not exist yet, so asking the Architect to predict it produces "no" every
+time: across every story before this rule, not one Writer task was ever cut. Cutting it
+always moves the judgement to the Writer, which reads the handoffs and is allowed to
+conclude nothing needs writing.
+
 ⚠️ **Per story, not per epic** — for the Writer too. An epic-wide documentation pass sounds
 cheaper, and its usual justification is that one branch touching the docs avoids conflicts.
 That only holds if stories land in parallel; where they merge one at a time, a later story

--- a/packages/claude-team/prompts/architect.md
+++ b/packages/claude-team/prompts/architect.md
@@ -74,8 +74,13 @@ a task or a story you create — nothing happens automatically.
 
 - **A `Role: tester` task per story that needs one**, alongside its authoring tasks. Tests
   belong next to the work while it is fresh.
-- **A `Role: writer` task per story that needs one**, ordered after the authoring tasks.
-  Documentation lands on the story branch by its own PR, like every other task.
+- **A `Role: writer` task on EVERY story. Always — this one is not a judgement call.**
+  ⚠️ You are shaping the story before any code exists, so you cannot yet know whether it
+  will need documenting: the evidence is `docsCandidates` in the authors' handoffs, which do
+  not exist while you are cutting tasks. Asked to guess, the honest answer is always "no",
+  and across every story so far it was — not one Writer task was ever cut.
+  **Cut it and let the Writer decide there is nothing to do.** A Writer run that documents
+  nothing is a correct, cheap, visible outcome; a story that silently never gets one is not.
 - ⚠️ **Order both last within the story, and say so.** The Tester and Writer read the
   authors' handoff comments on the story's **issue**, so triggering either before the authors
   have run wastes it.

--- a/packages/claude-team/prompts/tester.md
+++ b/packages/claude-team/prompts/tester.md
@@ -4,17 +4,21 @@ You are usually triggered on **your own task issue** — the Architect cuts a `R
 task on the story, and the `@claude` label routes it here by that stamp. A
 `@claude/tester` comment names you directly and works on an issue or a PR.
 
-## Where to read the handoffs
+## The story is your context and your handoffs
 
-They are comments on the **story's issue**, `$STORY` — not on a PR:
+⚠️ **Read the story before you read the diff.** `$STORY` is where both live:
 
 ```
 gh issue view "$STORY" --comments
 ```
 
-⚠️ The story's issue, because it always exists. Its PR does not until the first task PR
-merges into the story branch, so a handoff written during the first task would have nowhere
-to go. ⚠️ If `$STORY` is empty, fall back to the **Branch** line on `$ISSUE`.
+The body says what the work was *for* — the outcome, the constraints, what was deliberately
+left out. The comments carry the authors' **Handoff** blocks, one per task. Your own task
+issue tells you almost none of that; it is a slice.
+
+⚠️ The story's issue, not its PR. The PR does not exist until the first task merges into the
+story branch, so a handoff written during the first task would have nowhere to go. ⚠️ If
+`$STORY` is empty, fall back to the **Branch** line on `$ISSUE`.
 
 ## Where your work goes
 
@@ -22,7 +26,7 @@ The same place the Implementor's did: the story's branch, named on the issue's *
 line. Your tests land in the story's PR beside the code they cover.
 
 ⚠️ **Cut your own branch off the story's, and open your own PR into it** — see _Your
-branch_ in the shared rules. Your tests lands on the story branch when that PR merges.
+branch_ in the shared rules. Your tests land on the story branch when that PR merges.
 
 ## Where your work comes from
 

--- a/packages/claude-team/prompts/writer.md
+++ b/packages/claude-team/prompts/writer.md
@@ -5,17 +5,21 @@ You are usually triggered on **your own task issue** — the Architect cuts a `R
 task on the story, and the `@claude` label routes it here by that stamp. A
 `@claude/writer` comment names you directly and works on an issue or a PR.
 
-## Where to read the handoffs
+## The story is your context and your handoffs
 
-They are comments on the **story's issue**, `$STORY` — not on a PR:
+⚠️ **Read the story before you read the diff.** `$STORY` is where both live:
 
 ```
 gh issue view "$STORY" --comments
 ```
 
-⚠️ The story's issue, because it always exists. Its PR does not until the first task PR
-merges into the story branch, so a handoff written during the first task would have nowhere
-to go. ⚠️ If `$STORY` is empty, fall back to the **Branch** line on `$ISSUE`.
+The body says what the work was *for* — the outcome, the constraints, what was deliberately
+left out. The comments carry the authors' **Handoff** blocks, one per task. Your own task
+issue tells you almost none of that; it is a slice.
+
+⚠️ The story's issue, not its PR. The PR does not exist until the first task merges into the
+story branch, so a handoff written during the first task would have nowhere to go. ⚠️ If
+`$STORY` is empty, fall back to the **Branch** line on `$ISSUE`.
 
 ## Where your work goes
 


### PR DESCRIPTION
Closes #554.

## The evidence

"A `Role: writer` task per story that needs one" was never once acted on:

| story | tasks cut |
|---|---|
| #516 / #517 | implementor, tester |
| #518 / #519 | tester |
| #496 | designer, implementor |
| #466 / #468 | implementor ×4 / ×2 |

All three writer-stamped issues in the repo — #500, #514, #539 — were created by the maintainer directly.

⚠️ **The Tester's bullet carries the same "that needs one" qualifier and is followed every time.** So this was never just weak wording.

## Why it kept saying no

The Architect judges this **before any code exists**. Tests have a trigger it can see — new behaviour. Documentation's trigger is `docsCandidates` in the authors' handoffs, which do not exist while tasks are being cut. Asked to predict something the system produces later, "no" is the honest answer, and it gave it every time.

## The change

**The Writer's task is cut on every story, unconditionally.** The judgement moves to the Writer, which reads the handoffs and is still allowed to conclude nothing needs writing — `A run that documents nothing is a correct outcome` stays in its prompt, untouched.

⚠️ **The Tester's qualifier is left alone.** It is being followed, and tests have a trigger the Architect can actually see while shaping. The asymmetry is about *when the evidence exists*, not about which roles matter.

## Also

Both consuming roles now name the **story** as the source of context *and* handoffs, not handoffs alone — its body says what the work was for and what was deliberately left out; its comments carry the Handoff blocks; a task issue is only a slice. Previously they were pointed at the story for handoffs and left to find context themselves.

`post-handoff.py` already posted to the story's issue, so no hook changed.

## Verification

`nx run-many --target=test` ✓ 6 projects.

Checked: both prompts carry the new context section; the Writer's "documents nothing is correct" line survives; the Tester's qualifier is unchanged.

⚠️ Prompts only — no hook, no workflow. The first Architect run after merge is the test: it should cut a `Role: writer` task on a story it would previously have skipped.

⚠️ **Worth watching for the failure mode this invites:** if Writer runs turn out to be mostly no-ops, the better shape is deriving the task from a non-empty `docsCandidates` via a hook — which cannot be forgotten. That needs evidence this version does not work first, and is noted as out of scope in #554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
