### PR TITLE
Estimated IBU: distinguish "cannot compute" from 0, show it on Summary

### DIFF
--- a/packages/app/src/hooks/useEstimatedIbu.ts
+++ b/packages/app/src/hooks/useEstimatedIbu.ts
@@ -36,8 +36,10 @@ function convert(scalar: Scalar, factors: Partial<Record<Unit, number>>): number
     return factor ? amount * factor : NaN;
 }
 
-function tinsethIbu(assignments: Assignment[], batchSize: Scalar, og: Scalar): number {
-    if (!assignments?.length) {
+function tinsethIbu(assignments: Assignment[], batchSize: Scalar, og: Scalar): number | null {
+    const hops = resourcesOf(assignments ?? [], "hop");
+
+    if (!hops.length) {
         return 0;
     }
 
@@ -45,12 +47,12 @@ function tinsethIbu(assignments: Assignment[], batchSize: Scalar, og: Scalar): n
     const gravity = amountOf(og);
 
     if (!(batchVolumeLiters > 0) || !(gravity > 0)) {
-        return 0;
+        return null;
     }
 
     const bignessFactor = TINSETH_MAX_UTILIZATION * Math.pow(TINSETH_GRAVITY_BASE, gravity - 1);
 
-    const total = resourcesOf(assignments, "hop").reduce((sum, hop) => {
+    const total = hops.reduce((sum, hop) => {
         const weightGrams = convert(hop.weight, GRAMS_PER_UNIT);
         const alphaDecimal = amountOf(hop.alpha) / 100;
         const boilMinutes = amountOf(hop.boil);
@@ -65,9 +67,9 @@ function tinsethIbu(assignments: Assignment[], batchSize: Scalar, og: Scalar): n
         return sum + bignessFactor * boilTimeFactor * mgPerLiter;
     }, 0);
 
-    return Number.isFinite(total) ? Math.round(total) : 0;
+    return Number.isFinite(total) ? Math.round(total) : null;
 }
 
-export default function useEstimatedIbu(assignments: Assignment[], batchSize: Scalar, og: Scalar): number {
+export default function useEstimatedIbu(assignments: Assignment[], batchSize: Scalar, og: Scalar): number | null {
     return useMemo(() => tinsethIbu(assignments, batchSize, og), [assignments, batchSize, og]);
 }

--- a/packages/app/src/screen/batch-summary/index.tsx
+++ b/packages/app/src/screen/batch-summary/index.tsx
@@ -4,14 +4,24 @@ import {organicNames} from "@/component/organics/from-brewable";
 import Screen from "@/component/screen";
 import Vitals from "@/component/vitals";
 import useActuals from "@/hooks/useActuals";
+import useEstimatedIbu from "@/hooks/useEstimatedIbu";
 import {useBatch} from "@/state/batches";
 import {useRecipeResource} from "@/state/disambiguation";
+import {parseNumberString} from "@/utils/math";
 
 export type BatchSummaryProps = { batchId: string; };
 export default function BatchSummary({ batchId }: BatchSummaryProps) {
     const batch = useBatch(batchId);
     const recipe = useRecipeResource(batch.recipeSource ?? "kb", batch.recipeId);
     const actuals = useActuals(batch);
+
+    const measuredOg = parseNumberString(actuals.og?.value ?? "")[0];
+    const estimatedIbu = useEstimatedIbu(
+        batch.brewable.assignments,
+        batch.batchSize,
+        measuredOg > 0 ? actuals.og : recipe.targets.og
+    );
+    const brewed = {...actuals, ibu: estimatedIbu === null ? "—" : String(estimatedIbu)};
 
     return (
         <Screen>
@@ -25,7 +35,7 @@ export default function BatchSummary({ batchId }: BatchSummaryProps) {
                 </div>
                 <div className="divider">Measurements</div>
                 {/* Need to refactor this type */}
-                <Vitals className="-mt-2" vitals={[["Target", recipe.targets], ["Actuals", actuals]]} />
+                <Vitals className="-mt-2" vitals={[["Target", recipe.targets], ["Actuals", brewed]]} />
                 <div className="divider">Organics</div>
                 <Organics className="-mt-2" {...organicNames(batch.brewable.assignments)} />
             </div>

--- a/packages/app/src/screen/recipe-edit/details/index.tsx
+++ b/packages/app/src/screen/recipe-edit/details/index.tsx
@@ -158,7 +158,7 @@ export default function RecipeEditDetails({ recipeId }: RecipeEditDetailsProps) 
             <DataGridRow zebra>
                 <DataGridLabel cols={3}>Estimated IBU</DataGridLabel>
                 <div className="col-start-4 col-span-3 flex items-center justify-end self-center pr-1 text-sm leading-6 lg:leading-8">
-                    {estimatedIbu}
+                    {estimatedIbu ?? "—"}
                 </div>
             </DataGridRow>
             <DataGridRow zebra>

--- a/packages/e2e/tests/batch-summary.spec.ts
+++ b/packages/e2e/tests/batch-summary.spec.ts
@@ -52,9 +52,14 @@ test("shows the recipe's target vitals, a fresh batch's zeroed actuals, and the 
 
     // defaultBatch's actuals, unset on a freshly-brewed batch
     await expect(vitalsRow(page, "Actuals", "ABV")).toContainText("0.0%");
-    await expect(vitalsRow(page, "Actuals", "IBU")).toContainText("0");
     await expect(vitalsRow(page, "Actuals", "O.G.")).toContainText("0.00°P");
     await expect(vitalsRow(page, "Actuals", "F.G.")).toContainText("0.00°P");
+
+    // IBU is the exception among the actuals: it is never measured, so it is
+    // derived from the batch's own hop bill rather than left at defaultBatch's
+    // "0". No gravity has been recorded yet, so it falls back to the recipe's
+    // target OG — Tinseth over anchor-steam's three Northern Brewer additions.
+    await expect(vitalsRow(page, "Actuals", "IBU")).toContainText("37");
 
     await expect(page.getByText("German Pils")).toBeVisible();
     await expect(page.getByText("Northern Brewer")).toBeVisible();

--- a/packages/e2e/tests/recipe-edit.spec.ts
+++ b/packages/e2e/tests/recipe-edit.spec.ts
@@ -172,10 +172,29 @@ test("adds an ingredient, equipment, and a phase from the recipe side, and all p
     await expect(page.getByText("4. Conditioning")).toBeVisible();
 });
 
+// A recipe with no hops has 0 IBU whatever its gravity, so this asserts the real
+// zero. It only means that because the no-hop case is decided BEFORE the gravity
+// guard — a fresh recipe also has og "0.00°P", so if the order were reversed this
+// would pass for the other reason and could not tell the two apart.
 test("Estimated IBU shows 0 for a freshly-created recipe with no hop assignments", async ({page}) => {
     await createRecipeFromTemplate(page, "E2E Estimated IBU Empty", "Empty");
 
     await expect(estimatedIbuRow(page)).toContainText("0");
+});
+
+// The complement, and the case a brewer actually hits: hops are present, so the
+// answer is not zero — but without a gravity it cannot be computed at all, and
+// saying "0" would read as "your hops contribute nothing".
+test("Estimated IBU shows an em dash when a hopped recipe has no gravity to compute from", async ({page}) => {
+    await editRecipeFromKbTemplate(page, "/kb/recipe/anchor-steam-beer-clone");
+
+    await expect(estimatedIbuRow(page)).not.toContainText("—");
+
+    const og = page.getByLabel("OG", {exact: true});
+    await og.fill("");
+    await og.blur();
+
+    await expect(estimatedIbuRow(page)).toContainText("—");
 });
 
 test("Estimated IBU live-recomputes when a hop's weight changes on the Ingredients panel", async ({page}) => {


### PR DESCRIPTION
## Summary

The Tinseth calculation from #518 was already correct. What was wrong is **what a 0 meant** and
**where the number appeared** — which is why a brewer never saw an IBU.

Closes #574.

### Zero was overloaded, and it was the default state

`useEstimatedIbu` now returns `number | null`. The no-hop case is decided **before** the gravity
guard, so:

| input | before | after |
|---|---|---|
| anchor-steam kb fixture (target 35) | 37 | **37** |
| no hop assignments | 0 | **0** — a real zero |
| hops, blank og | 0 | **null → `—`** |
| hops, blank batchSize | 0 | **null → `—`** |
| hops, og typed as 0 | 0 | **null → `—`** |

#518 specified the old guard for *"a mid-edit blank value is a normal transient state"*. That
premise does not hold: `data/defaultRecipe.ts:26` seeds `targets.og` as `"0.00°P"`, so **`og = 0`
is the persistent default of every new recipe** — and "I cannot compute this" rendered
identically to "your hops contribute nothing", for every recipe a brewer creates.

### Batch Summary now shows an IBU

It derives from the batch's own hop bill, using the **measured** OG when a gravity reading
exists and the recipe's target otherwise — so it computes before brew day and sharpens after.

It lands in the **Actuals** cell, which previously held `defaultBatch`'s hardcoded `"0"` that
nothing ever wrote. ⚠️ Worth a maintainer opinion: an IBU is never really *measured*, so
"Actuals" is a slightly loose label — but it is the only IBU a batch can have, and reading
`Target 35 / Actuals 37` shows drift if hops changed in Planning. Say the word and I will move
it to its own column instead.

### The test asserted the bug

`recipe-edit.spec.ts:175` asserted a fresh recipe shows `0` — but that recipe has no hops **and**
no OG, so `0` was over-determined: it passed for two independent reasons and **would still have
passed with the hop path entirely dead**. Exactly the failure mode the Tester brief now forbids,
already in the suite.

The guard ordering makes it mean one thing, and a companion test covers the case a brewer
actually hits — hops present, no gravity → `—`.

## Verification

- `nx run-many --target=test` ✓ 6 projects · `tsc --noEmit` ✓ · `npm run build -w packages/app` ✓
- ⚠️ **Playwright cannot install chromium on macOS 13**, so the browser suite was not runnable
  locally. Instead I bundled the **real hook** with esbuild and ran it against the real kb
  fixture, before and after — that is the table above. Probe deleted; `git status` clean.
- ⚠️ **The two e2e tests are therefore unverified locally.** Functional test runs on PRs to
  `mainline`, so this PR's own CI is the instrument. If the new one fails it will be the
  emptied-OG interaction, not the assertion.

## Also

#525 *"Compute Estimated IBU from a recipe's hop schedule (Tinseth)"* closed as a duplicate of
#518, with the verified 37-vs-35 result recorded on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
