### PR TITLE
Label stories `story`, as epics get `epic`

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -80,7 +80,7 @@ run-name: >-
 #   pre   authors job     set-issue-status.py      board: place + set Status (STATUS input)
 #   post  architect       set-issue-status.py      places the story and its tasks as Todo
 #   post  architect       ensure-story-branch.py   creates the story's branch if it is missing
-#   post  architect       sync-kind-label.py       applies the epic/bug label its title announces
+#   post  architect       sync-kind-label.py       applies the epic/bug/story classification label
 #   post  architect       file-sub-issues.py       parents stories to epics, tasks to stories
 #   post  authors job     finish-pr.py             labels the PR, appends `Closes #<issue>`
 #   post  authors job     post-handoff.py          puts the JSON handoff on the story's ISSUE
@@ -326,9 +326,9 @@ jobs:
         run: "$RUNNER_TEMP/agent-bin/log-to-story.py"
       # ⚠️ Derived from the title the Architect had to write anyway. A `gh` call it was
       # merely asked to remember is the shape that fails.
-      # ⚠️ CLASSIFICATION labels only — `epic`/`bug`, what an issue IS. Never a routing label:
+      # ⚠️ CLASSIFICATION labels only — `epic`/`bug`/`story`, what an issue IS. Never a routing label:
       # those are the maintainer's and are a record of what has run.
-      - name: Label the issue kind from its title
+      - name: Label the issue kind
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -44,11 +44,19 @@ covering both, and it does not:
 | kind | labels | who applies | what it means |
 |---|---|---|---|
 | **routing** | the front-door label, `@claude/<role>` | the maintainer; hooks stamp the trail | what should *happen* to this issue, and what has already run |
-| **classification** | `epic`, `bug` | anyone filing; a hook derives it from the title | what this issue *is* |
+| **classification** | `epic`, `bug`, `story` | anyone filing; a hook applies it after the Architect runs | what this issue *is* |
 
 A classification label is durable and derivable, so it survives a run and nothing has to
-re-derive it. ⚠️ A plain story carries **no** classification label — that absence is what says
-so, which is why `sync-kind-label.py` only ever adds and never removes.
+re-derive it. ⚠️ **Every kind gets one, `story` included.** An earlier version left a story
+unlabelled and treated the absence as the signal — which reads fine inside a hook and badly on
+a board, where you cannot filter for "the ones with nothing". `team.kind()` still *derives*
+story from the absence of the other markers; the label is what makes that visible.
+
+⚠️ **`sync-kind-label.py` asks `kind()`, not the title.** Keying on the title worked only while
+every kind announced itself — a story has no prefix to match and would never have been labelled.
+⚠️ And it refuses to write when it cannot read the issue: `kind()` falls back to `story` on a
+failed API call exactly as it does for a plain issue, so a rate-limited minute would otherwise
+relabel an epic. It only ever adds, never removes.
 - A story owns one branch and one PR against the default branch, and it accumulates.
 - A task is a slice of a story with its own branch and its own PR **into the story branch**.
 

--- a/packages/claude-team/hooks/sync-kind-label.py
+++ b/packages/claude-team/hooks/sync-kind-label.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Post-hook for the Architect. Applies the CLASSIFICATION label an issue's title announces —
-`epic` or `bug` — and never removes one.
+"""Post-hook for the Architect. Applies the CLASSIFICATION label an issue's kind calls for —
+`epic`, `bug` or `story` — and never removes one.
 
 DERIVED FROM THE TITLE, which the Architect must write anyway. Asking the model to also
 remember a `gh` call is the shape that fails — the manifest it was told to leave got written
@@ -11,9 +11,13 @@ instruction it can skip is not.
 one. The routing labels (`@claude`, `@claude/<role>`) say what should happen to it, belong to
 the maintainer, and are a record of what has already run — nothing here touches those.
 
+⚠️ ASKS team.kind(), NOT THE TITLE. It used to read the title alone, which worked while only
+`epic` and `bug` announced themselves — a story has no title prefix to match, so it would
+never have been labelled. kind() reads label-or-title with the precedence already defined
+once, so an issue already labelled `bug` cannot also be handed `story` as a fallback.
+
 Only ever adds. If the maintainer labelled or titled something, that is the classification and
-this run keeps it. A title announcing nothing leaves the labels alone entirely: a plain story
-carries no classification label, and that absence is what says so.
+this run keeps it.
 """
 
 from __future__ import annotations
@@ -32,16 +36,14 @@ if not ISSUE:
     raise SystemExit(0)
 
 data = team.issue(ISSUE, "title", "labels")
-title = data.get("title") or ""
-
-# Same precedence as team.kind(): epic wins, so an issue titled both ways resolves one way.
-if team.titled_epic(title):
-    wanted = team.EPIC_LABEL
-elif team.titled_bug(title):
-    wanted = team.BUG_LABEL
-else:
-    print(f"#{ISSUE} announces no classification in its title — leaving its labels alone.")
+# ⚠️ Every issue has a title, so its absence means the READ failed, not that the issue is
+# plain. kind() defaults to "story" either way, and writing on that would label an epic
+# `story` for the duration of a rate limit — do nothing instead.
+if not data.get("title"):
+    team.warn(f"could not read #{ISSUE} — leaving its labels alone rather than guessing.")
     raise SystemExit(0)
+
+wanted = team.KIND_LABELS[team.kind(ISSUE, data)]
 
 if any((l.get("name") or "").lower() == wanted for l in data.get("labels", [])):
     print(f"#{ISSUE} is already labelled {wanted}.")

--- a/packages/claude-team/hooks/team.py
+++ b/packages/claude-team/hooks/team.py
@@ -128,12 +128,17 @@ def role_stamp(body: str) -> str:
 
 EPIC_LABEL = "epic"
 BUG_LABEL = "bug"
+STORY_LABEL = "story"
 
 # The CLASSIFICATION labels — what an issue *is*. Distinct from the routing labels
 # (`@claude`, `@claude/<role>`), which say what should happen to it, belong to the maintainer,
-# and are a record of what has run. Only these two are derivable from a title and safe for
-# whoever files an issue to apply.
-KIND_LABELS = {"epic": EPIC_LABEL, "bug": BUG_LABEL}
+# and are a record of what has run. These are safe for whoever files an issue to apply.
+#
+# ⚠️ EVERY KIND GETS ONE, INCLUDING `story`. An earlier version left a story unlabelled and
+# called the absence the signal — which reads fine in a hook and badly on a board, where you
+# cannot filter for "the ones with no classification". `kind()` still DERIVES story from the
+# absence of the other markers; the label is what makes that visible.
+KIND_LABELS = {"epic": EPIC_LABEL, "bug": BUG_LABEL, "story": STORY_LABEL}
 
 
 def titled_epic(title: str) -> bool:
@@ -150,7 +155,7 @@ def titled_bug(title: str) -> bool:
     return bool(re.match(r"\s*bug\b", title or "", re.IGNORECASE))
 
 
-def kind(number: str | int) -> str:
+def kind(number: str | int, data: dict | None = None) -> str:
     """Classify an issue as `epic`, `bug` or `story`. An unprocessed issue is a STORY.
 
     Each classification needs a durable marker — its label, or a title that announces it.
@@ -168,8 +173,13 @@ def kind(number: str | int) -> str:
     misfires on an ordinary sentence like "a story under the Claude Team epic", and a false
     positive makes the Architect decompose a story into sub-stories. The model weighs the
     comment against this default instead.
+
+    ⚠️ FALLS BACK TO "story" ON A FAILED READ, because issue() returns {} for both "no such
+    issue" and "the API said no" — and a story is the right default for an issue that exists.
+    A caller that WRITES based on the answer must therefore check the read itself: pass `data`
+    in and confirm it has a title first, or a rate-limited minute relabels an epic as a story.
     """
-    data = issue(number, "title", "labels")
+    data = data if data is not None else issue(number, "title", "labels")
     names = {(l.get("name") or "").lower() for l in data.get("labels", [])}
     title = data.get("title") or ""
 


### PR DESCRIPTION
## Summary

Stories now get a `story` label, the way epics get `epic`.

Closes #644.

⚠️ This **reverses** something recorded in `packages/claude-team/CLAUDE.md` yesterday: *"a plain
story carries no classification label — that absence is what says so."* True inside a hook,
useless on a board — you cannot filter for "the ones with nothing". `team.kind()` still
*derives* story from the absence of the other markers; the label is what makes that visible.

## The change

- `team.py` — `STORY_LABEL`, and `story` joins `KIND_LABELS` (which was defined and unused until
  now — this is what it was for).
- `sync-kind-label.py` — asks `team.kind()` instead of reading the title. ⚠️ Keying on the title
  only ever worked because every kind announced itself; **a story has no prefix to match** and
  would never have been labelled. `kind()` reads label-or-title with the precedence defined once,
  so an issue already labelled `bug` cannot also be handed `story` as a fallback.

## ⚠️ The hazard that change introduced — caught while testing it

`team.issue()` returns `{}` both for *"no such issue"* and *"the API refused"*, and `kind()`
falls back to `story` for either. Right for a plain issue; **wrong for a failed read.**

With the GraphQL budget exhausted, my first verification returned this:

```
#480  kind=story  -> label 'story'   Epic: title + epic label     ← wrong
#600  kind=story  -> label 'story'   bug label                    ← wrong
#537  kind=story  -> label 'story'   titled "Bug: …"              ← wrong
```

Every issue read as a story, so the hook would have relabelled an epic `story` for the duration
of a rate limit — a durable, wrong marker written because a read failed quietly.

So `kind()` takes optional pre-fetched data, and the hook fetches once, confirms a **title** came
back, and writes nothing if it did not. Every issue has a title; its absence means the read
failed, not that the issue is plain.

## Verification

⚠️ **Stubbed, not live** — the GraphQL budget was exhausted for this whole change (`0/5000`),
which is also why the issue and PR were created over REST. The shapes are what matter here:

```
  ok  epic   -> label epic    epic title + label
  ok  epic   -> label epic    epic title alone
  ok  epic   -> label epic    epic label alone
  ok  bug    -> label bug     bug title
  ok  bug    -> label bug     bug label
  ok  story  -> label story   plain -> story
  ok  epic   -> label epic    epic beats bug

  failed read: kind() still says 'story' (its documented default)
               hook checks data['title'] first -> writes nothing
```

Workflow parses, 7 architect steps. `py_compile` ✓ · `nx run-many --target=test` ✓ 6 projects.

The `story` label already exists in the repo, so nothing needs creating. The first Architect run
after merge is the live check.

## Left alone deliberately

`delegate.py` also calls `kind()`, and also gets `story` on a failed read — but it only *routes*
on the answer, and "shape it as a story" is the recoverable outcome. Writing a durable label is
the case that needed the guard. Worth revisiting separately if a rate limit ever misroutes an
epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
