### PR TITLE
Name the secondary inputs in Planning's ingredient rows

### DIFF
--- a/packages/app/src/screen/brewable-edit/ingredients/assignment-row.tsx
+++ b/packages/app/src/screen/brewable-edit/ingredients/assignment-row.tsx
@@ -74,6 +74,7 @@ function RecipeEditAssignmentRow({ row, assignment, remove, update, updateScalar
                             <DataGridLabel tiny className="ml-6">Alpha %</DataGridLabel>
                             <DataGridInput
                                 colStart={6}
+                                label={`${assignmentResourceName(assignment)} alpha`}
                                 value={assignment.resource.alpha.value}
                                 onChange={onChangeAlphaValue}
                                 onBlur={onBlurAlpha}
@@ -83,6 +84,7 @@ function RecipeEditAssignmentRow({ row, assignment, remove, update, updateScalar
                             <DataGridLabel tiny className="ml-6">Boil</DataGridLabel>
                             <DataGridInput
                                 colStart={6}
+                                label={`${assignmentResourceName(assignment)} boil`}
                                 value={assignment.resource.boil.value}
                                 onChange={onChangeBoilValue}
                                 onBlur={onBlurBoil}
@@ -98,6 +100,7 @@ function RecipeEditAssignmentRow({ row, assignment, remove, update, updateScalar
                             <DataGridLabel tiny className="ml-6">Attenuation %</DataGridLabel>
                             <DataGridInput
                                 colStart={6}
+                                label={`${assignmentResourceName(assignment)} attenuation`}
                                 value={assignment.resource.avg_attn.value}
                                 onChange={onChangeAttnValue}
                                 onBlur={onBlurAttn}
@@ -107,6 +110,7 @@ function RecipeEditAssignmentRow({ row, assignment, remove, update, updateScalar
                             <DataGridLabel tiny className="ml-6">Temp</DataGridLabel>
                             <DataGridInput
                                 colStart={6}
+                                label={`${assignmentResourceName(assignment)} temp`}
                                 value={assignment.resource.temp.value}
                                 onChange={onChangeTempValue}
                                 onBlur={onBlurTemp}
@@ -129,6 +133,7 @@ function RecipeEditAssignmentRow({ row, assignment, remove, update, updateScalar
                             <DataGridLabel tiny className="ml-6">Weight</DataGridLabel>
                             <DataGridInput
                                 colStart={6}
+                                label={`${assignmentResourceName(assignment)} weight`}
                                 value={weight.value}
                                 onChange={onChangeWeightValue}
                                 onBlur={onBlurWeight}
@@ -141,6 +146,7 @@ function RecipeEditAssignmentRow({ row, assignment, remove, update, updateScalar
                             <DataGridLabel tiny className="ml-6">Boil</DataGridLabel>
                             <DataGridInput
                                 colStart={6}
+                                label={`${assignmentResourceName(assignment)} boil`}
                                 value={assignment.resource.boil?.value ?? ""}
                                 onChange={onChangeBoilValue}
                                 onBlur={onBlurBoil}

--- a/packages/e2e/tests/brew-timer.spec.ts
+++ b/packages/e2e/tests/brew-timer.spec.ts
@@ -189,25 +189,44 @@ test("the ingredients quick action works down the phase in the order it lists th
     }
 });
 
-// BATCH-SCHEDULE-08: a phase lists boil-timed additions longest-boil first, which is the order
-// they actually go in.
+// BATCH-SCHEDULE-08/-09: the phase lists boil additions longest-boil first, and Planning is
+// left exactly as the brewer arranged it.
 //
-// ⚠️ WEAKER THAN IT LOOKS, and worth knowing before trusting it. The kb recipe already stores
-// its three Northern Brewer additions in descending boil order, so this passes whether the
-// screen sorts or merely preserves that order — it was green against the #656 defect. It catches
-// a *wrong* sort (ascending, or by name), not the absence of one. The real guard for #656 is the
-// test above, which reads the rendered order and was verified to fail when the sort is reverted.
-// A fixture whose stored order disagrees with its boil order would need the planning screen's
-// boil input to carry an accessible name; it does not yet.
-test("a phase lists its boil additions in the order they go in", async ({page}) => {
+// ⚠️ The edit is what gives this test teeth. The kb recipe already stores its three Northern
+// Brewer additions in descending boil order, so asserting the panel order straight after brewing
+// cannot tell "the screen sorted them" from "they were already sorted" — an earlier version of
+// this test was green against the #656 defect for exactly that reason. Retiming the first-stored
+// addition to 1 min makes the stored order (1, 20, 0) and the brewing order (20, 1, 0) disagree,
+// so only a screen that really sorts can pass.
+test("a phase lists its boil additions in the order they go in, without reordering Planning", async ({page}) => {
     await brewBatchFromKbRecipe(page, "E2E Brew Order Batch");
+
+    await page.getByRole("tab", {name: "Planning", exact: true}).click();
+    await page.getByRole("tab", {name: "Ingredients", exact: true}).click();
+
+    const toggles = page.getByRole("button", {name: "Show assignment details"});
+    for (let guard = 0; guard < 12 && await toggles.count() > 0; guard++) {
+        await toggles.first().click();
+    }
+
+    const boilTimes = (where: Page) => where.getByLabel(/Northern Brewer boil/)
+        .evaluateAll(inputs => inputs.map(i => parseFloat((i as HTMLInputElement).value)));
+
+    const planned = page.getByLabel("Northern Brewer boil");
+    await expect(planned).toHaveCount(3);
+    expect(await boilTimes(page)).toEqual([60, 20, 0]);
+
+    // retime the first one so it now goes in LAST
+    await planned.nth(0).fill("1");
+    await planned.nth(0).blur();
+    await settleSave(page);
+
+    // BATCH-SCHEDULE-09: Planning still reads in the brewer's own arrangement
+    await expect.poll(() => boilTimes(page)).toEqual([1, 20, 0]);
+
+    // BATCH-SCHEDULE-08: the brew-day panel reads chronologically instead
     await openSchedulePhase(page, "2. Boil");
-
-    const boils = await page.getByLabel(/Northern Brewer boil/).evaluateAll(
-        inputs => inputs.map(i => parseFloat((i as HTMLInputElement).value)));
-
-    expect(boils.length).toBeGreaterThan(1);
-    expect(boils).toEqual([...boils].sort((a, b) => b - a));
+    await expect.poll(() => boilTimes(page)).toEqual([20, 1, 0]);
 });
 
 // BATCH-SCHEDULE-01: "If the brewer also enters a value, that value is recorded against the

--- a/packages/spec/product/batch-schedule.md
+++ b/packages/spec/product/batch-schedule.md
@@ -53,6 +53,15 @@ the order the brewer arranged while planning.
 > order the brewer's own arrangement is the best answer available, and re-sorting it — by name,
 > say — would overrule a decision they made deliberately while planning.
 
+**BATCH-SCHEDULE-09** — Planning lists ingredients in the order the brewer put them in, and
+nothing re-orders them there. Changing an addition's boil time moves it on the brew-day schedule
+and leaves it where it is in Planning.
+
+> *Why:* the two screens answer different questions. Planning is where the brewer arranges the
+> recipe, and re-sorting under their hands while they type would fight them. The brew day is
+> where the plan is read back as a sequence, and that is the only place an order should be
+> imposed on it.
+
 
 ## Known gaps
 


### PR DESCRIPTION
## Summary

Six of the seven `DataGridInput`s in
`screen/brewable-edit/ingredients/assignment-row.tsx` carried no `label`, so every field behind
a row's expander had **no accessible name at all** — a screen reader announced an expanded hop
row as two unlabelled text boxes. Only the top-level weight was named.

| field | resource |
|---|---|
| `alpha`, `boil` | hop |
| `avg_attn`, `temp` | yeast |
| `weight`, `boil` | additive |

Same defect as #399, and `packages/design` already accepted the prop — call sites only, no
design change. Named to the file's own convention: `` `${assignmentResourceName(assignment)} boil` ``.

## The test it unblocked, and why the old one was worthless

**BATCH-SCHEDULE-08**'s guard asserted the boil column read descending straight after brewing.
The kb recipe *already stores* its three Northern Brewer additions in descending boil order, so
that assertion could not distinguish "the screen sorted them" from "they were already sorted" —
it was **green against the #656 defect it existed to catch.**

The replacement is the case you raised on #656:

> It is entirely possible from the planning / recipe screens to have hops incorrectly ordered
> because the user adds hops in one order, but defines their addition times differently.

It retimes the first-stored addition to 1 min, so stored order and brewing order disagree:

| | order |
|---|---|
| stored after the edit | 1, 20, 0 |
| **Planning shows** | **1, 20, 0** — the brewer's arrangement, untouched |
| **the brew-day panel shows** | **20, 1, 0** — chronological |

Only a screen that genuinely sorts can pass that.

⚠️ **Verified to fail.** I reverted the panel sort to `name.localeCompare`, re-ran, watched it go
red, and restored. The version it replaces stayed **green** through the same experiment — which
is the whole reason it needed replacing.

## Spec

**BATCH-SCHEDULE-09** (new) states the other half, which the same test now pins: Planning lists
ingredients in the order the brewer put them in and nothing re-orders them there. It is the
counterpart to -08 and belongs beside it — there is no planning spec file, and creating one for a
single behaviour seemed worse than stating it where its pair lives. Say if you would rather it
moved.

Closes #660

## Verification

- `nx run-many --target=test` ✓ · `tsc --noEmit` ✓ · `nx build app` ✓
- **Full Playwright suite: 97 passed.**
- The falsification run described above.

## Out of scope

- Any `packages/design` change — none was needed.
- **Three additions of one hop still yield three identical labels** (`"Northern Brewer boil"` ×3).
  Real, but it predates this and applies just as much to the already-named weight input; the new
  test addresses them positionally, which is legitimate for genuinely identical resources. Worth
  its own issue if you want them distinguished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
