### PR TITLE
Allow the deploy workflows to be triggered by hand

### DIFF
--- a/.github/workflows/build-test-deploy.app-kb-prod.yaml
+++ b/.github/workflows/build-test-deploy.app-kb-prod.yaml
@@ -2,6 +2,12 @@ name: Build, Test, and Deploy (App KB Prod)
 run-name: "Build, Test, and Deploy (App KB Prod)"
 
 on:
+  # ⚠️ Manual trigger, and it is a recovery mechanism rather than a convenience. A push is
+  # otherwise the only way to deploy, so a deploy that fails — or one that never fires — can
+  # only be retried by producing another commit. Both have happened: a transient ECONNRESET in
+  # download-artifact left prod a commit behind (#587-era), and a design-only change deployed
+  # Storybook but not the app. Pick the branch in the Actions tab and run it.
+  workflow_dispatch:
   push:
     branches:
       - mainline
@@ -16,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: List changed files
+        # ⚠️ push only — a manual run has no github.event.commits to summarise, and the
+        # first step of the mechanism that rescues a broken deploy must not be the thing
+        # that breaks it.
+        if: github.event_name == 'push'
         env:
           # passed via env (not inlined) so commit/file names cannot inject into the shell
           COMMITS: ${{ toJSON(github.event.commits) }}

--- a/.github/workflows/build-test-deploy.app-prod.yaml
+++ b/.github/workflows/build-test-deploy.app-prod.yaml
@@ -2,6 +2,12 @@ name: Build, Test, and Deploy (App Prod)
 run-name: "Build, Test, and Deploy (App Prod)"
 
 on:
+  # ⚠️ Manual trigger, and it is a recovery mechanism rather than a convenience. A push is
+  # otherwise the only way to deploy, so a deploy that fails — or one that never fires — can
+  # only be retried by producing another commit. Both have happened: a transient ECONNRESET in
+  # download-artifact left prod a commit behind (#587-era), and a design-only change deployed
+  # Storybook but not the app. Pick the branch in the Actions tab and run it.
+  workflow_dispatch:
   push:
     branches:
       - mainline
@@ -17,6 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: List changed files
+        # ⚠️ push only — a manual run has no github.event.commits to summarise, and the
+        # first step of the mechanism that rescues a broken deploy must not be the thing
+        # that breaks it.
+        if: github.event_name == 'push'
         env:
           # passed via env (not inlined) so commit/file names can't inject into the shell
           COMMITS: ${{ toJSON(github.event.commits) }}

--- a/.github/workflows/build-test-deploy.design-prod.yaml
+++ b/.github/workflows/build-test-deploy.design-prod.yaml
@@ -2,6 +2,12 @@ name: Build, Test, and Deploy (Design Prod)
 run-name: "Build, Test, and Deploy (Design Prod)"
 
 on:
+  # ⚠️ Manual trigger, and it is a recovery mechanism rather than a convenience. A push is
+  # otherwise the only way to deploy, so a deploy that fails — or one that never fires — can
+  # only be retried by producing another commit. Both have happened: a transient ECONNRESET in
+  # download-artifact left prod a commit behind (#587-era), and a design-only change deployed
+  # Storybook but not the app. Pick the branch in the Actions tab and run it.
+  workflow_dispatch:
   push:
     branches:
       - mainline
@@ -16,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: List changed files
+        # ⚠️ push only — a manual run has no github.event.commits to summarise, and the
+        # first step of the mechanism that rescues a broken deploy must not be the thing
+        # that breaks it.
+        if: github.event_name == 'push'
         env:
           # passed via env (not inlined) so commit/file names cannot inject into the shell
           COMMITS: ${{ toJSON(github.event.commits) }}

--- a/.github/workflows/build-test-deploy.www-prod.yaml
+++ b/.github/workflows/build-test-deploy.www-prod.yaml
@@ -2,6 +2,12 @@ name: Build, Test, and Deploy (WWW Prod)
 run-name: "Build, Test, and Deploy (WWW Prod)"
 
 on:
+  # ⚠️ Manual trigger, and it is a recovery mechanism rather than a convenience. A push is
+  # otherwise the only way to deploy, so a deploy that fails — or one that never fires — can
+  # only be retried by producing another commit. Both have happened: a transient ECONNRESET in
+  # download-artifact left prod a commit behind (#587-era), and a design-only change deployed
+  # Storybook but not the app. Pick the branch in the Actions tab and run it.
+  workflow_dispatch:
   push:
     branches:
       - mainline
@@ -17,6 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: List changed files
+        # ⚠️ push only — a manual run has no github.event.commits to summarise, and the
+        # first step of the mechanism that rescues a broken deploy must not be the thing
+        # that breaks it.
+        if: github.event_name == 'push'
         env:
           # passed via env (not inlined) so commit/file names cannot inject into the shell
           COMMITS: ${{ toJSON(github.event.commits) }}


### PR DESCRIPTION
## Summary

A push was the only way to deploy, so a deploy that **failed** — or one that **never fired** —
could only be retried by producing another commit.

Closes #598.

Both failure modes have now happened inside two days:

| when | what | result |
|---|---|---|
| 2026-08-05 | transient `ECONNRESET` in `download-artifact`; Build and Test passed, Deploy died | prod silently a commit behind until re-run by hand |
| 2026-08-06 | `5eb0378` changed only `packages/design`, not then in the app deploy's `paths` | **Storybook deployed, the app did not** |
| 2026-08-06 | `248c915` bumped `packages/app/README.md` purely to force a deploy | ⚠️ **no run fired at all** |

That last row is the argument. The one commit whose entire purpose was to force a deploy did
not produce one, and all four workflows report `active`. ⚠️ **I could not determine why**, and
I would rather say so than invent a cause — but with a manual trigger it stops being blocking.

Measured while diagnosing:

```
prod bundle   assets/index-DriHHmbm.js
local build   assets/index-Rtmr7tN5.js     (mainline)
```

## The change

`workflow_dispatch:` on all four `build-test-deploy.*.yaml`.

⚠️ **The "List changed files" step is guarded to `push`.** It reads
`toJSON(github.event.commits)`, which a manual run has no value for. `jq` would most likely
tolerate the resulting `"null"` — but "most likely" is not good enough for the *first step of
the mechanism that exists to rescue a broken deploy*, and a manual run has no commit list to
summarise anyway.

## Verification

Parsed all four and asserted both properties, rather than reading the diff:

```
  workflow                              triggers                  changed-files guarded
  build-test-deploy.app-kb-prod.yaml    workflow_dispatch, push   github.event_name == 'push'
  build-test-deploy.app-prod.yaml       workflow_dispatch, push   github.event_name == 'push'
  build-test-deploy.design-prod.yaml    workflow_dispatch, push   github.event_name == 'push'
  build-test-deploy.www-prod.yaml       workflow_dispatch, push   github.event_name == 'push'
```

Push behaviour untouched — same branch, same paths:

```
  app-kb-prod    ["mainline"]  ["packages/kb/**"]
  app-prod       ["mainline"]  ["packages/app/**","packages/design/**"]
  design-prod    ["mainline"]  ["packages/design/**"]
  www-prod       ["mainline"]  ["packages/www/**","packages/design/**"]
```

`nx run-many --target=test` ✓ 6 projects.

⚠️ **`workflow_dispatch` only becomes available once this is on the default branch** — GitHub
reads the trigger list from `mainline`, so the button appears after merge, not on this PR.

## Separately: the modal fix is correct, just not deployed

Verified at phone width locally on `mainline`, which is what you were seeing on mobile:

```
PORTALLED: true    viewport 390x844
box 341x149        margins L24 R24 T348 B348     padding 0px    track 390px
```

Centred on both axes. **Not a mobile bug** — production is serving a pre-fix bundle, and desktop
prod is broken the same way. Once this merges, an App Prod dispatch against `mainline` ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
