### PR TITLE
Let an author say its task is unfinished

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -924,6 +924,12 @@ jobs:
           ROLES: ${{ steps.roles.outputs.list }}
           REPO: ${{ github.repository }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          # ⚠️ The same author output post-handoff.py gets, and the reason this step can tell a
+          # finished task from a half-done one. Without it the hook only ever asked whether the
+          # closing keyword was present, never why it was absent — so an author that deliberately
+          # left it off had that decision overwritten, and #617 closed as completed with its
+          # wiring never written.
+          HANDOFF: ${{ steps.implementor.outputs.structured_output || steps.designer.outputs.structured_output }}
         run: "$RUNNER_TEMP/agent-bin/finish-pr.py"
       - name: Persist the author's handoff
         if: always()

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -281,8 +281,8 @@ skip.
 
 ## The handoff between authors
 
-An author's step carries `--json-schema`, so its final message is a contract: `decisions` for
-the record, `testingNotes` for the Tester, `docsCandidates` for the Writer. A hook posts it to
+An author's step carries `--json-schema`, so its final message is a contract: `remaining` for
+whether the task is finished at all, `decisions` for the record, `testingNotes` for the Tester, `docsCandidates` for the Writer. A hook posts it to
 the **story's issue** as one comment per task, where the Tester reads it on its own trigger. ⚠️ The Writer reads it only
 on a **re-trigger** — it runs before the authors, so on its first pass the comments do not exist
 yet.
@@ -298,6 +298,26 @@ yet.
   that carries **review feedback** produced a schema-forced handoff and dropped it. A `PR` env
   var is the other half of the same trigger; without it `decisions` has no path on the only
   trigger it exists for.
+- ⚠️ **`remaining` is the only way an author can say it did not finish, and leaving the closing
+  keyword out of the PR body was never one.** `finish-pr.py` put it back — it asked whether the
+  keyword was present, never why it was absent — so the omission an author meant as a signal was
+  overwritten and the task closed as **completed**. Measured: #617's wiring was never written, it
+  closed anyway, and the Tester that ran next found no feature to test. The keyword is now
+  withheld when `remaining` is non-empty, the PR carries a warning block saying so, and the task
+  gets a comment listing what is left.
+- ⚠️ **The schema beats the prose, deliberately.** A body is something a model can write anything
+  into, including a closing keyword contradicting its own report — so a non-empty `remaining`
+  **strips** the keyword rather than warning about the contradiction and letting the task close.
+  The forced channel wins over the skippable one; that is the whole reason there is a schema.
+- ⚠️ **The withheld keyword becomes a bare `#N` reference, not nothing.** That keeps the PR
+  discoverable from the task while leaving `closingIssuesReferences` empty, so
+  `close-merged-work.py` finds nothing to close by either of its two routes. ⚠️ Its fallback is a
+  regex over the body, so the warning block's own wording must never read as a closing keyword —
+  asserted, because "does not close #N" in the wrong phrasing would silently re-close the task the
+  block exists to keep open.
+- ⚠️ **`remaining` is upserted on the task; `decisions` is appended to the story.** Not an
+  inconsistency: what is left is a snapshot that a later run supersedes, while a decision is a
+  record that a later run must not erase.
 - ⚠️ **`decisions` is the antidote to a review that dies in its own thread.** A maintainer
   changes course on a PR; the issue still describes what they rejected, and nothing rewrites it.
   The next agent reads the old plan and rebuilds the rejected thing — measured: a resolver
@@ -371,7 +391,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 | `ensure-story-branch.py` | post, Architect + Researcher | creates the story's branch if it is missing; an epic and a spike have none, and it says so rather than warning |
 | `sync-kind-label.py` | post, Architect + Researcher | applies the `epic`/`spike`/`bug`/`story` label `kind()` derives |
 | `file-sub-issues.py` | post, Architect | parents stories to their epic, tasks to their story |
-| `finish-pr.py` | post, authors | labels the PR and ensures it closes its issue |
+| `finish-pr.py` | post, authors | labels the PR, and ensures it closes its issue — or, when the author reported work `remaining`, that it does not |
 | `post-handoff.py` | post, authors | posts the JSON handoff to the story's issue, and appends its `decisions` to one running log there |
 | `log-to-story.py` | post, Architect + authors + on merge | rewrites one comment on the story listing its tasks in trigger order |
 | `log-to-epic.py` | post, authors | rewrites one rolling work-log comment on the epic |
@@ -400,7 +420,9 @@ turns and cannot be forgotten.
   `finish-pr.py` labels the PR that run created. Nothing labels someone else's work.
 - ⚠️ **`Closes #<issue>` is both a prompt instruction and a hook.** The model writing it puts
   the link where a human reads it; the hook is the net, because a missing keyword loses the
-  close with nothing to signal it.
+  close with nothing to signal it. ⚠️ **Unless the author reported `remaining`** — then the hook
+  withholds the keyword rather than adding it. A forgotten keyword and a deliberately omitted one
+  were indistinguishable, and the deliberate one lost.
 - ⚠️ **Keep long-lived credentials out of any job a model step shares** unless the workflow
   puts them in *step* env. Step env is per-step, so a scripted step can hold a token the
   model step beside it cannot read. Secret masking covers logs only — not an API payload a

--- a/packages/claude-team/hooks/finish-pr.py
+++ b/packages/claude-team/hooks/finish-pr.py
@@ -4,7 +4,8 @@ to remember:
 
   1. points the PR at its story's branch
   2. labels the PR with the role(s) that worked it
-  3. makes sure the body carries `Closes #<issue>`
+  3. makes sure the body carries `Closes #<issue>` — UNLESS the author reported the task
+     unfinished, in which case it makes sure the body does NOT
 
 (1) and (3) each silently lose work. A PR that targets the default branch takes its task out
 of the story model — it ships to prod on merge and the story never gets a PR. A missing
@@ -16,6 +17,7 @@ this runs once at the end of it. A single role is a list of one; the PR should c
 whole trail, not whichever ran last.
 """
 
+import json
 import os
 import re
 import subprocess
@@ -24,6 +26,7 @@ import team
 
 ROLES = os.environ.get("ROLES") or team.fail("ROLES is required")
 ISSUE = os.environ.get("ISSUE", "")
+HANDOFF = os.environ.get("HANDOFF", "")
 
 if not team.REPO:
     team.fail("REPO is required")
@@ -159,8 +162,63 @@ if not ISSUE:
     print("No triggering issue — nothing to close.")
     raise SystemExit(0)
 
+# ⚠️ AN AUTHOR HAS TO BE ABLE TO SAY "NOT FINISHED", and for a long time it could not. The only
+# gesture available was leaving the keyword out of the PR body, and this hook put it back —
+# it asked whether the keyword was there, never why it was absent. #617 closed as COMPLETED with
+# its wiring never written, and the Tester that ran next found no feature to test.
+#
+# ⚠️ THE SCHEMA WINS OVER THE PROSE, and that is the whole design. `remaining` is forced by
+# `--json-schema`; a body is something a model may write anything into, including a closing
+# keyword that contradicts its own report. So a non-empty `remaining` also STRIPS a keyword the
+# model wrote, rather than warning about the contradiction and letting the task close anyway.
+#
+# ⚠️ ABSENT OR UNPARSABLE HANDOFF STILL CLOSES. That means the author's step failed or never ran,
+# which is not the same as "incomplete" — three states, not two — and the net against a merely
+# forgotten keyword has to stay in place for it.
+remaining = []
+if HANDOFF:
+    try:
+        parsed = json.loads(HANDOFF)
+        if isinstance(parsed.get("remaining"), list):
+            remaining = [str(item).strip() for item in parsed["remaining"] if str(item).strip()]
+    except json.JSONDecodeError:
+        team.warn("could not parse the handoff — treating this task as finished, as before.")
+
+closes = re.compile(rf"(?i)\b(clos|fix|resolv)[a-z]*(\s+)#{ISSUE}\b")
 body = (team.gh_json("pr", "view", pr, "--repo", team.REPO, "--json", "body") or {}).get("body") or ""
-if re.search(rf"(?i)(clos|fix|resolv)[a-z]*\s+#{ISSUE}\b", body):
+
+if remaining:
+    listed = "\n".join(f"- {item}" for item in remaining)
+    # a bare `#N` cross-references without the closing semantics, so the PR stays discoverable
+    # from the task while `close-merged-work.py` finds nothing to close
+    stripped = closes.sub(rf"refs\g<2>#{ISSUE}", body)
+    note = (
+        f"\n\n> [!WARNING]\n"
+        f"> **This does not finish #{ISSUE}, and merging it will not close it.**\n"
+        f"> The author reported the task incomplete. Still to do:\n"
+        + "".join(f"> - {item}\n" for item in remaining)
+    )
+    if team.gh("pr", "edit", pr, "--repo", team.REPO, "--body", stripped + note) is None:
+        team.warn(f"could not mark PR #{pr} as not finishing #{ISSUE} — it may close the task on merge")
+    else:
+        print(f"PR #{pr} -> withheld 'Closes #{ISSUE}': {len(remaining)} item(s) remaining")
+
+    # ⚠️ ON THE TASK TOO. The PR body is where the merge decision happens; the task is where
+    # someone looks afterwards and asks why it is still open. A PR comment is not durable for an
+    # issue — the lesson #654 was filed for.
+    #
+    # Upserted, not appended, unlike the decisions log: this is a snapshot of what is left right
+    # now, and an earlier run's list is superseded rather than part of a record.
+    team.upsert_comment(
+        ISSUE,
+        f"<!-- claude-team:remaining:{ISSUE} -->",
+        f"<!-- claude-team:remaining:{ISSUE} -->\n"
+        f"### Left unfinished\n\n"
+        f"PR #{pr} does not close this. Still to do:\n\n{listed}\n" + team.run_footer(),
+    )
+    raise SystemExit(0)
+
+if closes.search(body):
     print(f"PR #{pr} already closes #{ISSUE}.")
     raise SystemExit(0)
 

--- a/packages/claude-team/prompts/implementor.md
+++ b/packages/claude-team/prompts/implementor.md
@@ -38,13 +38,31 @@ Code, and only code.
 
 ## The handoff to the Tester, the Writer, and whoever comes next
 
-Your **final message is a JSON object** matching the schema you were given: `decisions` for
-the record, `testingNotes` for the Tester, `docsCandidates` for the Writer. The consuming
-roles are handed it directly as context — none goes looking for a section in a comment.
+Your **final message is a JSON object** matching the schema you were given: `remaining` for
+whether the task is actually done, `decisions` for the record, `testingNotes` for the Tester,
+`docsCandidates` for the Writer. The consuming roles are handed it directly as context — none
+goes looking for a section in a comment.
 
 - **Every key is required.** `[]` is a real answer, and the right one when there is
   genuinely nothing: it says "I considered this and there is nothing here", which a later
   role can act on. A missing key says nothing at all.
+
+⚠️ **`remaining` is the only way to say you did not finish, and leaving the closing keyword out
+of the PR body is NOT one.** A hook puts that keyword back — it always did, because a *forgotten*
+keyword is the commoner mistake and losing the close is silent. So the omission you meant as a
+signal is overwritten, the task closes as completed, and the next role runs against work that
+was never done. That is not hypothetical: it cost a story its wiring and sent a Tester to test a
+feature that did not exist.
+
+- `[]` means finished. Say it plainly when it is true; most runs finish.
+- Non-empty means the task stays open, the PR says so, and this list is what the next run is
+  handed. Write each item so someone who was not on this run can pick it up — **what is missing**,
+  not what went wrong.
+- ⚠️ **This is for the task in front of you being incomplete**, not for follow-up work you noticed.
+  Follow-ups are their own issue; putting them here keeps a finished task open forever.
+- ⚠️ **Do not write `Closes #<issue>` in the body while reporting work remaining.** The schema
+  wins — the hook strips a contradicting keyword — but a PR that says two things is one a reviewer
+  has to adjudicate, and you already know the answer.
 
 ⚠️ **`decisions` is how a review survives its own thread, and it is the one you will be
 tempted to leave empty on the run where it matters most.** When you are triggered on a PR and

--- a/packages/claude-team/schemas/handoff.json
+++ b/packages/claude-team/schemas/handoff.json
@@ -2,6 +2,14 @@
   "type": "object",
   "description": "What an authoring role passes to the roles that run after it, and to whoever picks the work up next. Every key is required. An empty array is a real answer meaning nothing here is worth another role a turn, and is not the same as the step never having run at all.",
   "properties": {
+    "remaining": {
+      "type": "array",
+      "description": "What this task still needs, and therefore is NOT finished. Empty means finished - the task closes on merge exactly as before. Non-empty means it does not: the closing keyword is withheld, the task stays open, and this list is what the next run is told. This is the only way to say half-done. Omitting the keyword from the PR body does not work and never did, because a hook adds it back; that is how a task whose wiring was never written closed as completed and the next role ran against a feature that did not exist. Do not use it to note follow-up work that belongs in its own issue - this is for the task in front of you being incomplete.",
+      "items": {
+        "type": "string",
+        "description": "One thing still to do, stated so someone who was not on this run can pick it up - what is missing, not what went wrong."
+      }
+    },
     "decisions": {
       "type": "array",
       "description": "Decisions reached DURING this run that the issue does not already state - above all one the maintainer made in review. This is the field that stops the next agent rebuilding what was just rejected: a review comment is not a durable artifact, the issue and the code are, and an agent reading a plan that still describes the rejected approach will faithfully rebuild it. Empty when the run only did what the issue already said.",
@@ -68,6 +76,6 @@
       }
     }
   },
-  "required": ["decisions", "testingNotes", "docsCandidates"],
+  "required": ["remaining", "decisions", "testingNotes", "docsCandidates"],
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary

Leaving `Closes #<issue>` out of the PR body was the **only** gesture an author had for "not
done", and `finish-pr.py` put it back — it asked whether the keyword was *present*, never why it
was *absent*. So the omission an author meant as a signal was overwritten: #617 closed as
**COMPLETED** with its wiring never written, and the Tester that ran next found no feature to
test.

`remaining` joins the handoff schema as a required key, alongside `decisions`, `testingNotes`
and `docsCandidates`.

| `remaining` | what happens |
|---|---|
| `[]` | `Closes #N` appended — unchanged from today |
| non-empty | keyword **withheld**, replaced by a bare `#N` so the PR stays discoverable; a warning block on the PR; a comment on the task listing what is left |

⚠️ **The schema beats the prose, deliberately.** A body is something a model can write anything
into, including a closing keyword contradicting its own report — so a non-empty `remaining`
**strips** the keyword rather than warning about the contradiction and letting the task close.
The forced channel wins over the skippable one; that is the entire reason there is a schema.

⚠️ **Absent or unparsable handoff still closes.** That means the author's step failed or never
ran, which is not the same as incomplete — three states, not two — and the net against a merely
*forgotten* keyword has to stay in place for it.

Closes #653

## Verification

⚠️ Workflow changes cannot run before merge, so the hook was exercised directly against a stubbed
`gh`:

| case | result |
|---|---|
| `remaining: []` | `added 'Closes #617'` |
| `remaining: [2 items]` | `withheld 'Closes #617'`, warning block on the PR, comment on the task |
| author wrote `Closes #617` **and** reported remaining | keyword **stripped** — `closes-keyword present: no` |
| no handoff (author step failed) | still closes — net intact |
| malformed handoff JSON | warns, still closes — net intact |

**And the part I would not have trusted without checking:** `close-merged-work.py` has a fallback
that regexes the PR body for a closing keyword. The warning block I add contains the phrase *"does
not finish #617, and merging it will not close it"* — one wording away from re-triggering the very
close it exists to prevent. I ran that hook's own regex against the produced body and asserted
**zero matches**, so the withholding actually holds by both of its routes.

`nx run-many --target=test` ✓ (6 projects, 0 errors — claude-team is Python).

## Notes

- **Where each thing lands, and why they differ.** `remaining` is **upserted** on the task;
  `decisions` (#655) is **appended** to the story. Not an inconsistency — what is left is a
  snapshot a later run supersedes, while a decision is a record a later run must not erase.
- **The task comment matters separately from the PR block.** The PR is where the merge decision
  happens; the task is where someone looks afterwards and asks why it is still open. A PR body is
  not durable for an issue — the lesson #654 was filed for.
- **The Implementor's prompt now says leaving the keyword out is not a signal**, since an author
  that does not know about `remaining` will reach for the gesture that silently failed before.
- ⚠️ One `HANDOFF:` line added to `.github/workflows/claude-roles.yaml` — the same author output
  `post-handoff.py` already receives. Workflows are off-limits to the roles, so worth your eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
