### PR TITLE
Add a gitignored LOCAL.md for machine-specific facts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 notes.md
+# machine-specific notes — see the root CLAUDE.md. Every line in it would be
+# wrong somewhere else, which is exactly why it is not committed.
+LOCAL.md
 test-results/
 playwright-report/
 .env.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ Guidance for Claude Code (claude.ai/code) working in this repo. **These instruct
 
 This root file holds the **universal** rules. Each package's deep-dive lives in its own `CLAUDE.md`, loaded on demand when you work in that package (see _Packages_).
 
+⚠️ **Read `LOCAL.md` at the repo root if it exists, and keep it current.** It holds facts about *the machine you are on* — which browser the functional suite can actually launch, which runtime versions differ from CI, which tool is broken here and what to use instead. It is **gitignored**, because every line in it would be wrong or misleading elsewhere; this pointer is committed because that is the half that has to survive a fresh session. The dividing rule: *would a contributor on a different laptop need this line?* If yes it belongs in a `CLAUDE.md`, not there. Absent on a fresh clone, which is fine — write one when you learn something the hard way.
+
 ## Overview
 
 - **What.** BrewDocs — offline-first homebrewing PWA (brew-day companion + knowledge base). **Proof-of-concept**; breaking changes are expected. There is deliberately **no data migration or on-load normalization** — assume a **pristine local store** in dev (`/?purge=true` to reset). Don't add "ensure"/backfill shims that repair old stored objects.


### PR DESCRIPTION
## Summary

Machine-specific facts kept being rediscovered one painful command at a time, with nowhere to
record them. `CLAUDE.md` is the wrong home — it is committed, so a line true only of this laptop
is actively misleading to anyone else and to CI.

Closes #589.

## The split

- **`LOCAL.md` is gitignored**, alongside the existing `notes.md`. Every line in it would be
  wrong or misleading elsewhere.
- **The pointer is committed** — one line in the root `CLAUDE.md`. That is the half that has to
  survive a fresh session: an uncommitted file nothing references is a file nobody opens.
- **The dividing rule is stated in both places:** *would a contributor on a different laptop
  need this line?* If yes, it belongs in a `CLAUDE.md`.

## What went into it

Only things that cost real time in one session:

| fact | what it cost |
|---|---|
| `npx playwright install` cannot work here (no macOS 13 chromium) | rediscovered three times before #587 |
| Python is 3.9.6 locally, 3.12 on the runners | a PEP-604 union in a hook **passes CI and fails locally** |
| `npx esbuild` crashes; the platform binary works | the only way to exercise a pure function — no unit-test runner exists |
| a probe's entry file must sit **inside** the repo | bare imports like `react-dom/server` do not resolve otherwise |
| the Bash working directory persists and drifts between calls | a relative path that worked once silently resolves elsewhere |

It cross-references the Node-PATH note in `CLAUDE.md` rather than copying it — two copies drift,
and this repo has been bitten by exactly that.

## Verification

```
$ git check-ignore -v LOCAL.md
.gitignore:5:LOCAL.md   LOCAL.md

$ git status --porcelain
 M .gitignore
 M CLAUDE.md
```

The file exists on disk, is ignored, and never appears in `git status` — so it cannot ride a
`git add -A` into a PR. `nx run-many --target=test` ✓ 6 projects.

Independent of #588; they touch different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
