### PR TITLE
Link a story's PR, state sequencing, and trace every status comment

### DIFF
--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -56,6 +56,29 @@ so, which is why `sync-kind-label.py` only ever adds and never removes.
 its tasks. It is what an author bases on and merges back into, never a branch for the task
 itself. Anything deriving a story from a branch name reads that prefix.
 
+⚠️ **A story's Branch line carries a compare link**, appended by `ensure-story-branch.py` after
+the closing backtick, so opening its PR is one click instead of a walk through the UI. One link
+serves the branch's whole life — GitHub redirects a compare URL to the existing PR once one is
+open. ⚠️ The link sits **outside** the backticks because `branch_line` is anchored and captures
+only what is between them; that is deliberate, not luck, and trailing text must stay outside.
+
+## Sequencing
+
+⚠️ **Stories are independent; a story's tasks are ordered.** Two different defaults, and each
+must be stated where it can be seen:
+
+- **Between stories** — independent unless the **epic's own body** says otherwise. A dependency
+  written only in the dependent story is not enough: #603's body opened with "Depends on #602
+  landing first", the epic said nothing, #603's tasks were started while #602's PR was open, and
+  its Tester found no feature to test.
+- **Within a story** — its tasks run in order, and the story says so. A hook already derives the
+  order from `(phase, issue number)`; the sentence is for the human deciding what to trigger.
+
+⚠️ **"Depends on" means MERGED.** A story whose tasks are all closed but whose PR is open has
+delivered nothing to any other branch — which is why the epic's work log carries a **landed**
+column beside the task count. `2/2 tasks` and `PR #629 open` are different facts, and only
+showing the first is what allowed this to happen.
+
 ⚠️ **Branch creation is scripted, not prompted** — the last load-bearing thing a model owned,
 and it failed about half the time. The host action mints its own branch for an issue trigger
 and injects *"You are already on the correct branch. Do not create a new branch"*, which

--- a/packages/claude-team/hooks/delegate.py
+++ b/packages/claude-team/hooks/delegate.py
@@ -61,7 +61,7 @@ def unroutable(reason: str) -> None:
             "issue", "comment", NUMBER, "--repo", team.REPO,
             "--body",
             f"🔔 I could not work out which role should handle this — {reason}. "
-            "Name one explicitly with `@claude/<role>`.",
+            "Name one explicitly with `@claude/<role>`." + team.run_footer(),
         )
     emit()
     raise SystemExit(0)

--- a/packages/claude-team/hooks/ensure-story-branch.py
+++ b/packages/claude-team/hooks/ensure-story-branch.py
@@ -29,11 +29,46 @@ them — the failure this hook exists to prevent, inflicted by the fix for it.
 """
 
 import os
+import re
 
 import team
 
 ISSUE = os.environ.get("ISSUE", "")
 KIND = os.environ.get("KIND", "")
+
+
+def link_branch_line(branch: str, default: str) -> None:
+    """Append a compare link to the Branch line, so opening the story's PR is one click.
+
+    ⚠️ AFTER the closing backtick, never inside it. `team.branch_line` is anchored to the start
+    of a line and captures only what sits between the backticks, so trailing text is invisible
+    to it — a property to preserve deliberately, not to rely on by accident.
+
+    Idempotent, because the Architect can be re-run on a story and a second link is noise.
+
+    One link serves the whole life of the branch: GitHub redirects a compare URL to the existing
+    PR once one is open, so this is not replaced when open-story-pr.py opens the story's PR.
+    """
+    body = team.issue_body(ISSUE)
+    if "/compare/" in body:
+        print("the Branch line already carries its link")
+        return
+
+    url = f"https://github.com/{team.REPO}/compare/{default}...{branch}?expand=1"
+    # a function as the replacement, so nothing in the URL is read as a backreference
+    updated, count = re.subn(
+        rf"^(\s*\*{{0,2}}branch:\s*`{re.escape(branch)}`\*{{0,2}})",
+        lambda m: f"{m.group(1)} · [open its PR]({url})",
+        body, count=1, flags=re.IGNORECASE | re.MULTILINE,
+    )
+    if not count:
+        team.warn(f"could not find #{ISSUE}'s Branch line to link")
+        return
+
+    if team.gh("issue", "edit", str(ISSUE), "--repo", team.REPO, "--body", updated) is not None:
+        print(f"linked the Branch line -> {url}")
+    else:
+        team.warn(f"could not write the PR link onto #{ISSUE}'s Branch line")
 
 if not team.REPO:
     team.fail("REPO is required")
@@ -56,15 +91,17 @@ if not named:
     )
     raise SystemExit(0)
 
-if team.gh("api", f"repos/{team.REPO}/branches/{named}") is not None:
-    print(f"branch {named} already exists — leaving it alone")
-    raise SystemExit(0)
-
 default = (
     team.gh_json("repo", "view", team.REPO, "--json", "defaultBranchRef") or {}
 ).get("defaultBranchRef", {}).get("name")
 if not default:
-    team.warn(f"could not read the default branch, so {named} was not created")
+    team.warn(f"could not read the default branch, so nothing could be done for {named}")
+    raise SystemExit(0)
+
+# Resolved BEFORE the exists check, so a re-run on an already-cut story still gets its link.
+if team.gh("api", f"repos/{team.REPO}/branches/{named}") is not None:
+    print(f"branch {named} already exists — leaving it alone")
+    link_branch_line(named, default)
     raise SystemExit(0)
 
 head = team.gh_json("api", f"repos/{team.REPO}/git/ref/heads/{default}") or {}
@@ -84,3 +121,4 @@ if team.gh(
     raise SystemExit(0)
 
 print(f"created branch {named} at {default}@{sha[:7]} — empty, ready for its first task")
+link_branch_line(named, default)

--- a/packages/claude-team/hooks/log-to-epic.py
+++ b/packages/claude-team/hooks/log-to-epic.py
@@ -115,7 +115,32 @@ else:
         note = " — label it `@claude` and the Architect will shape it"
     next_line = f"**#{nxt['number']} — {nxt.get('title','')}**  \nnext open {scope}{note}"
 
-table = ["| story | state | tasks |", "|---|---|---|"]
+def landed(number: str | int) -> str:
+    """Whether a story's work is actually IN the default branch, which is not the same question
+    as whether its tasks are closed.
+
+    ⚠️ THIS COLUMN EXISTS BECAUSE THE TASK COUNT WAS READ AS "DONE". An epic showed
+    `#602 … | ⬜ open | 2/2` — every task closed — while its PR was still open, so the props a
+    dependent story needed existed on no branch that story could see. The dependent story was
+    started anyway and its Tester found nothing to test. Task completeness and landedness are
+    different facts; only one of them was on the board.
+
+    Derived from the story's own Branch line and GitHub's PR state — never from prose.
+    """
+    branch = team.branch_line(team.issue_body(number))
+    if not branch:
+        return "no branch"
+    prs = team.gh_json(
+        "pr", "list", "--repo", team.REPO, "--head", branch, "--state", "all",
+        "--json", "number,state",
+    ) or []
+    if not prs:
+        return "no PR yet"
+    pr = prs[0]
+    return f"PR #{pr['number']} {(pr.get('state') or '').lower()}"
+
+
+table = ["| story | state | tasks | landed |", "|---|---|---|---|"]
 for story in team.sub_issues(EPIC):
     kids = team.sub_issues(story["number"])
     if not kids:
@@ -125,7 +150,10 @@ for story in team.sub_issues(EPIC):
         open_ns = " ".join(f"#{k['number']}" for k in kids if k.get("state") == "open")
         counts = f"{done}/{len(kids)}" + (f" · open: {open_ns}" if open_ns else "")
     mark = "✅" if story.get("state") == "closed" else "⬜"
-    table.append(f"| #{story['number']} {story.get('title','')} | {mark} {story.get('state','')} | {counts} |")
+    table.append(
+        f"| #{story['number']} {story.get('title','')} | {mark} {story.get('state','')} "
+        f"| {counts} | {landed(story['number'])} |"
+    )
 
 # carry the previous Recent lines forward
 previous: list[str] = []
@@ -165,7 +193,7 @@ body = "\n".join(
     ]
 ) + "\n"
 
-if team.upsert_comment(EPIC, MARKER, body):
+if team.upsert_comment(EPIC, MARKER, body + team.run_footer()):
     print(f"updated the work log on epic #{EPIC}")
 else:
     team.warn(f"could not update the work log comment on epic #{EPIC}")

--- a/packages/claude-team/hooks/log-to-story.py
+++ b/packages/claude-team/hooks/log-to-story.py
@@ -95,7 +95,7 @@ lines += [
     "Rewritten automatically whenever a task changes state.",
 ]
 
-if team.upsert_comment(STORY, MARKER, "\n".join(lines) + "\n"):
+if team.upsert_comment(STORY, MARKER, "\n".join(lines) + "\n" + team.run_footer()):
     print(f"updated the task order on story #{STORY}")
 else:
     team.warn(f"could not update the task order on #{STORY}")

--- a/packages/claude-team/hooks/post-handoff.py
+++ b/packages/claude-team/hooks/post-handoff.py
@@ -48,7 +48,7 @@ body = (
     f"```json\n{HANDOFF}\n```\n"
 )
 
-if team.upsert_comment(target, marker, body):
+if team.upsert_comment(target, marker, body + team.run_footer()):
     print(f"posted the handoff for #{ISSUE} on story #{target}")
 else:
     team.warn(f"could not post the handoff on #{target}")

--- a/packages/claude-team/hooks/team.py
+++ b/packages/claude-team/hooks/team.py
@@ -198,6 +198,26 @@ def story_from_branch(branch: str) -> str:
 # ── one marked comment, rewritten in place ──────────────────────────────────────────────
 
 
+def run_footer() -> str:
+    """A trailing line linking the Actions run that wrote a comment, or "" outside Actions.
+
+    ⚠️ Every hook-written comment carries this. The model's own tracking comment already links
+    its job, so a run that produced BOTH reads as one story; a status comment without it is a
+    dead end — the maintainer sees what changed and has no way back to why.
+
+    `GITHUB_REPOSITORY` and `GITHUB_RUN_ID` are set for every step, so nothing has to be
+    threaded through the workflow. Empty when run by hand, which keeps local output clean.
+
+    These comments are rewritten in place, so the link always names the run that LAST touched
+    it — which is the run whose reasoning explains what is on screen.
+    """
+    repo = os.environ.get("GITHUB_REPOSITORY") or REPO
+    run = os.environ.get("GITHUB_RUN_ID")
+    if not (repo and run):
+        return ""
+    return f"\n---\n<sub>Written by [this run](https://github.com/{repo}/actions/runs/{run}).</sub>\n"
+
+
 def upsert_comment(number: str | int, marker: str, body: str) -> bool:
     """Create or update the single comment carrying `marker` on an issue or PR.
 

--- a/packages/claude-team/prompts/architect.md
+++ b/packages/claude-team/prompts/architect.md
@@ -32,6 +32,24 @@ Rewrite it so a reader knows what "done" looks like and why it matters, and say 
 and what is deliberately out. Break it into **stories**, each one shippable with its own PR.
 ⚠️ Do **not** cut a branch: epics have none.
 
+⚠️ **Say how the stories are sequenced, in the EPIC's own body.** The default is that they are
+**independent** — any of them can be picked up in any order — and a reader is entitled to assume
+that unless you say otherwise. So when one story genuinely depends on another, that dependency
+is something you must write down, at the top, naming both:
+
+```
+**Sequencing.** #602 must land before #603 — #603 wires the callbacks #602 adds.
+Otherwise independent.
+```
+
+⚠️ **Writing it only in the dependent story is not enough**, and that has already cost a run:
+#603's body opened with "Depends on #602 landing first", the epic said nothing, and #603's tasks
+were started while #602's PR was still open — its Tester found no feature to test.
+
+⚠️ **"Depends on" means MERGED, not "its tasks are closed."** A story whose tasks are all done
+but whose PR is open has delivered nothing to any other branch. Say *landed*, and say which
+branch needs it.
+
 ⚠️ **Leave an epic saying it is one.** Title it `Epic: <…>`, and never strip an existing
 `Epic` prefix or `epic` label — those are the classification, and removing one silently
 demotes the issue on its next run. The label is applied for you, from the title.
@@ -124,6 +142,14 @@ fresh in front of you.
 
 ⚠️ **A task you cannot cleanly assign should be split, not guessed at.** If a task spans two
 roles' territory, that is a sign it is two tasks.
+
+⚠️ **A story's tasks ARE sequenced — that is the default, and the opposite of the story rule.**
+Stories are independent unless the epic says otherwise; a story's tasks are ordered unless you
+say otherwise. Say so in the story body, so nobody has to infer it from the numbering:
+
+```
+**Sequencing.** Its tasks run in order: #606, then #607, then #608.
+```
 
 ⚠️ **Create tasks in the order they should be run.** That order is read, not just described:
 a hook lists the story's tasks by `(phase, issue number)` and names the next one to trigger,


### PR DESCRIPTION
## Summary

Three gaps that together sent #618's Tester at a feature that did not exist.

Closes #632. Closes #633.

### 1. The story branch links its PR

`ensure-story-branch.py` appends a compare link to the Branch line:

```
**Branch: `603-brewtimer-…`** · [open its PR](…/compare/mainline...603-brewtimer-…?expand=1)
```

⚠️ **After the closing backtick, never inside it.** `branch_line` is anchored and captures only
what sits between the backticks, so trailing text is invisible to it — a property preserved
deliberately. One link serves the branch's whole life: GitHub redirects a compare URL to the
existing PR once one is open. Idempotent, and a re-run on an already-cut story now gets its link
too (the default branch is resolved before the exists check).

### 2. The Architect states sequencing — your rule, written down

> Stories are independently sequenced unless indicated otherwise; the tasks of a story are
> generally always sequenced.

Each default is now stated where it can be seen: story dependencies in the **epic's own body**,
task ordering in the story's.

⚠️ **Writing it only in the dependent story is not enough, and that is what happened.** #603
opened with *"Depends on #602 landing first"*, the epic said nothing, and #603's tasks were
started while #602's PR was open.

⚠️ **"Depends on" means MERGED**, not "its tasks are closed" — the prompt now says so explicitly.

### 3. The epic's work log distinguishes done from landed

The board showed this, and it is what misled:

```
| #602  BrewTimer: add unified quick-action UI | ⬜ open | 2/2 |
```

`2/2` reads as finished. But PR #629 was open, so the props #603 wires existed on **no branch it
could see**. The table gains a `landed` column, derived from each story's Branch line and
GitHub's PR state — never from prose. Run against the real epic:

```
  #602  tasks 2/2   landed: PR #629 open
  #603  tasks 2/3   landed: PR #630 open
```

That board would have said "don't start #603 yet".

### 4. Every status comment links its run

The model's tracking comment already ends with `[View job]`. The **hook-written** comments — the
story table, the epic work log, the handoff, the unroutable notice — carried nothing, which is
backwards: those are the ones read as *status*, and they had no route back to the reasoning.

`team.run_footer()` builds it from `GITHUB_REPOSITORY` and `GITHUB_RUN_ID`, both set for every
step, so nothing is threaded through the workflow. They are rewritten in place, so the link
names the run that **last** touched the comment — the one whose reasoning explains what is on
screen now.

## Verification

Exercised, not read:

```
branch_line on a LINKED line   '603-foo'  → story '603'      (plain, linked, linked+role below)
substitution on #603's real body           1 change, rest of body byte-identical, reparses clean
landed() against epic #601                 #602 → "PR #629 open"   #603 → "PR #630 open"
run_footer() in Actions                    "\n---\n<sub>Written by [this run](…/runs/…).</sub>\n"
run_footer() run by hand                   ""
```

⚠️ One thing I checked because it would have been silent: `log-to-epic` carries its Recent lines
forward by filtering `startswith("- ")`, and the new footer opens with `---`. No space after the
dash, so it is not swept into the history.

`py_compile` on all six touched hooks ✓ · `nx run-many --target=test` ✓ 6 projects.

⚠️ Not reachable by CI — `issues`/`issue_comment` run the workflow from the default branch. The
next Architect run is the check: a linked Branch line, sequencing stated on the epic, and a
footer on the story log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
