### PR TITLE
log-to-epic.py: identify the epic by asking, not by absence of a parent

### DIFF
--- a/packages/claude-team/hooks/log-to-epic.py
+++ b/packages/claude-team/hooks/log-to-epic.py
@@ -11,7 +11,12 @@ one exactly once.
 ONE COMMENT, REWRITTEN — not one per run. An epic with ten tasks and three roles each would
 otherwise accumulate thirty comments. The status table is rebuilt from live state every time,
 so it is never stale; only the Recent lines accumulate, and they are capped.
+
+NO EPIC IS A NORMAL OUTCOME. A story here need not sit under one, and when it does not there is
+nothing for this hook to say — log-to-story covers that case on the story itself. See resolve().
 """
+
+from __future__ import annotations
 
 import datetime as dt
 import os
@@ -32,14 +37,50 @@ if not ISSUE:
     print("Not triggered on an issue — no epic to log against.")
     raise SystemExit(0)
 
-# A task's parent is its story and the story's parent is the epic; a story's parent is the
-# epic directly. Walk up at most two levels and stop at whatever has no parent.
-p1 = team.parent(ISSUE)
-if not p1:
-    print(f"#{ISSUE} has no parent — an epic itself, or unparented work. Nothing to log.")
+def resolve(number: str) -> tuple[str, str] | None:
+    """Which story and which epic this issue belongs to, or None when there is no epic.
+
+    ⚠️ THE EPIC IS IDENTIFIED BY ASKING, NEVER BY ABSENCE OF A PARENT. This walked up until an
+    ancestor had no parent and called that the epic, which is right for a story sitting under
+    one and wrong for a task whose story has no epic at all — and the two arrive identically,
+    as "an issue whose parent has no parent". A parentless story therefore read as an epic and
+    its own tasks read as stories: a work log landed on #537 listing #538 and #539 under a
+    "Stories" heading, telling the maintainer the Architect would shape a task already stamped
+    Role: writer.
+
+    The same assumption was removed from story_from_branch in #502 and survived here.
+    """
+    parent = team.parent(number)
+    if not parent:
+        print(f"#{number} has no parent — an epic itself, or unparented work. Nothing to log.")
+        return None
+
+    if team.is_epic(parent):
+        return number, parent
+
+    story = parent
+    grandparent = team.parent(story)
+    if not grandparent:
+        print(f"story #{story} sits under no epic — nothing to log. (log-to-story covers it.)")
+        return None
+
+    # An ancestor two levels up is where an epic belongs. If it does not say it is one, warn
+    # rather than assume: silence would hide a mislabelled epic, and assuming is this bug.
+    if not team.is_epic(grandparent):
+        team.warn(
+            f"#{grandparent} is where #{number}'s epic should be, but carries neither the "
+            f"'{team.EPIC_LABEL}' label nor an 'Epic' title, so nothing was logged. Mark it if "
+            "it is one."
+        )
+        return None
+
+    return story, grandparent
+
+
+resolved = resolve(ISSUE)
+if not resolved:
     raise SystemExit(0)
-p2 = team.parent(p1)
-STORY, EPIC = (p1, p2) if p2 else (ISSUE, p1)
+STORY, EPIC = resolved
 
 print(f"logging #{ISSUE} (story #{STORY}) against epic #{EPIC}")
 


### PR DESCRIPTION
## Summary

`log-to-epic.py` decided which ancestor was the epic by asking *"does it have a parent?"*
instead of *"is it an epic?"*. Two different shapes reach that branch identically — **an issue
whose parent has no parent** — and it is right for only one:

| ISSUE | parent | correct | old behaviour |
|---|---|---|---|
| a story | its epic | STORY=issue, EPIC=parent | ✅ |
| a task | a **parentless story** | there is no epic | ❌ EPIC = the story |

Closes #583.

**Observed:** a work log landed on story #537 listing #538 and #539 — its own *tasks* — under a
**Stories** heading, advising *"next open story of epic #537 — label it `@claude` and the
Architect will shape it"* for a task already stamped `Role: writer`.

⚠️ Same assumption #502 removed from `story_from_branch`; it survived in a second hook.

## The fix

Resolution asks `team.is_epic` at each level, and is now a pure function so it can be exercised
without posting anything.

- **No epic is a normal outcome** — a standalone story is legitimate here, and `log-to-story`
  already covers it. Prints and exits.
- **An ancestor that should be an epic but carries neither marker warns.** Silence would hide a
  mislabelled epic; assuming is the bug.

## Verification

Exercised against **real issues**, resolution only:

```
  ok  #538 -> None            task under PARENTLESS story #537 — the reported bug
  ok  #539 -> None            its sibling, stamped Role: writer
  ok  #482 -> ('482','480')   story directly under epic #480
  ok  #567 -> None            task under story #515, which has no epic
  ok  #480 -> None            the epic itself
```

⚠️ **No task → story → epic chain exists in this repo today**, so the fully-nested branch cannot
be reached with real data. Stubbed the two lookups rather than leave it unproven:

```
  nested task -> story -> epic : ('story', 'epic')
  grandparent not marked epic  : None, warned
```

`py_compile` ✓ · `nx run-many --target=test` ✓ 6 projects.

## Two things found while verifying

**1. I overstated something earlier — correcting it.** When I showed the trigger order for
#515 as *"what `log-to-story` will now say"*, that was me running the sort function over the
four task numbers by hand. **#515 has zero sub-issues** — its tasks are not parented to it — so
the hook produces *"#515 has no tasks — nothing to order"* and there is no story log at all.
The sort change from #581 is correct; it just has nothing to sort for that story. Worth filing
separately: either `file-sub-issues.py` did not run for #515 or it declined to match.

**2. Python version.** The new signature uses a PEP-604 union. `team.py` is the only hook that
carries `from __future__ import annotations`, and was the only one needing it — this file now
does too. Without it this works on the runner's 3.12 and raises `TypeError` on 3.9, which is
what my local run hit: green in CI, broken anywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
