### PR TITLE
Anchor sub-issue discovery on the Branch line, not on prose

### DIFF
--- a/packages/claude-team/hooks/file-sub-issues.py
+++ b/packages/claude-team/hooks/file-sub-issues.py
@@ -4,8 +4,14 @@ milestone down.
 
 Children are DISCOVERED, not declared. This used to read a machine-readable manifest the
 model left in a comment; across nine epics it wrote one exactly once, so the hook silently
-filed nothing. The anchor is now the reference the Architect must already put in every
-child's body — `epic #N` or `story #N`.
+filed nothing.
+
+⚠️ THE ANCHOR IS THE `Branch:` LINE, not prose. It replaced an `epic #N`/`story #N` reference
+that read as reliable and was not: no prompt ever required it, so a run that omitted it filed
+nothing and said nothing. A task's Branch line cannot be skipped — routing reads it, so a task
+without one does not work at all — and its leading number is the story. The prose reference is
+still honoured, because it is the only anchor an EPIC has: a story's Branch line names itself,
+not its epic. See claims_parent.
 
 A manifest is still honoured when one exists, unioned with what was discovered, so epics
 decomposed under the old contract keep working.
@@ -46,7 +52,7 @@ if manifests:
 #
 # Three markers, all required:
 #   1. the author is a Bot — the Architect creates sub-issues through the action
-#   2. a reference to this parent, as `epic #<N>` or `story #<N>`
+#   2. the body claims this parent — see claims_parent below
 #   3. a number above the parent's
 #
 # The body markers alone are not enough in a repo that documents its own conventions: a
@@ -64,12 +70,34 @@ listing = team.gh_json(
 ) or []
 # the trailing (non-digit|end) stops `epic #412` from matching `epic #4123`
 refers = re.compile(rf"(?i)(epic|story) +#{ISSUE}([^0-9]|$)")
+
+
+def claims_parent(body: str) -> bool:
+    """Two anchors, unioned. The Branch line is the reliable one.
+
+    ⚠️ THE PROSE REFERENCE IS NOT REQUIRED OF THE ARCHITECT ANYWHERE. Anchoring on it alone is
+    the same mistake one level up from the manifest this hook already abandoned: a model-written
+    marker that no prompt demands. Story #515's four tasks each carried both stamped lines and
+    were all bot-authored, and every filter passed except this one — so nothing was filed,
+    sub_issues came back empty, and log-to-story reported "no tasks" with nothing to signal it.
+
+    The Branch line cannot be skipped: routing itself reads it, so a task without one does not
+    work at all. Its leading number is the story.
+
+    ⚠️ It resolves STORY -> TASK ONLY. A story's own Branch line names *itself*, not its epic,
+    so an epic has nothing but the prose to go on — which is why both anchors stay. That
+    asymmetry also means this can never adopt a story as its own child: the `number > parent`
+    bound already excludes the parent itself.
+    """
+    return team.story_from_branch(team.branch_line(body)) == str(ISSUE) or bool(refers.search(body))
+
+
 discovered = sorted(
     i["number"] for i in listing
     if not i.get("pull_request")
     and i.get("number", 0) > int(ISSUE)
     and (i.get("user") or {}).get("type") == "Bot"
-    and refers.search(i.get("body") or "")
+    and claims_parent(i.get("body") or "")
 )
 if discovered:
     print(f"discovered for #{ISSUE}:", " ".join(str(d) for d in discovered))


### PR DESCRIPTION
## Summary

`file-sub-issues.py` discovered a parent's children by looking for the prose reference
`epic #N` / `story #N`. **No prompt ever required that prose**, so a run that omitted it filed
nothing — and said nothing.

Closes #604.

Story #515's four tasks each carried both stamped lines and were all `claude[bot]`-authored.
Every filter passed except the prose one:

```
#565  — no 'story #N' reference     Branch: 515-need-to-addenable-phase-mode   claude[bot]
#567  — no reference                Branch: 515-need-to-addenable-phase-mode   claude[bot]
#568  — no reference                Branch: 515-need-to-addenable-phase-mode   claude[bot]
#569  — no reference                Branch: 515-need-to-addenable-phase-mode   claude[bot]
```

So `sub_issues(515)` returned **0**, `log-to-story` reported *"#515 has no tasks — nothing to
order"*, and the story had no board — indistinguishable from a story that genuinely has none.

⚠️ **This is the same mistake one level up from the one the hook already fixed.** Its docstring
explains that it stopped trusting a model-written *manifest* because "across nine epics it wrote
one exactly once" — and then anchored on model-written *prose* that nothing demands.

## The fix

Anchor on the **`Branch:` line**. It cannot be skipped: routing reads it, so a task without one
does not work at all — and its leading number *is* the story. That is the rule the rest of these
hooks already follow.

⚠️ **The prose reference stays, unioned.** The branch anchor resolves **story → task only**: a
story's own Branch line names *itself*, not its epic, so an epic has nothing else to go on.
Dropping it would fix stories and silently break epics — which is the failure being fixed, in
the other direction.

The `Bot` author check and the `number > parent` bound both stay. The author check is what
stopped a meta-issue quoting the convention verbatim from being adopted as a child of the issue
it described; the bound is also what makes a parent adopting itself impossible.

## Verification

Predicate exercised against **real issues**, read-only — nothing was parented by this run:

```
  ok  #515 -> [565, 567, 568, 569]   story whose tasks carry NO prose — the reported bug
  ok  #591 -> [593, 594, 595]        story whose tasks do carry prose — no regression
  ok  #480 -> [482, 483, 484]        EPIC — only prose can resolve this
  ok  #537 -> [538, 539]             an older story
```

The epic case is the one that matters most: it proves the prose path is still load-bearing and
still works.

`py_compile` ✓ · `nx run-many --target=test` ✓ 6 projects.

⚠️ Not reachable by CI — `issues`/`issue_comment` run the workflow from the default branch. The
next Architect run on a story is the check.

## Note

#515's four tasks were parented by hand before this, so the story board works now regardless.
This stops the next one silently having none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
