### PR TITLE
Cover the quick-action check-off behaviours

### DIFF
--- a/packages/e2e/tests/brew-timer.spec.ts
+++ b/packages/e2e/tests/brew-timer.spec.ts
@@ -153,6 +153,124 @@ test("a quick-action tab goes unavailable, with its reason, once the phase is ex
     await expect(dialog.getByRole("tab", {name: "Reading"})).toHaveAttribute("aria-selected", "true");
 });
 
+// BATCH-SCHEDULE-01/-07: each use of the Ingredients quick action checks off one more item of
+// that kind, and never the one it just checked. Three grains in the kb recipe's mash phase, so
+// this proves *advance*, not merely *checks one off*.
+//
+// ⚠️ Deliberately asserts the SET of checked names, never a particular one. Which item a use
+// picks is BATCH-SCHEDULE-01's "earliest", and the grid renders rows in a different order than
+// the quick action walks (see the finding on #618) — pinning a name here would bake today's
+// implementation into the assertion, which is the one thing a spec-derived test must not do.
+test("the ingredients quick action advances through a phase, never re-checking an item", async ({page}) => {
+    await brewBatchFromKbRecipe(page, "E2E Quick Action Advance Batch");
+    await page.getByRole("tab", {name: "Brewing", exact: true}).click();
+
+    const GRAINS = ["Crystal Malt 40L", "German Pils", "Special Robust"];
+    const checkedNames = async () => {
+        const out: string[] = [];
+        for (const name of GRAINS) {
+            if (await page.getByRole("checkbox", {name}).isChecked()) out.push(name);
+        }
+        return out;
+    };
+
+    expect(await checkedNames()).toEqual([]);
+
+    for (let expected = 1; expected <= GRAINS.length; expected++) {
+        await page.getByRole("button", {name: "Quick actions"}).click();
+        const dialog = page.getByRole("dialog").filter({hasText: "Quick action"});
+        await dialog.getByRole("tab", {name: "Ingredients"}).click();
+        await dialog.getByRole("button", {name: "Confirm"}).click();
+        await expect(dialog).not.toBeVisible();
+        await settleSave(page);
+
+        // exactly one more each time — a re-check would leave the count flat
+        expect(await checkedNames()).toHaveLength(expected);
+    }
+
+    expect((await checkedNames()).sort()).toEqual([...GRAINS].sort());
+});
+
+// BATCH-SCHEDULE-01: "If the brewer also enters a value, that value is recorded against the
+// same item." Asserted against whichever item the action chose, for the reason above.
+test("a value typed into the ingredients quick action is recorded against the item it checked off", async ({page}) => {
+    await brewBatchFromKbRecipe(page, "E2E Quick Action Value Batch");
+    await page.getByRole("tab", {name: "Brewing", exact: true}).click();
+
+    await page.getByRole("button", {name: "Quick actions"}).click();
+    const dialog = page.getByRole("dialog").filter({hasText: "Quick action"});
+    await dialog.getByRole("tab", {name: "Ingredients"}).click();
+    await dialog.getByLabel("Ingredient weight").fill("9.99");
+    await dialog.getByRole("button", {name: "Confirm"}).click();
+    await expect(dialog).not.toBeVisible();
+    await settleSave(page);
+
+    const GRAINS = ["Crystal Malt 40L", "German Pils", "Special Robust"];
+    const checked: string[] = [];
+    for (const name of GRAINS) {
+        if (await page.getByRole("checkbox", {name}).isChecked()) checked.push(name);
+    }
+    expect(checked).toHaveLength(1);
+
+    // the value lands on the item that was checked, and on no other
+    await expect(page.getByLabel(`${checked[0]} weight`)).toHaveValue(/9\.99/);
+    for (const other of GRAINS.filter(n => n !== checked[0])) {
+        await expect(page.getByLabel(`${other} weight`)).not.toHaveValue(/9\.99/);
+    }
+});
+
+// BATCH-SCHEDULE-06: equipment is NAMED by the brewer, not resolved for them. The test names a
+// deliberately non-first item — an "earliest incomplete" resolver could never satisfy this,
+// which is the point: it is what distinguishes the behaviour from the one it replaced.
+test("the equipment quick action checks off the item the brewer names", async ({page}) => {
+    await brewBatchFromKbRecipe(page, "E2E Quick Action Equipment Batch");
+    await page.getByRole("tab", {name: "Brewing", exact: true}).click();
+
+    await page.getByRole("button", {name: "Quick actions"}).click();
+    const dialog = page.getByRole("dialog").filter({hasText: "Quick action"});
+    await dialog.getByRole("tab", {name: "Equipment"}).click();
+    await dialog.getByLabel("Equipment item").selectOption({label: "Digital Hydrometer"});
+    await dialog.getByRole("button", {name: "Confirm"}).click();
+    await expect(dialog).not.toBeVisible();
+    await settleSave(page);
+
+    await expect(page.getByRole("checkbox", {name: "Digital Hydrometer"})).toBeChecked();
+    await expect(page.getByRole("checkbox", {name: "Mash Tun - 10gal"})).not.toBeChecked();
+
+    // and it is no longer on offer
+    await page.getByRole("button", {name: "Quick actions"}).click();
+    await dialog.getByRole("tab", {name: "Equipment"}).click();
+    const left = await dialog.getByLabel("Equipment item").locator("option").allTextContents();
+    expect(left).not.toContain("Digital Hydrometer");
+    expect(left).toContain("Mash Tun - 10gal");
+});
+
+// BATCH-SCHEDULE-07: "never reaches into a later phase while the current phase still has one
+// left." The mash phase has grains and no hops; the boil phase has hops. While mash grains
+// remain, Hop must not be on offer and the boil's hops must stay untouched.
+test("a quick action never reaches into a later phase", async ({page}) => {
+    await brewBatchFromKbRecipe(page, "E2E Quick Action Phase Scope Batch");
+    await page.getByRole("tab", {name: "Brewing", exact: true}).click();
+
+    await page.getByRole("button", {name: "Quick actions"}).click();
+    const dialog = page.getByRole("dialog").filter({hasText: "Quick action"});
+    await dialog.getByRole("tab", {name: "Ingredients"}).click();
+
+    const kinds = await dialog.getByLabel("Ingredient kind").locator("option").allTextContents();
+    expect(kinds).toContain("Grain");
+    expect(kinds).not.toContain("Hop");
+
+    await dialog.getByRole("button", {name: "Confirm"}).click();
+    await expect(dialog).not.toBeVisible();
+    await settleSave(page);
+
+    // the boil phase's hops are untouched
+    await openSchedulePhase(page, "2. Boil");
+    for (const box of await page.getByRole("checkbox", {name: /Northern Brewer/}).all()) {
+        await expect(box).not.toBeChecked();
+    }
+});
+
 // Covers the marker overlay's 24px hit target + popover work (#380): each
 // marker gets its own transparent hit box independent of its drawn dot, and
 // only one popover is open at a time. Real wall-clock separation between the


### PR DESCRIPTION
## Summary

Functional coverage for the quick-action check-off behaviours, into the story branch so it lands
before #630 merges.

Four tests, each citing the behaviour id it proves:

| test | proves |
|---|---|
| advances through a phase, never re-checking an item | **BATCH-SCHEDULE-01 / -07** — three uses check off three distinct grains, one more each time |
| a typed value is recorded against the item it checked off | **BATCH-SCHEDULE-01** — the value lands on the checked item and on no other |
| the equipment action checks off the item the brewer names | **BATCH-SCHEDULE-06** — proven with a deliberately *non-first* item, which an "earliest incomplete" resolver could not satisfy |
| never reaches into a later phase | **BATCH-SCHEDULE-07** — while mash grains remain, Hop is not offered and the boil's hops stay untouched |

Together with the two already on the branch (all-tabs-enabled, and exhaustion carrying its
reason — both **BATCH-SCHEDULE-04**), that covers #618's list as corrected.

Closes #618

## ⚠️ I found a defect while writing these, and did not absorb it into a test

**The grid and the quick action use different orders, so the row that gets checked is not the one
the brewer sees first.** Filed as #656 with measurements.

`index.tsx:86-89` sorts displayed rows alphabetically by name; `nextIncompleteAssignment` sorts
by boil time descending and falls back to `brewable.assignments` order for anything without one —
every grain and yeast. On the kb recipe's mash phase:

| | order |
|---|---|
| stored | German Pils, Crystal Malt 40L, Special Robust |
| **displayed** | **Crystal Malt 40L**, German Pils, Special Robust |
| **checked by one use** | **German Pils** — the second row on screen |

So the two ingredient tests here assert the **set** of checked items and its size, never a
particular name. Naming one would have made the suite green *because* it encodes today's
behaviour — the "derived from the implementation" trap, and the thing that makes a test worse
than no test. #656 asks for them to be tightened once the order is decided; that decision is the
maintainer's, since BATCH-SCHEDULE-01 says "earliest" without defining the order and for grains
there is no brewing order for it to mean.

⚠️ **Everything here passes with #656 present.** A green suite is not evidence that ordering is
fine.

## Verification

- `nx run-many --target=test` (eslint) ✓ — 6 projects, 0 errors.
- **`brew-timer.spec.ts`: 12 passed.** Full suite: **96 passed** (3.6m, local Chrome).
- No app, design or spec code touched — tests only.

## Notes

- I corrected #618's own acceptance criteria before working it: they asked for equipment
  "earliest incomplete" and advance-on-repeat, which is the design ruled out on #626 and
  superseded by BATCH-SCHEDULE-06. Working them as written would have produced tests asserting
  behaviour that no longer exists.
- Base is the story branch, so **Verify runs but functional-test does not** (it is scoped to PRs
  into `mainline`). The suite was run locally in full; it runs on CI when #630 goes in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
