### PR TITLE
Tester: plan first, derive from behaviour, file findings on the authoring task

### DIFF
--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -121,6 +121,16 @@ only the Architect can cut it in two.
 ⚠️ **The Tester and Writer are tasks the Architect cuts**, ordered after the authoring ones.
 No role chains off another — nothing runs that a maintainer did not trigger.
 
+⚠️ **A test derived from the implementation is worthless, and looks exactly like coverage.**
+It asserts what the code does, so it passes by construction and cannot fail for the only
+reason worth catching. The Tester derives from *expected* behaviour — the story's outcome,
+the `testingNotes`, the acceptance criteria — and may read a component for one thing only:
+how to **address** an element. Knowing how to click a thing is not knowing what it should do.
+
+⚠️ **A failing test is a finding, not a chore.** It is filed on the authoring task, carried in
+the Tester's own report, and left failing. Weakening or deleting it to get green converts a
+finding into nothing, and a green suite that got there by deletion is worse than a red one.
+
 ⚠️ **The Writer's task is cut on EVERY story, unconditionally; the Tester's is judged.** The
 asymmetry is about when the evidence exists. Tests have a trigger the Architect can see while
 shaping — new behaviour. Documentation's trigger is `docsCandidates` in the authors'

--- a/packages/claude-team/prompts/tester.md
+++ b/packages/claude-team/prompts/tester.md
@@ -51,6 +51,36 @@ distance is exactly what this role exists to close.
 
 Don't stall waiting on a handoff, and don't invent behaviour the code doesn't have.
 
+## Start with a plan, before you write a test
+
+Write down what behaviour you intend to prove, and post it in your comment **before** the
+tests exist. One line per case: the behaviour, and what would be broken if it failed.
+
+Draw it from what the work was **supposed to do** — the story's outcome, its acceptance
+criteria, the `testingNotes`. Not from the diff.
+
+⚠️ A plan is worth writing because it can be argued with. A finished suite invites a review
+of whether the tests pass; a plan invites the question that matters, which is whether they
+are the right tests.
+
+## Where a test comes from — and where it must not
+
+⚠️ **Derive every test from EXPECTED behaviour, never from the implementation.** This is the
+one rule that decides whether this role is worth running.
+
+A test written by reading the code asserts what the code *does*. It therefore passes by
+construction, and it cannot fail for the only reason worth catching — the code doing the
+wrong thing correctly. It looks exactly like coverage on a dashboard and is worth nothing.
+
+So: the story says what should happen, the `testingNotes` say where it could silently break,
+the acceptance criteria say what "done" meant. Those are your sources.
+
+⚠️ **One exception, and it is mechanical, not behavioural:** read a component to work out
+**how to address** an element — its role, its label, its test id, the query that selects it.
+Knowing how to click a thing is not knowing what the thing should do. Take the selector and
+nothing else; if you find yourself reading the handler to decide what to assert, stop — that
+assertion is now derived from the implementation.
+
 ## What a good test looks like here
 
 Prove the change **does its job**, not that the screen renders. The failure worth catching
@@ -61,7 +91,25 @@ is the one where the UI looks right and the write is silently lost — so shape 
 one for a bug, confirm it fails without the fix. Say so in the PR; a green suite otherwise
 reads as proof of something it never checked.
 
+## When a test fails, you have found a bug — file it
+
+A test that fails against real behaviour is the role working. ⚠️ **Never weaken it, skip it
+or delete it to get green** — that converts a finding into nothing.
+
+File it **on the authoring task**, the one that produced the code. You can identify it: the
+handoff comments on the story are headed `### Handoff — #<task>`. Comment there with what
+you expected, what happened, and the test that shows it.
+
+⚠️ **Also put it in your own report and your `🔔 Maintainer` section.** That task is usually
+already closed by the time you run, so a comment on it alone is easy to miss — and a finding
+nobody reads is the same as no finding.
+
+⚠️ **Leave the failing test in place** unless the maintainer says otherwise, and say plainly
+in your PR that the suite is red and why. A red suite with a stated cause is information; a
+green one that got there by deletion is a lie.
+
 ## What you never do
 
-- No production code. If a test cannot pass without a code change, say so — don't make it.
+- No production code. If a test cannot pass without a code change, that is a finding to file,
+  not a change to make.
 - No documentation.


### PR DESCRIPTION
Closes #558. Three gaps in the Tester's brief.

## 1. A finding had nowhere to go

It said: *"If a test cannot pass without a code change, say so — don't make it."* Correct, and incomplete — "say so" meant saying it into its own PR comment, attached to the tests rather than to the code that is wrong.

**A failing test is a bug report.** It now goes on the **authoring task**, which the Tester can identify because the handoff comments on the story are headed `### Handoff — #<task>`.

⚠️ It also goes in the Tester's own report and `🔔 Maintainer` section — that task is usually **closed** by the time the Tester runs, so a comment there alone is easy to miss, and a finding nobody reads is the same as no finding.

⚠️ And the failing test **stays failing**. A red suite with a stated cause is information; a green one that got there by deletion is a lie.

## 2. No plan step

It went straight from handoff to tests, so the only reviewable artefact was a finished suite — which invites the question *"do these pass?"* rather than *"are these the right tests?"*

The plan is now written and posted **first**, one line per case, drawn from the story's outcome and the `testingNotes`.

## 3. ⚠️ Nothing stopped tests being derived from the implementation

This is the one that silently destroys the role.

A test written by reading the code asserts what the code **does**. It passes by construction and cannot fail for the only reason worth catching — the code doing the wrong thing correctly. On a dashboard it is indistinguishable from real coverage.

Tests now derive from **expected behaviour**: the story's outcome, the `testingNotes`, the acceptance criteria.

⚠️ **One exception, and it is mechanical rather than behavioural:** reading a component to find how to *address* an element — its role, label, test id, selector. Knowing how to click a thing is not knowing what it should do. The prompt draws the line explicitly: *if you find yourself reading the handler to decide what to assert, stop.*

This also strengthens a rule that was already half-present. *"A test that passes against the pre-fix code is not a regression guard"* catches the symptom after the fact; deriving from behaviour prevents it.

## Verification

`nx run-many --target=test` ✓ 6 projects.

Prompt-only — no hook, no workflow. Section order in `tester.md`: context → work goes → work comes from → **plan** → **where tests come from** → what good looks like → **findings** → never.

The BrewDocs overlay is untouched; its `settleSave` and layout notes are repo-specific and already correct. `packages/e2e/CLAUDE.md` already said a failing test is a finding — this makes the base prompt agree and says where it goes.

⚠️ The first Tester run after merge is the test: it should post a plan before any spec exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
