### PR TITLE
Move branch management into the scripted layer

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -78,6 +78,7 @@ run-name: >-
 #   delegate job          delegate.py              picks the role from issue state
 #   pre   every role      stamp-role-label.py      stamps @claude/<role> on the issue or PR
 #   pre   authors job     set-issue-status.py      sets the issue's board Status (STATUS input)
+#   post  architect       ensure-story-branch.py   creates the story's branch if it is missing
 #   post  architect       sync-epic-label.py       labels an issue whose title announces an epic
 #   post  architect       file-sub-issues.py       parents stories to epics, tasks to stories
 #   post  authors job     finish-pr.py             labels the PR, appends `Closes #<issue>`
@@ -172,6 +173,9 @@ jobs:
     outputs:
       roles: ${{ steps.route.outputs.roles }}
       story: ${{ steps.route.outputs.story }}
+      # the branch NAME, not the number — passed to the host action as `base_branch` so an
+      # author's task branch is cut off the story's branch instead of the default one
+      story_branch: ${{ steps.route.outputs.story_branch }}
       kind: ${{ steps.route.outputs.kind }}
       defaulted: ${{ steps.route.outputs.defaulted }}
       reason: ${{ steps.route.outputs.reason }}
@@ -295,6 +299,22 @@ jobs:
             --allowedTools "Read,Edit,Write,Bash(gh:*),Bash(git:*)"
             --max-turns 100
 
+      # ⚠️ FIRST of the post-hooks, and the reason branch creation is no longer the model's.
+      # The action mints its branch LOCALLY and never pushes one with no commits — and an
+      # Architect's branch must be empty — so a model obeying the action's "you are already on
+      # the correct branch" left nothing on the remote while reporting the branch as cut.
+      # ⚠️ POST, never pre: the action falls back to `claude/<entity>-<n>-<timestamp>` if the
+      # name it is about to generate already exists remotely, so pushing it up front would
+      # strand the whole run on a branch nobody looks at.
+      - name: Ensure the story's branch exists
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          # an epic has no branch, and a missing one there must not warn
+          KIND: ${{ needs.delegate.outputs.kind }}
+        run: "$RUNNER_TEMP/agent-bin/ensure-story-branch.py"
       - name: Update the story's task order
         if: always()
         env:
@@ -365,6 +385,19 @@ jobs:
   #
   # ⚠️ THE POST-HOOKS RUN ONCE, AT THE END. Three copies would relabel and re-check the
   # same PR three times.
+  #
+  # ⚠️ `base_branch` IS WHY THE AUTHORS NO LONGER FIGHT THE ACTION OVER BRANCHES. A task's
+  # branch must be cut off its STORY's branch; left unset the action cuts from the default
+  # branch and then injects "You are already on the correct branch. Do not create a new
+  # branch", contradicting the prompt telling the model to re-cut it — a coin flip we lost
+  # about half the time (#530, #570). Setting it makes the action's own branch the correct
+  # one, so the two instructions agree instead of competing.
+  #
+  # It arrives from `delegate.py`, which already parses the story's Branch line to derive the
+  # story number and now emits the string beside it. Empty is falsy in `setupBranch`
+  # (`if (baseBranch) { sourceBranch = baseBranch }`), so an unresolvable story degrades to
+  # the old behaviour rather than breaking. On a PR trigger the action checks out the PR's own
+  # branch and never reads this at all.
   authors:
     needs: delegate
     if: |
@@ -542,6 +575,9 @@ jobs:
           # shape. For a task that fully resolves it, since an author cuts any `<task#>-…`
           # branch it likes. It cannot match a story branch the Architect already named, so
           # finish-pr.py also reports commits stranded on an unexpected branch.
+          # a task branch is cut off its STORY branch, not the default one — see the job
+          # header. Empty when no story resolves, which falls back to the default branch.
+          base_branch: ${{ needs.delegate.outputs.story_branch }}
           branch_prefix: ""
           branch_name_template: "{{entityNumber}}-{{description}}"
           track_progress: true
@@ -611,6 +647,9 @@ jobs:
           # shape. For a task that fully resolves it, since an author cuts any `<task#>-…`
           # branch it likes. It cannot match a story branch the Architect already named, so
           # finish-pr.py also reports commits stranded on an unexpected branch.
+          # a task branch is cut off its STORY branch, not the default one — see the job
+          # header. Empty when no story resolves, which falls back to the default branch.
+          base_branch: ${{ needs.delegate.outputs.story_branch }}
           branch_prefix: ""
           branch_name_template: "{{entityNumber}}-{{description}}"
           track_progress: true
@@ -667,6 +706,9 @@ jobs:
           # shape. For a task that fully resolves it, since an author cuts any `<task#>-…`
           # branch it likes. It cannot match a story branch the Architect already named, so
           # finish-pr.py also reports commits stranded on an unexpected branch.
+          # a task branch is cut off its STORY branch, not the default one — see the job
+          # header. Empty when no story resolves, which falls back to the default branch.
+          base_branch: ${{ needs.delegate.outputs.story_branch }}
           branch_prefix: ""
           branch_name_template: "{{entityNumber}}-{{description}}"
           track_progress: true
@@ -727,6 +769,9 @@ jobs:
           # shape. For a task that fully resolves it, since an author cuts any `<task#>-…`
           # branch it likes. It cannot match a story branch the Architect already named, so
           # finish-pr.py also reports commits stranded on an unexpected branch.
+          # a task branch is cut off its STORY branch, not the default one — see the job
+          # header. Empty when no story resolves, which falls back to the default branch.
+          base_branch: ${{ needs.delegate.outputs.story_branch }}
           branch_prefix: ""
           branch_name_template: "{{entityNumber}}-{{description}}"
           track_progress: true

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -38,6 +38,32 @@ state, not from something a model was asked to leave behind.
 its tasks. It is what an author bases on and merges back into, never a branch for the task
 itself. Anything deriving a story from a branch name reads that prefix.
 
+⚠️ **Branch creation is scripted, not prompted** — the last load-bearing thing a model owned,
+and it failed about half the time. The host action mints its own branch for an issue trigger
+and injects *"You are already on the correct branch. Do not create a new branch"*, which
+contradicts any prompt telling a model to cut one. Which instruction wins is the model's call,
+and it went both ways. Three pieces replace it:
+
+- **The story branch** — a **post**-hook reads the `Branch:` line the Architect had to write
+  anyway and creates that ref at the default branch's head. The Architect names it and
+  nothing else.
+- **A task's branch** — the action's own `base_branch` input, set to the story's branch. The
+  branch it creates is then the right one, so its injected instruction becomes true instead of
+  something to argue with. Configure the action rather than fight it.
+- **A task PR's base** — `finish-pr.py` retargets it onto the story branch. The model still
+  writes `--base` for the human-readable reason; the hook is the net.
+
+⚠️ **The story-branch hook must run POST, and this inverts the obvious implementation.**
+`setupBranch` checks whether the name it is about to generate already exists remotely and, if
+so, discards the configured template and falls back to `claude/<entity>-<n>-<timestamp>`. A
+pre-hook pushing the story branch would collide with the very name the action mints from
+`{{entityNumber}}-{{description}}`, stranding the run on a branch nobody looks at. Orphaned
+`claude/*` branches in a consuming repo are this fallback firing on a re-run.
+
+⚠️ **The hook never touches a branch that exists.** Absent is the only case it handles: an
+existing branch may carry an author's commits, and resetting it to the default branch would
+destroy exactly the work the hook exists to protect.
+
 ⚠️ **Tasks must not share one branch.** They did once, and it was a race: if a consumer keys
 its concurrency group on issue number, two tasks are in *different* groups and can commit to
 the same branch at the same time. Sub-branching removes the possibility rather than relying
@@ -45,10 +71,10 @@ on runs being triggered one at a time.
 
 ## How a story moves
 
-1. **Architect** shapes the story, cuts its branch off the default branch, and creates its
-   tasks — each stamped with the role that should pick it up.
-2. Each **task** is triggered on its own. Its author cuts a branch off the story branch,
-   works there, and opens a PR into the story branch.
+1. **Architect** shapes the story, **names** its branch on a `Branch:` line, and creates its
+   tasks — each stamped with the role that should pick it up. A hook creates the branch.
+2. Each **task** is triggered on its own. Its author starts on a branch already cut off the
+   story branch, works there, and opens a PR into the story branch.
 3. Merging that task PR closes the task and lands its work on the story.
 4. The **story's** PR accumulates all of it. The maintainer reviews and merges the story as
    a whole.
@@ -216,6 +242,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 | `delegate.py` | the router job | picks the role from issue state — routing is scripted, not judged |
 | `stamp-role-label.py` | pre, every role | stamps `@claude/<role>` on the triggering issue or PR |
 | `set-issue-status.py` | pre, authors | sets the issue's board Status; the column is an input |
+| `ensure-story-branch.py` | post, Architect | creates the story's branch if it is missing |
 | `sync-epic-label.py` | post, Architect | applies the `epic` label to an issue titled as one |
 | `file-sub-issues.py` | post, Architect | parents stories to their epic, tasks to their story |
 | `finish-pr.py` | post, authors | labels the PR and ensures it closes its issue |

--- a/packages/claude-team/hooks/delegate.py
+++ b/packages/claude-team/hooks/delegate.py
@@ -32,7 +32,7 @@ IS_PR = os.environ.get("IS_PR", "false") == "true"
 if not team.REPO:
     team.fail("REPO is required")
 
-ROLES = STORY = REASON = KIND = ""
+ROLES = STORY = STORY_BRANCH = REASON = KIND = ""
 DEFAULTED = False
 
 
@@ -41,12 +41,12 @@ def emit() -> None:
     if out:
         with open(out, "a", encoding="utf-8") as handle:
             handle.write(
-                f"roles={ROLES}\nstory={STORY}\nkind={KIND}\n"
+                f"roles={ROLES}\nstory={STORY}\nstory_branch={STORY_BRANCH}\nkind={KIND}\n"
                 f"defaulted={str(DEFAULTED).lower()}\nreason={REASON}\n"
             )
     print(
-        f"roles={ROLES} story={STORY or 'none'} kind={KIND or 'n/a'} "
-        f"defaulted={str(DEFAULTED).lower()} — {REASON}"
+        f"roles={ROLES} story={STORY or 'none'} branch={STORY_BRANCH or 'none'} "
+        f"kind={KIND or 'n/a'} defaulted={str(DEFAULTED).lower()} — {REASON}"
     )
 
 
@@ -118,7 +118,8 @@ for role in ("architect", "implementor", "tester", "writer", "designer", "securi
                 # No fallback to the issue's own number: an issue with no Branch line is
                 # not part of a story, and claiming it is its own would be worse than
                 # empty, which every prompt already handles.
-                STORY = team.story_from_branch(team.branch_line(team.issue_body(NUMBER)))
+                STORY_BRANCH = team.branch_line(team.issue_body(NUMBER))
+                STORY = team.story_from_branch(STORY_BRANCH)
                 if STORY:
                     REASON += f"; #{NUMBER} belongs to story #{STORY}"
         emit()
@@ -172,6 +173,11 @@ if not branch:
 # a parent" assumes every story sits under an epic, and they do not — a parentless story
 # resolves each of its tasks to itself. Tried, measured, reverted.
 STORY = team.story_from_branch(branch) or (parent or NUMBER)
+
+# The branch STRING, not just the number it starts with. The authoring jobs pass it to the host
+# action as `base_branch`, which is what makes the action cut a task's branch off its story's
+# branch instead of the default one. Emitting it here costs nothing — the line is already read.
+STORY_BRANCH = branch
 
 stamped = team.role_stamp(body)
 if stamped in ("implementor", "tester", "writer", "designer"):

--- a/packages/claude-team/hooks/ensure-story-branch.py
+++ b/packages/claude-team/hooks/ensure-story-branch.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Post-hook for the Architect. Guarantees the story's branch exists on the remote.
+
+WHY A HOOK AT ALL. Cutting the branch was the Architect's job and it silently failed about half
+the time, because the host action and our prompt give contradictory instructions and the model
+picks one:
+
+    Creating local branch 537-bug-deriveschedule-should-be-a ... from source branch: mainline
+      - You are already on the correct branch (537-...). Do not create a new branch.
+
+The action creates that branch LOCALLY and never pushes a branch with no commits — and an
+Architect's branch is required to be empty. So a model that obeys the action leaves nothing on
+the remote while reporting the branch as cut. The next author then finds no branch and targets
+the default branch instead, which takes the story out of the story model entirely.
+
+⚠️ POST, NEVER PRE — and this inverts the obvious implementation. `setupBranch` checks whether
+the name it is about to generate already exists remotely and, if it does, throws away our
+template and falls back to `claude/<entity>-<n>-<timestamp>`:
+
+    Branch '${newBranch}' already exists, falling back to default format
+
+Our template mints exactly the name the Architect records, so pushing it up front would collide
+with the action's own generation and strand the whole run on a `claude/...` branch nobody
+looks at. Running after the model means the action has already generated its name.
+
+⚠️ NEVER TOUCHES AN EXISTING BRANCH. Absent is the only case this handles. A branch that
+exists may carry an author's commits, and resetting it to the default branch would discard
+them — the failure this hook exists to prevent, inflicted by the fix for it.
+"""
+
+import os
+
+import team
+
+ISSUE = os.environ.get("ISSUE", "")
+KIND = os.environ.get("KIND", "")
+
+if not team.REPO:
+    team.fail("REPO is required")
+
+if not ISSUE:
+    print("Not triggered on an issue — no story branch to ensure.")
+    raise SystemExit(0)
+
+# An epic has no branch by design, so a missing one is correct and must not warn.
+if KIND == "epic":
+    print(f"#{ISSUE} is an epic — epics have no branch.")
+    raise SystemExit(0)
+
+named = team.branch_line(team.issue_body(ISSUE))
+if not named:
+    team.warn(
+        f"#{ISSUE} carries no Branch line, so there is no story branch to create. Every role "
+        "that follows reads that line to know where to commit; without it the story cannot be "
+        "worked. Re-run the Architect on it."
+    )
+    raise SystemExit(0)
+
+if team.gh("api", f"repos/{team.REPO}/branches/{named}") is not None:
+    print(f"branch {named} already exists — leaving it alone")
+    raise SystemExit(0)
+
+default = (
+    team.gh_json("repo", "view", team.REPO, "--json", "defaultBranchRef") or {}
+).get("defaultBranchRef", {}).get("name")
+if not default:
+    team.warn(f"could not read the default branch, so {named} was not created")
+    raise SystemExit(0)
+
+head = team.gh_json("api", f"repos/{team.REPO}/git/ref/heads/{default}") or {}
+sha = (head.get("object") or {}).get("sha")
+if not sha:
+    team.warn(f"could not read {default}'s head, so {named} was not created")
+    raise SystemExit(0)
+
+# The API, not a push: the model has switched branches by now and the working tree is not a
+# reliable place to cut from. A ref created at the default branch's head is empty by
+# construction, which is what the story model wants — the first author's work is its first commit.
+if team.gh(
+    "api", "--method", "POST", f"repos/{team.REPO}/git/refs",
+    "-f", f"ref=refs/heads/{named}", "-f", f"sha={sha}",
+) is None:
+    team.warn(f"could not create branch {named} at {default}@{sha[:7]}")
+    raise SystemExit(0)
+
+print(f"created branch {named} at {default}@{sha[:7]} — empty, ready for its first task")

--- a/packages/claude-team/hooks/finish-pr.py
+++ b/packages/claude-team/hooks/finish-pr.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""Post-hook for every role that opens a PR. Does the two things a prompt kept being asked
+"""Post-hook for every role that opens a PR. Does the three things a prompt kept being asked
 to remember:
 
-  1. labels the PR with the role(s) that worked it
-  2. makes sure the body carries `Closes #<issue>`
+  1. points the PR at its story's branch
+  2. labels the PR with the role(s) that worked it
+  3. makes sure the body carries `Closes #<issue>`
 
-(2) is the one that silently loses work: close-merged-work finds what a PR finished by
-parsing that keyword, so a missing line means the issue never closes and never reaches Done,
-with nothing to signal it.
+(1) and (3) each silently lose work. A PR that targets the default branch takes its task out
+of the story model — it ships to prod on merge and the story never gets a PR. A missing
+closing keyword means close-merged-work finds nothing to close, so the issue never reaches
+Done, with nothing to signal it either way.
 
 ROLES is a space-separated list because the authoring roles are gated steps in ONE job and
 this runs once at the end of it. A single role is a list of one; the PR should carry the
@@ -121,6 +123,31 @@ if not pr:
         raise SystemExit(0)
     pr = str(found[0]["number"])
     print(f"opened PR #{pr} from {branch} into {base} — it had {stranded} and none of its own")
+
+# ⚠️ A TASK PR MUST TARGET ITS STORY'S BRANCH, and `gh pr create --base` is a model
+# instruction like any other. #564 targeted the default branch — correctly, that time, because
+# the story branch was missing — but the same slip with the branch present takes the task out
+# of the story model: it ships straight to the deploy branch and the story never gets a PR at
+# all, since open-story-pr only fires when a merged PR's base is a story branch.
+#
+# ⚠️ Retarget only when the named branch really exists and is not this PR's own head. A story
+# triggered directly resolves its Branch line to the branch the PR is already FROM, and
+# GitHub rejects a PR whose base is its head.
+if ISSUE:
+    named = team.branch_line(team.issue_body(ISSUE))
+    current = (
+        team.gh_json("pr", "view", pr, "--repo", team.REPO, "--json", "baseRefName") or {}
+    ).get("baseRefName") or ""
+    if (
+        named
+        and named != current
+        and named != branch
+        and team.gh("api", f"repos/{team.REPO}/branches/{named}") is not None
+    ):
+        if team.gh("pr", "edit", pr, "--repo", team.REPO, "--base", named) is not None:
+            print(f"PR #{pr} retargeted {current} -> {named}")
+        else:
+            team.warn(f"PR #{pr} targets {current}, not the story branch {named}, and I could not move it")
 
 for role in ROLES.split():
     if team.gh("pr", "edit", pr, "--repo", team.REPO, "--add-label", f"@claude/{role}") is not None:

--- a/packages/claude-team/prompts/_shared.md
+++ b/packages/claude-team/prompts/_shared.md
@@ -87,25 +87,26 @@ given, and say in your report that you had no story context.
 
 ## Your branch
 
-Your task's issue names its **story's** branch on a **Branch** line — that is what you base
-on and merge back into, not where you commit.
+**You are already on it.** You start on a branch cut for your task off its **story's** branch,
+and you should commit there. Your task's issue names the story's branch on a **Branch** line;
+that is what you merge back into, not where you commit.
 
-```
-git fetch origin <story-branch>
-git checkout -b <task#>-<kebab-summary> origin/<story-branch>
-```
+⚠️ **Do not cut another branch.** This was once yours to do and is now set up before you
+start, so re-cutting it either does nothing or moves your work somewhere nothing looks. If
+what you are on looks wrong, say so in your report rather than fixing it by hand.
 
-⚠️ **Cut it off the story branch, never off the default branch.** Your task usually depends
-on work already merged into the story, and basing on the default branch silently drops it.
-
-⚠️ **If the story branch does not exist, stop and say so in a comment.** Do not invent one —
-the Architect creating it is what keeps one story to one branch.
+⚠️ **Never commit to the story branch itself, and never to the default branch.** Your work
+reaches the story through your PR.
 
 ⚠️ **Open your PR against the story branch**, not the default branch:
 
 ```
-gh pr create --base <story-branch> --head <task#>-<kebab-summary> --title "…" --body "…"
+gh pr create --base <story-branch> --head <your-branch> --title "…" --body "…"
 ```
+
+⚠️ **If the story branch does not exist, say so plainly in your report.** Do not invent one.
+Target the default branch so the work is at least reviewable, and state in the PR that it
+needs retargeting — a scripted hook will move it once the branch is there.
 
 ⚠️ **Write `Closes #<your task>` in that PR's body.** GitHub will not act on it — closing
 keywords only fire when a PR targets the *default* branch — so a scripted hook parses the

--- a/packages/claude-team/prompts/architect.md
+++ b/packages/claude-team/prompts/architect.md
@@ -40,24 +40,20 @@ work:
    you write anything down.
 2. **Rewrite the issue description** into a real story: the outcome, the constraints, what
    is out of scope, and verified paths.
-3. **Cut the branch** off the default branch, empty, and record it — but **check first
-   whether it already exists**:
-   ```
-   git fetch origin
-   git ls-remote --exit-code --heads origin <branch>   # does it exist?
-   git checkout -B <issue#>-<kebab-summary> origin/<default-branch>
-   git push -u origin <issue#>-<kebab-summary>
-   ```
-   Then write it into the issue body on its own line:
+3. **Name the story's branch and record it.** Write it into the issue body on its own line:
    ```
    **Branch: `<issue#>-<kebab-summary>`**
    ```
-   ⚠️ **If the branch exists and has commits of its own, leave it alone.** `checkout -B`
-   from the default branch would reset it, and pushing that would discard an author's work.
-   Say in your comment that it already exists and move on.
-   ⚠️ If it exists with **no** commits of its own, fast-forwarding it to the current default
-   branch is fine and usually helpful — the story then starts from current code. Say that
-   you did it.
+   ⚠️ **Do not create it, and do not push it.** A scripted hook creates it from this line
+   after you finish, at the default branch's head, empty. That is deliberate: you are running
+   on a branch the host action already made for you and told you to stay on, and it never
+   pushes a branch with no commits — so a story branch left to you reached the remote about
+   half the time, and the next author found nothing to base on.
+   ⚠️ **The line is the whole deliverable here**, and the only part of branch handling still
+   yours. Without it nothing downstream can work: the hook has no name to create, routing
+   cannot resolve the story, and every role that follows has nowhere to commit.
+   ⚠️ An existing branch is left untouched by the hook, commits or not — so if a story is
+   re-shaped, its branch keeps whatever an author already put there.
 4. **Cut the story into tasks** if it needs dividing. A story one author can finish should
    not be split — extra issues cost more than they save.
    ⚠️ **Read the existing sub-issues before creating any.** A story you are re-triggered on
@@ -65,7 +61,7 @@ work:
    accurately, do they carry both required lines — and correct or add rather than duplicate.
    Filing a second set of tasks over the top of a good one is worse than doing nothing.
 
-⚠️ Cut the branch **empty**. Do not commit to it; the first author's work is its first commit.
+⚠️ The branch is **empty**. Do not commit to it; the first author's work is its first commit.
 
 ## Testing and documentation are work you cut, not work that follows
 


### PR DESCRIPTION
## Summary

Branch creation was the last load-bearing thing still owned by a model, and it failed about
half the time. This moves it into the scripted layer.

Closes #570.

**The cause**, from the Architect's own run log on #537:

```
Creating local branch 537-bug-deriveschedule-should-be-a for issue #537 from source branch: mainline...
  - You are already on the correct branch (537-...). Do not create a new branch.
```

The host action mints that branch **locally** and never pushes one with no commits — while an
Architect's branch is required to be empty. A model that obeys the action therefore leaves
nothing on the remote and reports the branch as cut. #564 then found no branch and targeted
`mainline`.

## Three pieces, one new hook

**1. `ensure-story-branch.py`** — creates the branch from the `Branch:` line the Architect had
to write anyway, at the default branch's head, empty.

⚠️ **POST, not pre — and this inverts the obvious implementation.** `setupBranch` checks
whether the name it is about to generate already exists remotely and, if so, discards our
template for `claude/<entity>-<n>-<timestamp>`. Our template mints *exactly* the name the
Architect records, so a pre-hook would collide with it and strand the run on a branch nobody
looks at. That is what the orphan `claude/issue-514-…` and `claude/issue-444-…` branches in
this repo are — the fallback firing on a re-run, #514 included.

It never touches an existing branch. Absent is the only case: an existing one may carry an
author's commits, and resetting it would destroy the work the hook exists to protect.

**2. Task branches — no hook.** The action's `base_branch` input already does it
(`if (baseBranch) { sourceBranch = baseBranch }`). `delegate.py` already parsed the story's
Branch line to get the number, so it now emits the string beside it and the four authoring
steps pass it through. The action's branch becomes the *correct* branch, so its injected
"stay on this branch" stops competing with our prompt and starts agreeing with it. Empty is
falsy there, so an unresolvable story degrades to today's behaviour.

**3. `finish-pr.py` retargets** a task PR whose base is not the story branch — the same
net-shape as the `Closes #` enforcement beside it. Guarded against retargeting a PR onto its
own head, which is what a story triggered directly would otherwise do.

## Prompts

The Architect names the branch and nothing else — the line is now its whole deliverable there.
The authors' _Your branch_ section says they are **already on** their branch and must not cut
another, and tells them to say so plainly rather than improvise if the story branch is missing.

## Verification

- `nx run-many --target=test` ✓ 6 projects · `py_compile` on all three hooks ✓
- Parsed the workflow and asserted the wiring, rather than eyeballing it:

```
delegate outputs: roles, story, story_branch, kind, defaulted, reason
hook step: architect -> Ensure the story's branch exists
architect/model:      base_branch=null      ← must not inherit; it cuts off the default branch
authors/Implementor:  base_branch="${{ needs.delegate.outputs.story_branch }}"
authors/Designer:     base_branch="${{ … }}"
authors/Tester:       base_branch="${{ … }}"
authors/Writer:       base_branch="${{ … }}"
security/model:       base_branch=null
```

- **`delegate.py` run against live issues**, all four routing paths emitting the new output:

| trigger | roles | story | story_branch |
|---|---|---|---|
| task #538 (stamped) | implementor | 537 | `537-bug-deriveschedule-should-be-a` |
| story #537 (no stamp) | implementor *(defaulted)* | 537 | `537-bug-deriveschedule-should-be-a` |
| `@claude/writer` on #539 | writer | 537 | `537-bug-deriveschedule-should-be-a` |
| unshaped #570 | architect | — | — |

- **`ensure-story-branch.py` run against live issues** for every read path: epic #480 → silent;
  no issue → exits; #570 (no Branch line) → warns; #519 → `branch 519-abv-calculation already
  exists — leaving it alone`.
- The create path is the one thing that cannot be inferred, and a silently-wrong `gh api` call
  has cost this repo before — so I proved it with a scratch ref and removed it:

```
refs/heads/zz-hook-probe-570 -> 728eeb8
ahead_by=0 behind_by=0          ← empty, which is what the story model wants
scratch ref deleted             ← confirmed gone, 0 matches
```

⚠️ Not reachable by CI: `issues` and `issue_comment` always run the workflow from the default
branch. The first Architect run after merge is the real check — it should leave a pushed, empty
story branch without the model pushing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
