### PR TITLE
Create packages/spec — the product specification package

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -14,10 +14,12 @@ on:
       # the day it is added. The cost is that a new non-code package under packages/ runs the
       # gate for nothing until it is excluded here — harmless, and visible.
       #
-      # ⚠️ packages/claude-team is not an npm workspace: it holds prompts and shell hooks, and
-      # `npm test -ws` never sees it.
+      # ⚠️ Neither packages/claude-team nor packages/spec is an npm workspace — one holds
+      # prompts and Python hooks, the other product-specification markdown, and `npm test -ws`
+      # never sees either.
       - 'packages/**'
       - '!packages/claude-team/**'
+      - '!packages/spec/**'
       - 'package.json'
       - 'package-lock.json'
       - 'nx.json'

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -18,10 +18,12 @@ on:
       # the day it is added. The cost is that a new non-code package under packages/ runs the
       # gate for nothing until it is excluded here — harmless, and visible.
       #
-      # ⚠️ packages/claude-team is not an npm workspace: it holds prompts and shell hooks, and
-      # `npm test -ws` never sees it.
+      # ⚠️ Neither packages/claude-team nor packages/spec is an npm workspace — one holds
+      # prompts and Python hooks, the other product-specification markdown, and `npm test -ws`
+      # never sees either.
       - 'packages/**'
       - '!packages/claude-team/**'
+      - '!packages/spec/**'
       - 'package.json'
       - 'package-lock.json'
       - 'nx.json'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ This root file holds the **universal** rules. Each package's deep-dive lives in 
 | `app` | The PWA itself: Vite + React + TanStack Router/Query. Deployed to app.brewdocs.beer. |
 | `www` | Astro marketing/info site at brewdocs.beer. |
 | `e2e` | Playwright functional-test harness (config + specs) driving the app dev server. Not part of Verify — its own `functional-test.yaml` CI workflow. |
+| `spec` | The **product specification** — what the app should do, in a brewer's terms. Markdown, **not** an npm workspace; no CI workflow runs for it. The durable source of expected behaviour a story cannot be. |
 
 ## Legend
 
@@ -75,6 +76,7 @@ Each package's deep-dive (Purpose / Where / Surface / Invariants / Gotchas …) 
 - **app** → [`packages/app/CLAUDE.md`](packages/app/CLAUDE.md) — the largest; holds Routing, Breadcrumbs, State, the Kb\*/app _Model boundary_, Derived batch data, BatchSchedule, the `useJsonEdit` editing pattern, PanelSwitcher, _Styling_, kb dev/build serving, and _Linting_.
 - **www** → [`packages/www/CLAUDE.md`](packages/www/CLAUDE.md)
 - **e2e** → [`packages/e2e/CLAUDE.md`](packages/e2e/CLAUDE.md)
+- **spec** → [`packages/spec/CLAUDE.md`](packages/spec/CLAUDE.md) (+ [`packages/spec/README.md`](packages/spec/README.md) for humans). ⚠️ Describes **behaviour**, never mechanism — the moment it explains *how*, it duplicates a `CLAUDE.md` and the two drift.
 
 ## Deployment
 

--- a/packages/spec/CLAUDE.md
+++ b/packages/spec/CLAUDE.md
@@ -1,0 +1,99 @@
+# packages/spec
+
+Package-specific guidance. See [`README.md`](README.md) for what this package is, and the
+repo-root `CLAUDE.md` for universal rules.
+
+**Purpose.** The product specification — what BrewDocs should do, in a brewer's terms. The
+durable answer to "what is this supposed to do?", which a story cannot be: a story is
+diff-shaped and becomes history the moment it merges.
+**Where.** `product/*.md`, one document per area of the app, plus `product/_template.md`.
+**Invariants.** Observable behaviour only. Ids are never renumbered or reused. Written from
+intent, never from a diff.
+**Gotchas.** Not an npm workspace — `npm test -ws` never sees it, and neither CI workflow runs
+for a spec-only change (both `paths` lists carry `'!packages/spec/**'`).
+
+## Why this package exists
+
+The Tester is required to derive every test from **expected** behaviour, never from the
+implementation — a test written by reading the code passes by construction and cannot fail for
+the only reason worth catching. That rule was given three sources: the story's outcome, the
+authors' `testingNotes`, and the acceptance criteria.
+
+⚠️ **All three are story-scoped.** Once a story merges, the only surviving description of what
+the product should do is the product. So the rule quietly inverted itself for everything except
+the story in front of you — a regression suite, which is most of a suite, had nowhere honest to
+come from. This package is that source.
+
+## What a document looks like
+
+Copy [`product/_template.md`](product/_template.md). One file per area a brewer navigates —
+named for the screen, not the code that renders it.
+
+- **Purpose** — what the area is for, in a sentence a brewer would recognise.
+- **Behaviours** — the promises the product makes, each with an id.
+- **Known gaps** — behaviour observed to be wrong or missing, with its issue.
+- **Out of scope** — what this area deliberately does not do, so nobody specifies it twice.
+
+### Writing a behaviour
+
+State what someone can **do** and what they then **see**. If a sentence cannot be checked by a
+person holding the app, it is not a behaviour.
+
+> **BATCH-SCHEDULE-04** — Checking off an ingredient keeps it checked after leaving the batch
+> and returning to it.
+
+⚠️ **Add a *why* only where the behaviour would otherwise look arbitrary** and someone might
+"simplify" it away. The reload in that example is the whole point — a save that throws in a
+fire-and-forget call leaves the UI looking correct — and a behaviour that does not say so
+invites a test that never reloads.
+
+## The two rules
+
+⚠️ **Observable behaviour only.** What a brewer can see and do. No file, component, hook, state
+shape or storage detail — the moment a document explains *how*, it is a second `CLAUDE.md`
+covering the same ground as the real one, and two descriptions of one mechanism drift. They
+have already drifted twice in this repo where nobody was even trying to keep two copies.
+
+The dividing question: **would this sentence still be true after a rewrite that changed no
+behaviour?** If yes it belongs here. If a refactor would falsify it, it belongs in a `CLAUDE.md`.
+
+⚠️ **Ids are never renumbered and never reused.** The id is what a test, an issue or a
+conversation points at. Renumbering silently retargets every one of those references: a test
+citing `BATCH-SCHEDULE-04` keeps passing while now proving a different promise, which is worse
+than the test not existing, because it reads as coverage.
+
+- The prefix is the filename, uppercased: `batch-schedule.md` → `BATCH-SCHEDULE-<nn>`. Nothing
+  to look up, and nothing to keep in sync.
+- Numbers run in order of being added, not in reading order. A new behaviour takes the next
+  unused number wherever it belongs on the page.
+- A retired behaviour stays, struck through, with what replaced it:
+  `~~**BATCH-SCHEDULE-03**~~ — *retired, superseded by BATCH-SCHEDULE-11.*`
+
+## Where a behaviour comes from
+
+⚠️ **From intent, never from a diff.** A specification written by reading an implementation can
+only restate what the code already does — so it cannot be used to decide whether the code is
+right, which is the single thing a specification is for. Worse, a Tester deriving tests from
+that document is deriving from the implementation at one remove, and the rule it was given
+looks satisfied.
+
+Legitimate sources: a story's stated outcome and acceptance criteria, an epic's goal, and the
+maintainer describing what they want.
+
+⚠️ **When specifying what already exists, work from the running app, not the source.** Reading
+the implementation enshrines today's behaviour as intended, bugs and all. Drive the screens,
+describe what happens, and put anything that looks wrong under **Known gaps** with an issue —
+never write a defect up as a promise.
+
+## Who writes it, who reads it
+
+| role | relationship |
+|---|---|
+| Writer | owns it. Writes a story's behaviours from its intent, **before** the code exists. |
+| Tester | first source when planning. Cites the ids it intends to prove. |
+| Architect | reads it when shaping a story that touches an existing area. |
+| Implementor / Designer | read it for context; never edit it. |
+
+⚠️ **The Writer runs FIRST in a story**, ahead of the authors — the ordering follows from
+"written from intent". A Writer that ran last would have the finished diff in front of it, which
+is the one source it must not use.

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -1,0 +1,45 @@
+# @brewdocs.beer/spec
+
+The product specification: **what BrewDocs should do**, described in a brewer's terms.
+
+It is the standing answer to "what is this screen supposed to do?" — the one that survives a
+story being merged and closed. Read it to understand the product without reading the product.
+
+## What this is not
+
+- **Not a design document.** It describes behaviour that exists or has been agreed, not options
+  under consideration.
+- **Not an implementation guide.** Nothing here names a file, a component, a hook or a data
+  shape. That is what each package's `CLAUDE.md` is for, and the two must not overlap — a
+  second description of the code drifts against the first.
+- **Not a wish list.** Behaviour arrives here when it is specified, not when it is imagined.
+
+## How to read it
+
+[`product/`](product/) holds one document per area of the app, mirroring what a brewer
+navigates rather than how the code is organised. Each opens with what the area is *for*, then
+lists its behaviours.
+
+Every behaviour carries a stable id — `BATCH-SCHEDULE-04`. Ids are how a test, an issue or a
+conversation points at one specific promise, so **they are never renumbered and never reused**.
+A behaviour that is retired stays in place, struck through, rather than leaving its number free
+for something else to claim.
+
+Each document ends with **Known gaps**: behaviour observed to be wrong or missing, recorded
+rather than quietly specified as if intended.
+
+## Who writes it
+
+The Writer, from a story's stated intent — its outcome and acceptance criteria — **before** the
+code exists. Deliberately not from the finished diff: a specification written by reading an
+implementation can only say what the code already does, which makes it useless for deciding
+whether the code is right.
+
+Humans write here too. A maintainer's description of what they want is exactly the right source.
+
+## Who reads it
+
+- **Brewers and maintainers** — the product's own description of itself.
+- **The Tester** — its first source when planning what to prove, and the only one that covers
+  behaviour from earlier stories.
+- **The Architect** — what already exists, when shaping a story that touches it.

--- a/packages/spec/product/_template.md
+++ b/packages/spec/product/_template.md
@@ -1,0 +1,63 @@
+# <Area>
+
+<!--
+Copy this file to product/<area>.md and delete these comments.
+
+The filename sets the id prefix, uppercased: batch-schedule.md -> BATCH-SCHEDULE-<nn>.
+Name the file for what a brewer navigates to, not for the code that renders it.
+
+Read packages/spec/CLAUDE.md before writing. The two rules that decide whether this
+document is worth anything: observable behaviour only, and ids are never renumbered
+or reused.
+-->
+
+**Purpose.** <What this area is for, in a sentence a brewer would recognise. Not what it
+contains — what it is *for*.>
+
+## Behaviours
+
+<!--
+State what someone can DO and what they then SEE. If a sentence cannot be checked by a
+person holding the app, it is not a behaviour and does not belong here.
+
+Test: would this still be true after a rewrite that changed no behaviour? If a refactor
+would falsify it, it belongs in a CLAUDE.md instead.
+
+Numbers run in order of being ADDED, not in reading order — a new behaviour takes the
+next unused number wherever it sits on the page.
+-->
+
+**<AREA>-01** — <Doing X results in Y.>
+
+**<AREA>-02** — <Doing X results in Y.>
+
+> *Why:* <Only where the behaviour would otherwise look arbitrary and someone might
+> "simplify" it away. Most behaviours need no note; one on every entry means none get read.>
+
+<!--
+A retired behaviour stays in place, struck through, naming what replaced it. Never delete
+it and never free its number — a test citing a reused id keeps passing while proving a
+different promise, which reads as coverage and is worse than no test.
+
+~~**<AREA>-03**~~ — *retired, superseded by <AREA>-11.*
+-->
+
+## Known gaps
+
+<!--
+Behaviour observed to be wrong or missing. Record it here rather than writing it up as a
+promise — specifying a defect as intended is how a bug becomes a requirement.
+
+Every entry names its issue. If there is no issue, file one.
+-->
+
+- <What is wrong, and what should happen instead.> — #<issue>
+
+## Out of scope
+
+<!--
+What this area deliberately does not do, so the same ground is not specified twice and
+nobody proposes it as missing.
+-->
+
+- <Deliberately absent behaviour, and briefly why.>


### PR DESCRIPTION
## Summary

Creates `packages/spec` — the product specification. Package and conventions only; no spec
content, no role changes.

Closes #576.

### Why it exists

#559 requires the Tester to derive every test from **expected** behaviour, and named three
sources: the story's outcome, the authors' `testingNotes`, the acceptance criteria.

⚠️ **All three are story-scoped.** Once a story merges, the only surviving description of what
the product should do is the product — so the rule inverted itself for everything except the
story in front of you. A regression suite, which is most of a suite, had nowhere honest to come
from. This package is that source.

### What's here

| file | for |
|---|---|
| `README.md` | a human arriving cold — what it is, what it isn't, how to read it |
| `CLAUDE.md` | the roles that read and write it |
| `product/_template.md` | the document shape, carrying both rules inline |

### The two rules, and the failure each prevents

**Observable behaviour only.** Decided by one question: *would this sentence still be true after
a rewrite that changed no behaviour?* If a refactor would falsify it, it belongs in a
`CLAUDE.md`. Without that line the spec becomes a second description of the same mechanism, and
two descriptions drift — they have already drifted twice here where nobody was trying to keep
two copies.

**Ids are never renumbered or reused.** The id is what a test, an issue or a conversation points
at. Renumbering silently retargets all of them: a test citing `BATCH-SCHEDULE-04` keeps passing
while now proving a different promise — which reads as coverage, and is worse than the test not
existing. A retired behaviour stays struck through rather than freeing its number.

The prefix derives from the filename (`batch-schedule.md` → `BATCH-SCHEDULE-<nn>`), so there is
nothing to look up and nothing to keep in sync.

### CI

`'!packages/spec/**'` added to both `verify.yaml` and `functional-test.yaml`, matching the
existing `claude-team` negation — markdown does not compile, and a spec-only PR should not spin
the gate. The shared comment now names both non-workspace packages.

## Verification

- `nx run-many --target=test` ✓ 6 projects
- Parsed both workflows and asserted the resulting `paths`, rather than eyeballing the edit:

```
verify           [...,"!packages/claude-team/**","!packages/spec/**",...]
functional-test  [...,"!packages/claude-team/**","!packages/spec/**",...]
```

This PR touches `verify.yaml` itself, so Verify runs on it — which is the check that the edit
did not break its own trigger.

## Next

#577 (Writer owns it, runs first) · #578 (Tester plans from it) · #579 (backfill from the
running app — needs a browser session with you).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
