### PR TITLE
Carry a run's decisions to the story, and deliver a PR follow-up's handoff

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -822,6 +822,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          # ⚠️ The PR half of the same trigger, and it is load-bearing. ISSUE is deliberately
+          # blank on a PR, and the hook used to return on that alone — so a follow-up run, which
+          # is where review feedback arrives, produced a schema-forced handoff and discarded it.
+          # STORY is resolved for a PR too (delegate.py rule 2, off the head branch), so with
+          # this the handoff and its `decisions` reach the story either way.
+          PR: ${{ github.event.issue.pull_request && github.event.issue.number || '' }}
           # where it is posted: the story's ISSUE, which always exists. The story's PR does
           # not, until the first task PR merges into its branch.
           STORY: ${{ needs.delegate.outputs.story }}

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -251,9 +251,9 @@ skip.
 
 ## The handoff between authors
 
-An author's step carries `--json-schema`, so its final message is a contract: `testingNotes`
-for the Tester, `docsCandidates` for the Writer. A hook posts it to the **story's issue** as
-one comment per task, where the Tester reads it on its own trigger. ⚠️ The Writer reads it only
+An author's step carries `--json-schema`, so its final message is a contract: `decisions` for
+the record, `testingNotes` for the Tester, `docsCandidates` for the Writer. A hook posts it to
+the **story's issue** as one comment per task, where the Tester reads it on its own trigger. ⚠️ The Writer reads it only
 on a **re-trigger** — it runs before the authors, so on its first pass the comments do not exist
 yet.
 
@@ -262,6 +262,29 @@ yet.
   entire reason this is a schema and not a prose section.
 - ⚠️ **The story's issue, not its PR.** The PR does not exist until the first task merges,
   so a handoff written during the first task would have nowhere to go.
+- ⚠️ **A PR follow-up must reach the story too, and for a long time it did not.** The workflow
+  blanks `ISSUE` on a PR trigger and the hook returned on that alone — before ever reading
+  `STORY`, which `delegate.py` rule 2 had already resolved from the head branch. So the one run
+  that carries **review feedback** produced a schema-forced handoff and dropped it. A `PR` env
+  var is the other half of the same trigger; without it `decisions` has no path on the only
+  trigger it exists for.
+- ⚠️ **`decisions` is the antidote to a review that dies in its own thread.** A maintainer
+  changes course on a PR; the issue still describes what they rejected, and nothing rewrites it.
+  The next agent reads the old plan and rebuilds the rejected thing — measured: a resolver
+  deleted on review (#626) was reinstated two PRs later (#651) by an agent reading a story that
+  still asked for it, and its author had done everything right, including leaving two 🔔
+  Maintainer heads-ups that nobody picked up. **A PR comment is not a durable artifact.** The
+  issue, the spec and the code are, and a decision reached in review lands in none of them
+  unless something puts it there.
+- ⚠️ **The decisions log APPENDS; every other hook comment upserts.** That difference is
+  deliberate, not an inconsistency. A status board or a handoff is *derived* — regenerated whole
+  each run, so replacing it loses nothing. A decision is a **record**: a PR draws several rounds
+  of review, and round two replacing round one destroys the fact the comment exists to keep. It
+  is still one comment; rounds stack inside it.
+- ⚠️ **Reporting a decision does not discharge it.** `decisions` records what changed; it does
+  not correct the specification, the acceptance criteria or the sibling task that now read the
+  old way. `supersedes` names them precisely so a human can go and fix them — a role reporting
+  a decision should also raise it where the maintainer will act on it.
 - ⚠️ **Deterministic at both ends:** the schema forces the author to produce it, the hook
   forces delivery. Neither is a model instruction. Asking a model to leave a
   machine-readable block for a later role is the version that fails.
@@ -319,7 +342,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 | `sync-kind-label.py` | post, Architect | applies the `epic`/`bug` label an issue title announces |
 | `file-sub-issues.py` | post, Architect | parents stories to their epic, tasks to their story |
 | `finish-pr.py` | post, authors | labels the PR and ensures it closes its issue |
-| `post-handoff.py` | post, authors | posts the JSON handoff to the story's issue |
+| `post-handoff.py` | post, authors | posts the JSON handoff to the story's issue, and appends its `decisions` to one running log there |
 | `log-to-story.py` | post, Architect + authors + on merge | rewrites one comment on the story listing its tasks in trigger order |
 | `log-to-epic.py` | post, authors | rewrites one rolling work-log comment on the epic |
 | `open-story-pr.py` | **on merge** | opens the story's PR once a task has landed on its branch |

--- a/packages/claude-team/hooks/post-handoff.py
+++ b/packages/claude-team/hooks/post-handoff.py
@@ -16,10 +16,13 @@ machine-readable block behind — the schema forces production, this forces deli
 
 import os
 
+import json
+
 import team
 
 HANDOFF = os.environ.get("HANDOFF", "")
 ISSUE = os.environ.get("ISSUE", "")
+PR = os.environ.get("PR", "")
 STORY = os.environ.get("STORY", "")
 ROLES = os.environ.get("ROLES", "").strip()
 
@@ -30,18 +33,66 @@ if not HANDOFF:
     print("No handoff to post — no author ran, or its step failed.")
     raise SystemExit(0)
 
-if not ISSUE:
-    print("Not triggered on an issue — nowhere to attribute a handoff.")
+# ⚠️ A PR FOLLOW-UP MUST REACH THE STORY, and for a long time it did not. This read
+# `if not ISSUE: exit` — and the workflow blanks ISSUE on a PR trigger — so the hook returned
+# before it ever looked at STORY, which `delegate.py` rule 2 had already resolved from the PR's
+# head branch. The run carrying the maintainer's review feedback therefore produced a
+# schema-forced handoff and dropped it on the floor. That is how the decision to delete
+# `nextIncompleteEquipment` (#626) reached nothing durable and was rebuilt two PRs later (#651).
+target = STORY or ISSUE
+if not target:
+    team.warn(
+        "no story and no issue — nowhere to attribute this handoff. A hand-cut branch with no "
+        "issue prefix resolves to no story; name the branch <story#>-<summary> so it does."
+    )
     raise SystemExit(0)
 
-target = STORY or ISSUE
+source = f"#{ISSUE}" if ISSUE else f"PR #{PR}" if PR else "an untraceable trigger"
 
-# One comment per TASK, not per story. A story has several authoring tasks and each has its
-# own handoff; keying the marker on the story would let the last one overwrite the rest.
-marker = f"<!-- claude-team:handoff:{ISSUE} -->"
+try:
+    parsed = json.loads(HANDOFF)
+except json.JSONDecodeError:
+    parsed = {}
+
+# ── the decisions log: appended, never replaced ─────────────────────────────────────────
+#
+# ⚠️ THIS ONE APPENDS, and the other upserts. A handoff is a snapshot for the next role and is
+# regenerated whole each run, so replacing it loses nothing. A decision is a RECORD: a PR draws
+# several rounds of review, and round two overwriting round one destroys the very fact this
+# exists to keep. One comment either way — thirty on a story is its own failure.
+decisions = parsed.get("decisions") or []
+if decisions:
+    lines = []
+    for entry in decisions:
+        lines.append(f"- **{entry.get('decision', '').strip()}**")
+        if entry.get("why"):
+            lines.append(f"  - *Why:* {entry['why'].strip()}")
+        if entry.get("supersedes"):
+            lines.append(f"  - *Supersedes:* {entry['supersedes'].strip()}")
+    attribution = f"**From {source}**{f' ({ROLES})' if ROLES else ''}{team.run_link()}"
+    section = attribution + "\n" + "\n".join(lines)
+
+    if team.append_to_comment(
+        target,
+        "<!-- claude-team:decisions -->",
+        section,
+        "### Decisions\n\nReached while the work was being done, so the issue above may still "
+        "describe what they replaced. Newest last.",
+    ):
+        print(f"logged {len(decisions)} decision(s) from {source} on #{target}")
+    else:
+        team.warn(f"could not log decisions on #{target}")
+
+# ── the handoff itself: one per task, or one per PR ─────────────────────────────────────
+#
+# Keyed on the TASK, not the story: a story has several authoring tasks and each has its own
+# handoff, so a story-keyed marker would let the last one overwrite the rest. A PR follow-up has
+# no task of its own, so it keys on the PR for the same reason.
+key = ISSUE or f"pr-{PR}"
+marker = f"<!-- claude-team:handoff:{key} -->"
 body = (
     f"{marker}\n"
-    f"### Handoff — #{ISSUE}{f' ({ROLES})' if ROLES else ''}\n\n"
+    f"### Handoff — {source}{f' ({ROLES})' if ROLES else ''}\n\n"
     "Machine-written, schema-enforced. `testingNotes` are for the Tester,\n"
     "`docsCandidates` for the Writer. An empty array is a real answer — it means the\n"
     "author considered it and found nothing, which is not the same as a missing key.\n\n"
@@ -49,6 +100,6 @@ body = (
 )
 
 if team.upsert_comment(target, marker, body + team.run_footer()):
-    print(f"posted the handoff for #{ISSUE} on story #{target}")
+    print(f"posted the handoff for {source} on story #{target}")
 else:
     team.warn(f"could not post the handoff on #{target}")

--- a/packages/claude-team/hooks/team.py
+++ b/packages/claude-team/hooks/team.py
@@ -228,6 +228,48 @@ def run_footer() -> str:
     return f"\n---\n<sub>Written by [this run](https://github.com/{repo}/actions/runs/{run}).</sub>\n"
 
 
+def append_to_comment(number: str | int, marker: str, section: str, header: str) -> bool:
+    """Add `section` to the marked comment, keeping what is already there.
+
+    ⚠️ THE DIFFERENCE FROM `upsert_comment` IS THE WHOLE POINT, and it is not a style choice.
+    Upserting is right for a derived status board — it is regenerated from GitHub state every
+    run, so replacing it loses nothing. This is for a record of decisions, which is not derived
+    from anything: a PR draws several rounds of review, and round two replacing round one
+    destroys exactly the fact the comment exists to keep.
+
+    Still ONE comment, because thirty on a story is its own failure. Rounds stack inside it.
+    """
+    comments = gh_json("api", f"repos/{REPO}/issues/{number}/comments", "--paginate")
+    existing = None
+    if isinstance(comments, list):
+        for comment in comments:
+            if marker in (comment.get("body") or ""):
+                existing = comment
+
+    if existing is None:
+        return gh(
+            "api", f"repos/{REPO}/issues/{number}/comments",
+            "-f", f"body={marker}\n{header}\n\n{section}",
+        ) is not None
+
+    return gh(
+        "api", "--method", "PATCH", f"repos/{REPO}/issues/comments/{existing['id']}",
+        "-f", f"body={(existing.get('body') or '').rstrip()}\n\n---\n\n{section}",
+    ) is not None
+
+
+def run_link() -> str:
+    """The same run URL as `run_footer`, inline rather than as a trailing block.
+
+    A footer is right for a comment that IS one run's output. The decisions log is not — it
+    accumulates rounds, so each entry carries its own provenance and a trailing rule per section
+    just stacks horizontal lines.
+    """
+    repo = os.environ.get("GITHUB_REPOSITORY") or REPO
+    run = os.environ.get("GITHUB_RUN_ID")
+    return f" · [run](https://github.com/{repo}/actions/runs/{run})" if repo and run else ""
+
+
 def upsert_comment(number: str | int, marker: str, body: str) -> bool:
     """Create or update the single comment carrying `marker` on an issue or PR.
 

--- a/packages/claude-team/prompts/implementor.md
+++ b/packages/claude-team/prompts/implementor.md
@@ -36,15 +36,34 @@ Code, and only code.
   status doc — a bloated handoff costs the turns it was meant to save. A **🔔 Maintainer**
   section, if you have one, goes below it.
 
-## The handoff to the Tester and the Writer
+## The handoff to the Tester, the Writer, and whoever comes next
 
-Your **final message is a JSON object** matching the schema you were given: `testingNotes`
-for the Tester, `docsCandidates` for the Writer. They are handed it directly as context —
-neither goes looking for a section in a comment.
+Your **final message is a JSON object** matching the schema you were given: `decisions` for
+the record, `testingNotes` for the Tester, `docsCandidates` for the Writer. The consuming
+roles are handed it directly as context — none goes looking for a section in a comment.
 
-- **Both keys are required.** `[]` is a real answer, and the right one when there is
+- **Every key is required.** `[]` is a real answer, and the right one when there is
   genuinely nothing: it says "I considered this and there is nothing here", which a later
   role can act on. A missing key says nothing at all.
+
+⚠️ **`decisions` is how a review survives its own thread, and it is the one you will be
+tempted to leave empty on the run where it matters most.** When you are triggered on a PR and
+the maintainer tells you to change course — drop this, do it that way instead — the issue you
+were given still describes the approach they just rejected. Nothing rewrites it. A PR comment
+is not a durable artifact; the issue and the code are. So the next agent reads the old plan and
+faithfully rebuilds what was thrown out.
+
+That is not hypothetical: a resolver deleted on review was reinstated two PRs later by an agent
+reading a story that still asked for it, and the whole round trip cost more than the feature.
+
+- Report a decision whenever this run settled something the issue does not already say — above
+  all one that came out of review. State the **rule now in force**, not the conversation.
+- `why` is not optional in spirit. An outcome with no reasoning behind it gets re-litigated by
+  the next reader, or quietly reverted.
+- `supersedes` is where you name what now reads the old way — acceptance criteria, a spec id, a
+  function. That is the list someone can actually go and fix.
+- ⚠️ Reporting it does **not** discharge it. If a decision leaves a specification wrong, say so
+  in your **🔔 Maintainer** section too — `decisions` records it, a heads-up gets it acted on.
 - ⚠️ **Do not pad either list.** An entry that restates the diff costs another role a turn
   to read and reject, and trains them to skim the ones that matter.
 - `why` is the field that decides an entry. For a testing note it is the silent failure

--- a/packages/claude-team/schemas/handoff.json
+++ b/packages/claude-team/schemas/handoff.json
@@ -1,7 +1,30 @@
 {
   "type": "object",
-  "description": "What an authoring role passes to the roles that run after it. Both keys are required. An empty array is a real answer meaning nothing here is worth another role a turn, and is not the same as the step never having run at all.",
+  "description": "What an authoring role passes to the roles that run after it, and to whoever picks the work up next. Every key is required. An empty array is a real answer meaning nothing here is worth another role a turn, and is not the same as the step never having run at all.",
   "properties": {
+    "decisions": {
+      "type": "array",
+      "description": "Decisions reached DURING this run that the issue does not already state - above all one the maintainer made in review. This is the field that stops the next agent rebuilding what was just rejected: a review comment is not a durable artifact, the issue and the code are, and an agent reading a plan that still describes the rejected approach will faithfully rebuild it. Empty when the run only did what the issue already said.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "decision": {
+            "type": "string",
+            "description": "The rule now in force, stated as the rule rather than as a description of the conversation. Someone applying it should not need the thread it came from."
+          },
+          "why": {
+            "type": "string",
+            "description": "What makes it true - the property of the domain or the code that decided it. Reasoning travels; an outcome on its own gets re-litigated or reverted."
+          },
+          "supersedes": {
+            "type": "string",
+            "description": "What this replaces and where that still reads the old way - the acceptance criteria on an issue, a spec id, a function that now contradicts it. Omit only when this is new ground rather than a correction."
+          }
+        },
+        "required": ["decision", "why"],
+        "additionalProperties": false
+      }
+    },
     "testingNotes": {
       "type": "array",
       "description": "For the Tester. Behaviour that a test written to distrust this change should cover — not a description of what was built. Empty when the change genuinely warrants no new coverage.",
@@ -45,6 +68,6 @@
       }
     }
   },
-  "required": ["testingNotes", "docsCandidates"],
+  "required": ["decisions", "testingNotes", "docsCandidates"],
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary

A decision reached in PR review reached nothing durable, so the issue kept describing the
approach that had just been rejected — and the next agent read it and rebuilt that.

Measured, not hypothetical: `nextIncompleteEquipment` was deleted on review of #626 and
**reinstated two PRs later** on #651, by an agent (me) reading a story that still asked for it.
The author of #626 did everything right — deleted it, explained the reasoning, and left two
🔔 Maintainer heads-ups naming both follow-ons. All of it stayed in the PR thread.

**A PR comment is not a durable artifact.** The issue, the spec and the code are, and a decision
reached in review lands in none of them unless something puts it there.

### Half one — the channel existed and was disconnected on the trigger that matters

`delegate.py` rule 2 already resolves a PR's story from its head branch, so
`needs.delegate.outputs.story` **is** populated on a follow-up. But the workflow blanks `ISSUE`
on a PR trigger and `post-handoff.py` returned on `if not ISSUE` — *before* it ever read `STORY`:

```python
if not ISSUE:
    print("Not triggered on an issue — nowhere to attribute a handoff.")
    raise SystemExit(0)

target = STORY or ISSUE   # never reached on a PR
```

So the one run that carries review feedback produced a schema-forced handoff and dropped it on
the floor. Same shape as the bug #476 fixed: a channel that exists, is required, and has no
reader. It now posts whenever a story resolves, attributed to the PR.

### Half two — the schema had nowhere for a decision to travel

`decisions` joins `testingNotes` and `docsCandidates` as a **required** key (`[]` a real answer,
same reasoning): the rule now in force, what makes it true, and — via `supersedes` — what still
reads the old way, so there is a list someone can go and fix.

### ⚠️ The decisions log appends; every other hook comment upserts

Deliberate, not an inconsistency. A handoff or a status board is *derived* — regenerated whole
each run, so replacing it loses nothing. A decision is a **record**: a PR draws several rounds
of review, and round two replacing round one destroys the fact the comment exists to keep. Still
one comment; rounds stack inside it.

Closes #654

## Verification

⚠️ **Workflow changes cannot be tested before merge** (`issue_comment` always runs the workflow
from the default branch), so the hook was exercised directly against a stubbed `gh`:

| case | result |
|---|---|
| PR follow-up (`ISSUE` blank, `PR` set) | posts to story #603 — previously discarded entirely |
| two review rounds on one PR | both preserved in one comment, each with its own run link |
| task-issue trigger | unchanged from today |
| `decisions: []` | logs nothing (no empty section) |
| no story and no issue | `::warning::`, exit 0 |
| no handoff (author step failed) | "no author ran", exit 0 |
| malformed handoff JSON | still posts the raw handoff, skips decisions, exit 0 |

Rendered output:

```
### Decisions

Reached while the work was being done, so the issue above may still describe what they replaced. Newest last.

**From PR #652** (implementor) · [run](…/actions/runs/111)
- **The equipment quick action names its item; it never resolves the next one.**
  - *Why:* Equipment has no boil time and no other intrinsic order.
  - *Supersedes:* BATCH-SCHEDULE-02, and the criteria on #618

---

**From PR #652** (implementor) · [run](…/actions/runs/222)
- **Unavailable reasons are written by the screen.**
  - *Why:* They are brewing statements.
```

Also asserted in-repo: `handoff.json` still parses, still compacts to **one line**, and still
contains **no single quote** — the workflow inlines it into a `--json-schema '…'` argument and
fails on either. My first draft did introduce an apostrophe; the assertion caught it.

`nx run-many --target=test` ✓ (6 projects, 0 errors — `claude-team` has no JS target; the hooks
are Python).

## ⚠️ Things to look at

- **I edited `.github/workflows/claude-roles.yaml`.** One `PR:` env line on the post-handoff
  step. House rules put workflows off-limits to the roles, and this cannot be verified until it
  is on `mainline` — worth your eyes specifically.
- **Local Python is 3.9.6, the runners are 3.12.** `team.py` already carries
  `from __future__ import annotations`, so the new `str | int` signature is fine in both; that is
  the trap `LOCAL.md` records.
- **Reporting a decision does not discharge it.** The prompt says so explicitly: `decisions`
  records what changed, but correcting a stale spec id or a sibling task's criteria still needs a
  🔔 Maintainer heads-up. This PR does not attempt to auto-edit issue bodies or specs.

## Out of scope

- #653 (`finish-pr.py` closing a half-done task) — related root cause, separate defect.
- The two follow-ons #626 flagged: `BATCH-SCHEDULE-02/03/04` still promise equipment
  auto-advance, and #618's acceptance criteria still ask a Tester to prove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
