### PR TITLE
Anchor the Branch and Role stamps to a line

### DIFF
--- a/packages/claude-team/hooks/team.py
+++ b/packages/claude-team/hooks/team.py
@@ -97,8 +97,22 @@ def parent(number: str | int) -> str | None:
 
 # ── the conventions the Architect writes into an issue ──────────────────────────────────
 
-_BRANCH = re.compile(r"branch:\s*`([^`]+)`", re.IGNORECASE)
-_ROLE = re.compile(r"role:\s*`?([a-z]+)`?", re.IGNORECASE)
+# ⚠️ ANCHORED TO A LINE, and that is the whole point. Unanchored, these matched the first
+# occurrence ANYWHERE in a body — so a task that mentioned a sibling's role in prose routed to
+# the wrong one. #607 is stamped `implementor` and read as `tester`, because two earlier lines
+# said "a separate task (Role: tester) depends on this". The Tester writes no production code,
+# so it would have reported that it could not do the work and the story would have stalled with
+# nothing obviously broken.
+#
+# ⚠️ This gets MORE likely as the Architect gets better: cross-referencing sibling tasks is good
+# issue-writing that happens to poison an unanchored parser.
+#
+# Bold is optional on purpose. Every stamp in practice is written `**Role: x**`, so requiring
+# the markers would work — but the defect is mid-line matching, and anchoring alone cures it.
+# Demanding `**` would be a second, unrelated tightening that turns a bold-less stamp into a
+# silent mis-route instead of a readable one.
+_BRANCH = re.compile(r"^\s*\*{0,2}branch:\s*`([^`]+)`", re.IGNORECASE | re.MULTILINE)
+_ROLE = re.compile(r"^\s*\*{0,2}role:\s*`?([a-z]+)`?", re.IGNORECASE | re.MULTILINE)
 
 
 def branch_line(body: str) -> str:


### PR DESCRIPTION
## Summary

`role_stamp` and `branch_line` searched **anywhere** in a body and took the first hit, so a task
that mentions a sibling's role in prose routes to the wrong role.

Closes #609.

```
#607, stamped implementor:
  line 69   …a separate task (Role: tester) depends on this.
  line 84   Adding e2e coverage — a separate task (Role: tester) covers it…
  line 99   **Role: implementor**            ← the real stamp, never reached
```

`delegate.py` routes on that, so labelling #607 would have sent the **Tester** at an implementor
task — a role that writes no production code, so it would report it could not do the work while
nothing looked broken.

⚠️ **Two real instances, not one.** #594 ("Center the shared Modal", stamped `designer`) also
read as `tester`. It never bit only because that work was done by hand.

⚠️ **`branch_line` had the identical exposure** and had simply never been hit — except that two
of my own issue bodies quoting this code parsed a sentence fragment as a branch name:

```
#511  branch = ' parsing (3), story derivation (3). ⚠️ Those copies must not drift — '
#604  branch = ' line**, which every task must carry for routing to\nwork at all…'
```

⚠️ **This gets more likely as the Architect gets better.** Cross-referencing sibling tasks is
good issue-writing that happens to poison an unanchored parser.

## The change

```python
_BRANCH = re.compile(r"^\s*\*{0,2}branch:\s*`([^`]+)`", re.IGNORECASE | re.MULTILINE)
_ROLE   = re.compile(r"^\s*\*{0,2}role:\s*`?([a-z]+)`?", re.IGNORECASE | re.MULTILINE)
```

**Bold stays optional deliberately.** Every stamp in the repo is written `**Role: x**` — 40
branch, 28 role, no exceptions — so requiring the markers would work. But the defect is
*mid-line matching*, and anchoring alone cures it. Demanding `**` would be a second, unrelated
tightening that turns a bold-less stamp into a silent mis-route instead of a readable one.

## Verification

Old vs new across **every issue in the repo**, not sample strings:

- **33** issues carrying a stamp parse identically.
- **No open issue changes its resolved story.** Every `story` column is unchanged.
- Every open role change is a correction:

```
  #607  'tester' -> 'implementor'   the reported bug
  #600  'writer' -> ''              a STORY has no role stamp by design; it was reading prose
  #480  'implementor' -> ''         epic — no branch, so rule 3 fires first; never consulted
  #484  'implementor' -> ''         same
  #609  'tester' -> ''              this issue, whose body quotes the broken lines
```

⚠️ Historical issues lose a branch value: pre-convention ones that read `mainline` (which
already resolved to no story, so nothing downstream changes) or a story branch from an older
format. **All closed.** No open issue loses one.

`py_compile` ✓ · `nx run-many --target=test` ✓ 6 projects.

⚠️ Not reachable by CI — `issues`/`issue_comment` run the workflow from the default branch.

## Also

#607's prose is being made unambiguous separately, so the issue reads correctly however it is
parsed — the stamp itself was always right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
