### PR TITLE
Put a shaped story and its tasks on the board as Todo

### DIFF
--- a/.github/agent-prompts/_shared.md
+++ b/.github/agent-prompts/_shared.md
@@ -18,7 +18,9 @@ Read the repo-root `CLAUDE.md` first; each package has its own, loaded when you 
 - ⚠️ **No data migrations and no backfill shims.** Dev assumes a pristine local store
   (`/?purge=true` resets it). A stale stored record may fail to render; it may not take a
   screen down with it. Containment, never repair.
-- Add issues and PRs to the project: `gh project item-add 4 --owner "@me" --url <url>`.
+- ⚠️ **Do not try to add anything to the project board.** You have no token that can reach
+  it — `gh project item-add` fails with *"Could not resolve to a ProjectV2"* and costs you a
+  turn. A scripted hook places what you create.
 - Commit subjects are plain imperative, no Conventional Commits prefix.
 - Run one command per Bash call — chaining trips the permission check. A denied tool call
   is settled; note it and move on.

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -77,7 +77,8 @@ run-name: >-
 #   delegate job          acknowledge.py           reacts 👀 so the trigger is visibly received
 #   delegate job          delegate.py              picks the role from issue state
 #   pre   every role      stamp-role-label.py      stamps @claude/<role> on the issue or PR
-#   pre   authors job     set-issue-status.py      sets the issue's board Status (STATUS input)
+#   pre   authors job     set-issue-status.py      board: place + set Status (STATUS input)
+#   post  architect       set-issue-status.py      places the story and its tasks as Todo
 #   post  architect       ensure-story-branch.py   creates the story's branch if it is missing
 #   post  architect       sync-kind-label.py       applies the epic/bug label its title announces
 #   post  architect       file-sub-issues.py       parents stories to epics, tasks to stories
@@ -348,6 +349,25 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
         run: "$RUNNER_TEMP/agent-bin/file-sub-issues.py"
+      # ⚠️ AFTER file-sub-issues, which is what makes the children discoverable — this places
+      # them too, and sub_issues() would return nothing if it ran first.
+      # ⚠️ PROJECTS_TOKEN is safe here on the same argument as the authors job: step env is
+      # per-step, so the model step in this job cannot read it.
+      - name: Put the story and its tasks on the board
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          PROJECT_OWNER: "@me"
+          PROJECT_NUMBER: "4"
+          STATUS: "Todo"
+          # never knock an in-flight story back — a re-shape must not undo In Progress
+          ONLY_IF_UNSET: "true"
+          # the tasks it just cut, or an epic's stories
+          INCLUDE_SUB_ISSUES: "true"
+        run: "$RUNNER_TEMP/agent-bin/set-issue-status.py"
   # ── Authors: Implementor | Designer | Tester | Writer ──────────────────────────
   # The four authoring roles as gated steps in one job. ⚠️ EXACTLY ONE RUNS PER TRIGGER —
   # `delegate.py` emits a single role, and each step gates on it. They share a job to share

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,9 +265,11 @@ What is BrewDocs-specific:
 - ⚠️ **`PROJECTS_TOKEN` appears in `close-merged-work.py` and `set-issue-status.py`, and
   nowhere else.** It is a long-lived classic PAT needing `project` **and** `read:org` (a
   fine-grained token cannot reach user-owned Projects v2), covering every project the
-  maintainer owns. It is safe only because both are *scripted* steps and step env is
-  per-step — the model step in the same job cannot read it. ⚠️ Never add it to a job whose
-  model step holds `Bash(gh:*)`.
+  maintainer owns. It is safe because it lives in *step* env on a **scripted** step, and step env is
+  per-step — the model step beside it cannot read it, whatever tools that model holds. ⚠️ Never
+  put it in **job**-level env, and never on a step a model can influence. (An earlier version of
+  this line said "never add it to a job whose model step holds `Bash(gh:*)`" — that never
+  described the repo, since the authors job's Implementor holds exactly that.)
 - The board is **project #4**: `gh project item-add 4 --owner "@me" --url <url>`.
 - The handoff schema is
   [`packages/claude-team/schemas/handoff.json`](packages/claude-team/schemas/handoff.json);

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -306,7 +306,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 | `acknowledge.py` | the router job, first | reacts 👀 so the trigger is visibly received |
 | `delegate.py` | the router job | picks the role from issue state — routing is scripted, not judged |
 | `stamp-role-label.py` | pre, every role | stamps `@claude/<role>` on the triggering issue or PR |
-| `set-issue-status.py` | pre, authors | sets the issue's board Status; the column is an input |
+| `set-issue-status.py` | pre, authors + post, Architect | puts an issue **on** the board and sets its Status; column and flags are inputs |
 | `ensure-story-branch.py` | post, Architect | creates the story's branch if it is missing |
 | `sync-kind-label.py` | post, Architect | applies the `epic`/`bug` label an issue title announces |
 | `file-sub-issues.py` | post, Architect | parents stories to their epic, tasks to their story |

--- a/packages/claude-team/hooks/set-issue-status.py
+++ b/packages/claude-team/hooks/set-issue-status.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-"""Sets an issue's Status on the project board.
+"""Ensures an issue is ON the project board, with the Status it should have.
 
 Parameterised on STATUS so one hook serves every caller — an author starting work, and an
 issue arriving on the board. Two hooks running the same GraphQL against the same field would
 drift the moment one is fixed and the other is not.
 
 PROJECT_OWNER, PROJECT_NUMBER and STATUS are INPUTS: the mechanism is package-side, the
-values belong to the consuming repo.
+values belong to the consuming repo. ONLY_IF_UNSET and INCLUDE_SUB_ISSUES tune it for the two
+callers — an Architect placing what it just shaped, and an author claiming a task.
 
 This is one of the two places PROJECTS_TOKEN may appear. Step env is per-step, so a model
 step in the same job cannot read it.
@@ -17,6 +18,10 @@ import os
 import team
 
 STATUS = os.environ.get("STATUS") or team.fail("STATUS is required")
+# write the status only when the item has none — see place()
+ONLY_IF_UNSET = os.environ.get("ONLY_IF_UNSET", "").lower() == "true"
+# also place the issue's children: a story's tasks, or an epic's stories
+INCLUDE_SUB_ISSUES = os.environ.get("INCLUDE_SUB_ISSUES", "").lower() == "true"
 ISSUE = os.environ.get("ISSUE", "")
 OWNER = os.environ.get("PROJECT_OWNER", "")
 PROJECT = os.environ.get("PROJECT_NUMBER", "")
@@ -31,11 +36,6 @@ if not ISSUE:
 token = os.environ.get("PROJECTS_TOKEN", "")
 if not token:
     team.warn(f"PROJECTS_TOKEN is not set — cannot set #{ISSUE} to {STATUS}.")
-    raise SystemExit(0)
-
-# don't resurrect finished work: a re-run on a closed issue leaves the board alone
-if team.issue_state(ISSUE) != "OPEN":
-    print(f"#{ISSUE} is closed — leaving its board status alone.")
     raise SystemExit(0)
 
 os.environ["GH_TOKEN"] = token
@@ -63,24 +63,63 @@ if not option:
 listing = team.gh_json(
     "project", "item-list", PROJECT, "--owner", OWNER, "--format", "json", "--limit", "500"
 ) or {}
-item = next(
-    (
-        i for i in listing.get("items", [])
-        if (i.get("content") or {}).get("type") == "Issue"
-        and (i.get("content") or {}).get("number") == int(ISSUE)
-    ),
-    None,
-)
-if not item:
-    team.warn(f"Issue #{ISSUE} is not on project {PROJECT} — skipping.")
-    raise SystemExit(0)
+on_board = {
+    (i.get("content") or {}).get("number"): i
+    for i in listing.get("items", [])
+    if (i.get("content") or {}).get("type") == "Issue"
+}
 
-if item.get("status") == STATUS:
-    print(f"#{ISSUE} is already {STATUS}.")
-    raise SystemExit(0)
 
-team.gh(
-    "project", "item-edit", "--id", item["id"], "--project-id", project["id"],
-    "--field-id", status_field["id"], "--single-select-option-id", option["id"],
-)
-print(f"#{ISSUE} -> {STATUS}")
+def place(number: str | int) -> None:
+    """Put an issue on the board and set its Status.
+
+    ⚠️ ADDING IS PART OF THE JOB, and used to be nobody's. This warned "not on project —
+    skipping" and left it there, while the only other candidate — a model told to run
+    `gh project item-add` — has no PROJECTS_TOKEN and cannot authenticate. So an
+    Architect-created issue reached the board only if the maintainer added it by hand. "Set the
+    status" and "be on the board" are one intent; splitting them across a hook that would not
+    add and a model that could not is what left the gap.
+    """
+    if team.issue_state(number) != "OPEN":
+        print(f"#{number} is closed — leaving its board status alone.")
+        return
+
+    item = on_board.get(int(number))
+    if not item:
+        added = team.gh_json(
+            "project", "item-add", PROJECT, "--owner", OWNER,
+            "--url", f"https://github.com/{team.REPO}/issues/{number}", "--format", "json",
+        )
+        if not (added or {}).get("id"):
+            team.warn(f"could not add #{number} to project {PROJECT}")
+            return
+        print(f"#{number} -> added to project {PROJECT}")
+        item = {"id": added["id"], "status": None}
+
+    current = item.get("status")
+    if current == STATUS:
+        print(f"#{number} is already {STATUS}.")
+        return
+    # ⚠️ The Architect can be re-run on a story that is already In Progress. Without this the
+    # re-shape would knock live work back to Todo, so the placing caller sets the flag and the
+    # authors' caller does not — moving to In Progress *should* override whatever was there.
+    if ONLY_IF_UNSET and current:
+        print(f"#{number} is already {current} — leaving it.")
+        return
+
+    if team.gh(
+        "project", "item-edit", "--id", item["id"], "--project-id", project["id"],
+        "--field-id", status_field["id"], "--single-select-option-id", option["id"],
+    ) is None:
+        team.warn(f"could not set #{number} to {STATUS}")
+        return
+    print(f"#{number} -> {STATUS}")
+
+
+place(ISSUE)
+
+# An Architect run produces a story AND its tasks (or an epic and its stories). Placing only the
+# triggering issue would leave everything it just created invisible on the board.
+if INCLUDE_SUB_ISSUES:
+    for child in team.sub_issues(ISSUE):
+        place(child["number"])


### PR DESCRIPTION
## Summary

Ask: the Architect should ensure a story lands on the board as **Todo**.

⚠️ **Nothing put it there at all.** Two halves failed in sequence:

- The model is told to run `gh project item-add 4 …`, but the model step has **no
  `PROJECTS_TOKEN` by design**. The Architect on #537 reported it verbatim: *"failed for both
  tasks (`Could not resolve to a ProjectV2 with the number 4`) — the model step doesn't carry
  `PROJECTS_TOKEN` by design"*.
- `set-issue-status.py`, which *does* hold the token, refused: `if not item: warn("not on
  project — skipping")`.

So an Architect-created issue reached the board only if you added it by hand — and every run
burned a turn on a command that cannot succeed.

Closes #640.

## The change

**"Set the status" and "be on the board" are one intent.** The hook now adds the item when it is
missing, and takes two flags for its two callers:

| flag | Architect | authors |
|---|---|---|
| `ONLY_IF_UNSET` | `true` | *(off)* |
| `INCLUDE_SUB_ISSUES` | `true` | *(off)* |

⚠️ **`ONLY_IF_UNSET` is the one that matters.** The Architect can be re-run on a story that is
already **In Progress** — without it, re-shaping would knock live work back to Todo. The authors'
caller deliberately leaves it off, because moving to In Progress *should* override whatever was
there.

⚠️ **`INCLUDE_SUB_ISSUES`** places the children too. A run produces a story *and its tasks* (or
an epic and its stories); placing only the trigger would leave everything it just created
invisible.

⚠️ **The step runs AFTER `file-sub-issues`** — that is what makes the children discoverable, and
`sub_issues()` returns nothing before it. I had it in the wrong position first and the step order
is now asserted, not eyeballed.

## Two corrections carried along

- **The overlay told every role to add things to the board.** Removed — asking a model to run a
  command it cannot authenticate is the shape this repo keeps deleting.
- **The root `CLAUDE.md` rule was wrong.** It said *"never add `PROJECTS_TOKEN` to a job whose
  model step holds `Bash(gh:*)`"* — which never described this repo, since the authors job's
  Implementor holds exactly that. What actually keeps it safe is **step env being per-step**, so
  the rule now says that, and says the real prohibitions: never job-level, never on a step a
  model can influence.

## Verification

```
flag parsing          Architect: ONLY_IF_UNSET=True  INCLUDE_SUB_ISSUES=True
                      authors:   both False (unset)
                      "TRUE"/"False" → True/False   (case-insensitive, safe default)

step order            … → sync-kind-label → file-sub-issues → put on the board   ← asserted

token placement       ok  scripted  architect / Put the story and its tasks on the board
                      ok  scripted  authors / Move the issue to In Progress
                      ok  scripted  merge_housekeeping / Close and file the PR's issues
                      (no job-level env, no `uses:` step)
```

`py_compile` ✓ · `nx run-many --target=test` ✓ 6 projects.

⚠️ **I could not exercise it against the real board** — the Projects GraphQL API was rate-limited
for the whole of this change (`graphql: 0/5000`), which is also why the issue and this PR were
created over REST. The board calls are unrun; the first Architect run after merge is the check.
If `Todo` is not the exact option name on project 4, the hook warns clearly rather than failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
