### PR TITLE
Give Summary's derived Actuals IBU its own functional test

### DIFF
--- a/packages/e2e/tests/batch-summary.spec.ts
+++ b/packages/e2e/tests/batch-summary.spec.ts
@@ -50,22 +50,36 @@ test("shows the recipe's target vitals, a fresh batch's zeroed actuals, and the 
     await expect(vitalsRow(page, "Target", "O.G.")).toContainText("1.05°P");
     await expect(vitalsRow(page, "Target", "F.G.")).toContainText("1.014°P");
 
-    // defaultBatch's actuals, unset on a freshly-brewed batch
+    // defaultBatch's actuals, unset on a freshly-brewed batch. IBU is deliberately
+    // absent here — it is the one actual that is derived rather than zeroed, and it
+    // has its own test below.
     await expect(vitalsRow(page, "Actuals", "ABV")).toContainText("0.0%");
     await expect(vitalsRow(page, "Actuals", "O.G.")).toContainText("0.00°P");
     await expect(vitalsRow(page, "Actuals", "F.G.")).toContainText("0.00°P");
-
-    // IBU is the exception among the actuals: it is never measured, so it is
-    // derived from the batch's own hop bill rather than left at defaultBatch's
-    // "0". No gravity has been recorded yet, so it falls back to the recipe's
-    // target OG — Tinseth over anchor-steam's three Northern Brewer additions.
-    await expect(vitalsRow(page, "Actuals", "IBU")).toContainText("37");
 
     await expect(page.getByText("German Pils")).toBeVisible();
     await expect(page.getByText("Northern Brewer")).toBeVisible();
     await expect(page.getByText("Wyeast 2112")).toBeVisible();
     await expect(page.getByText("Yeast Nutrients")).toBeVisible();
     await expect(page.getByText("Irish Moss")).toBeVisible();
+});
+
+// IBU is the one actual a brewer never measures, so Summary derives it from the
+// batch's own hop bill instead of leaving it at defaultBatch's "0". A freshly
+// brewed batch has no gravity reading, which also makes this the fallback case:
+// the estimate uses the recipe's target OG.
+//
+// anchor-steam-beer-clone's three Northern Brewer additions over its 5gal batch
+// at 1.05 OG come to 37 by Tinseth, against a hand-authored target of 35.
+//
+// ⚠️ Anchored rather than `toContainText("37")`, which also passes on 137 and 371.
+// An IBU wrong by an order of magnitude is the failure most worth catching here,
+// and a substring match cannot see it.
+test("Summary derives a non-zero Actuals IBU from the batch's own hop bill", async ({page}) => {
+    await brewBatchFromKbRecipe(page, "E2E Summary IBU Batch");
+    await page.getByRole("tab", {name: "Summary", exact: true}).click();
+
+    await expect(vitalsRow(page, "Actuals", "IBU")).toHaveText(/^IBU\s*37$/);
 });
 
 // mirrors batch-edit.spec.ts's own copy — this file drives the Brewing tab


### PR DESCRIPTION
## Summary

The Actuals IBU assertion existed, but as the **eighth check** inside a test named *"shows the
recipe's target vitals, a fresh batch's **zeroed** actuals, and the batch's organics"*.

Closes #585.

Three problems, all about a failure being readable rather than the check itself:

- **The name contradicted it.** IBU is a fresh batch's one *non-zero* actual, so the test
  claimed "zeroed actuals" and then proved one was not — pointing a reader at the wrong feature.
- **It only ran if seven earlier assertions passed.** Any Target-column regression hid the IBU
  check entirely: the suite failed, but not for this.
- **`toContainText("37")` is a substring match**, so it passed on `137` and `371` too. An IBU
  wrong by an order of magnitude is the failure most worth catching, and it could not see it.

## The change

```ts
test("Summary derives a non-zero Actuals IBU from the batch's own hop bill", async ({page}) => {
    await brewBatchFromKbRecipe(page, "E2E Summary IBU Batch");
    await page.getByRole("tab", {name: "Summary", exact: true}).click();

    await expect(vitalsRow(page, "Actuals", "IBU")).toHaveText(/^IBU\s*37$/);
});
```

Removing IBU from the broad test also makes **its** name true again — nothing else in it is
non-zero.

anchor-steam's three Northern Brewer additions over a 5gal batch at 1.05 target OG come to 37 by
Tinseth, against a hand-authored target of 35.

## Verification

`nx run-many --target=test` ✓ 6 projects.

⚠️ **Playwright still cannot install chromium on macOS 13**, so CI is the instrument. The one
thing I would watch: `toHaveText` with an anchored regex is stricter than anything else in this
suite, which all uses `toContainText`. If it fails it will be over the row's exact text content,
not over the number — the value itself is already proven, since the pre-existing
`toContainText("37")` has been passing since #575.

## The gap this leaves, deliberately

Summary picks the OG for its estimate: **measured when a gravity reading exists, the recipe's
target otherwise**. This test covers the fallback — a freshly brewed batch has no readings.

**The measured-OG side is untested.** `batch-summary.spec.ts` already has four tests that record
gravity readings (lines 120–176), so the fixture for it exists; none of them assert IBU. That
branch only fires on brew day, which is the worse half to have uncovered. Happy to add it — it
needs the expected value computed for those readings first, so I did not fold it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
