### PR TITLE
Tester plans from the product specification

### DIFF
--- a/.github/agent-prompts/tester.md
+++ b/.github/agent-prompts/tester.md
@@ -1,5 +1,11 @@
 You own `packages/e2e` — the Playwright suite that drives the real app in a browser. Read
-`packages/e2e/CLAUDE.md` first; it is short and it is the spec.
+`packages/e2e/CLAUDE.md` first; it is short, and it is how the harness works.
+
+⚠️ **Two different things are called "spec" here, and confusing them ruins a run.** A `.spec.ts`
+file is a Playwright test. The **product specification** is `packages/spec/product/*.md` — what
+the app is supposed to do, and where your plan's behaviour ids come from. Read the area's
+document before you plan; it is the only source that survives its own story, so it is what a
+regression test can honestly be built on. You never edit it — that is the Writer's.
 
 Browsers are already installed. Never run `npx playwright install`.
 

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -149,9 +149,17 @@ No role chains off another — nothing runs that a maintainer did not trigger.
 
 ⚠️ **A test derived from the implementation is worthless, and looks exactly like coverage.**
 It asserts what the code does, so it passes by construction and cannot fail for the only
-reason worth catching. The Tester derives from *expected* behaviour — the story's outcome,
-the `testingNotes`, the acceptance criteria — and may read a component for one thing only:
-how to **address** an element. Knowing how to click a thing is not knowing what it should do.
+reason worth catching. The Tester derives from *expected* behaviour — the **product
+specification** first, then the story's outcome, the `testingNotes`, the acceptance criteria —
+and may read a component for one thing only: how to **address** an element. Knowing how to
+click a thing is not knowing what it should do.
+
+⚠️ **The specification is the only one of those that outlives its story.** The other three
+describe a single change and are gone once it merges, which is precisely when a regression
+suite needs to know what the product promises — so without a specification the derive-from-
+behaviour rule silently inverted for everything except the story in front of you. The Tester
+cites behaviour ids in its plan, which is what makes coverage a question a reviewer can ask
+rather than a claim they have to accept.
 
 ⚠️ **A failing test is a finding, not a chore.** It is filed on the authoring task, carried in
 the Tester's own report, and left failing. Weakening or deleting it to get green converts a

--- a/packages/claude-team/prompts/tester.md
+++ b/packages/claude-team/prompts/tester.md
@@ -56,8 +56,12 @@ Don't stall waiting on a handoff, and don't invent behaviour the code doesn't ha
 Write down what behaviour you intend to prove, and post it in your comment **before** the
 tests exist. One line per case: the behaviour, and what would be broken if it failed.
 
-Draw it from what the work was **supposed to do** — the story's outcome, its acceptance
-criteria, the `testingNotes`. Not from the diff.
+Draw it from what the work was **supposed to do** — the product specification first, then the
+story's outcome, its acceptance criteria, the `testingNotes`. Not from the diff.
+
+⚠️ **Cite the specification's behaviour ids in the plan**, one per case where one exists. That
+is what turns a plan from a claim into something checkable: a reviewer can ask why nothing
+covers a particular id, which is a question a prose list of cases cannot be asked.
 
 ⚠️ A plan is worth writing because it can be argued with. A finished suite invites a review
 of whether the tests pass; a plan invites the question that matters, which is whether they
@@ -72,8 +76,18 @@ A test written by reading the code asserts what the code *does*. It therefore pa
 construction, and it cannot fail for the only reason worth catching — the code doing the
 wrong thing correctly. It looks exactly like coverage on a dashboard and is worth nothing.
 
-So: the story says what should happen, the `testingNotes` say where it could silently break,
-the acceptance criteria say what "done" meant. Those are your sources.
+So: **the product specification says what the product should do**, the story says what this
+change was meant to add to that, the `testingNotes` say where it could silently break, and the
+acceptance criteria say what "done" meant. Those are your sources.
+
+⚠️ **The specification comes first, and it is the only one that outlives its story.** The other
+three describe a single change and stop being available the moment it merges — which is exactly
+when a regression suite needs to know what the product promises. Read the specification for the
+area you are testing before you read anything else.
+
+⚠️ **A behaviour with no entry in the specification is a finding, not a blocker.** Say so in
+your report — the Writer is meant to have specified it, and a gap is worth knowing about. Then
+carry on from the story and test it anyway.
 
 ⚠️ **One exception, and it is mechanical, not behavioural:** read a component to work out
 **how to address** an element — its role, its label, its test id, the query that selects it.


### PR DESCRIPTION
## Summary

Points the Tester's planning at the product specification, and has it cite behaviour ids.

Closes #578. ⚠️ **Merge order: #580 → #581 → this.** All three name `packages/spec/`, which #580
creates. I verified this branch and #581 do **not** conflict (`git merge-tree`, 0 markers), so
the order is about the referenced package existing, not about textual clashes.

### The gap it closes

#559 required the Tester to derive from expected behaviour and named three sources: the story's
outcome, `testingNotes`, the acceptance criteria.

⚠️ **All three describe a single change and are gone once it merges** — which is exactly when a
regression suite needs to know what the product promises. So the rule silently inverted itself
for everything except the story in front of you. The specification is the only source that
outlives its own story, so it goes first.

### Behaviour ids in the plan

The plan now cites the ids it intends to prove. That turns it from a claim into something
checkable: **a reviewer can ask why nothing covers `BATCH-SCHEDULE-07`**, which is not a
question a prose list of cases can be asked.

A behaviour with no spec entry is a **finding, not a blocker** — report the gap, then test it
from the story anyway.

### One naming hazard, handled

⚠️ The word "spec" now means two things in this repo. The Tester's overlay previously said
*"read `packages/e2e/CLAUDE.md` first; it is short and it is the spec"* — which, once
`packages/spec` exists, reads as a pointer to the wrong artifact entirely. The overlay now
separates them: a `.spec.ts` file is a Playwright test, the product specification is
`packages/spec/product/*.md`, the Tester reads one and never edits the other.

Left untouched: reading a component to learn how to **address** an element stays the one
permitted look at the implementation. This changes where the *assertion* comes from, not that.

## Verification

- `nx run-many --target=test` ✓ 6 projects
- `git merge-tree` against `577-writer-owns-spec` — 0 conflict markers, so the two can merge in
  either order.

⚠️ Prompt-only and not reachable by CI. The first Tester run after all three merge is the check:
its plan should open with cited ids, or with a stated gap where the spec is silent.

## Remaining

#579 — backfill the spec from the running app. ⚠️ That one needs a browser session with you:
Playwright cannot install chromium on macOS 13, and the whole point is to describe observed
behaviour rather than read the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
