### PR TITLE
Give the Researcher no shell

### DIFF
--- a/.github/agent-prompts/researcher.md
+++ b/.github/agent-prompts/researcher.md
@@ -20,18 +20,15 @@ Facts that shape most spikes in this repo, so you do not have to rediscover them
 - ⚠️ **`packages/app/dist/assets/*.css` is the only reliable answer to "what does this class do"** —
   daisyui is nested per-consumer, so reading `node_modules` at the repo root will mislead you.
 
-For probing:
+⚠️ **You cannot run anything here** — no `nx`, no `npm`, no Playwright, no dev server. Where a
+question needs a measurement, describe it in `unknowns.howToSettle` precisely enough that a
+Tester or Implementor task can be cut from it: which command, against which screen, and what
+result would mean what. `packages/e2e` is a Playwright harness already wired to the app, so
+naming a spec there is usually the most actionable form that brief can take.
 
-- `nx dev app` runs the app; `packages/e2e` is a Playwright harness already wired to it, and a
-  throwaway spec under `packages/e2e/tests/` driven with `npx playwright test` is usually the
-  fastest way to get a real number out of a browser.
-- ⚠️ **Delete every probe and revert every file you touched, then confirm `git status` is clean.**
-  Say so in your findings. An uncommitted scratch file at the repo root is one `git add -A` from
-  shipping.
+You can still **read** everything: the code, the `CLAUDE.md` files, `packages/spec` for what the
+product promises, and `packages/kb/data` for the real shapes. Most of what a spike needs about
+this repo is readable.
 
-Write findings **into the issue**, appended below the maintainer's question — do not rewrite it.
-⚠️ **Write no code comments** anywhere; if something needs explaining it goes in the issue or a
-`CLAUDE.md`, which is where this repo keeps its reasoning.
-
-Do not open a PR, and do not apply labels — a hook stamps `@claude/researcher` for you, and
-classification labels are derived from the title.
+Your findings go into the issue through a scripted hook, appended below the maintainer question.
+⚠️ Do not attempt to edit the issue or open a PR — you have no way to, and trying wastes turns.

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -385,12 +385,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       # ⚠️ contents READ, unlike every authoring role and unlike the Architect. A spike ships
-      # nothing and has no branch to cut, so write access would only ever be a way for this run
-      # to leave something behind. It is also the role that reads the open web, which makes it
-      # the one where a narrower blast radius is worth the most.
+      # nothing and has no branch to cut.
       contents: read
       issues: write
-      id-token: write
+      # ⚠️ NO `id-token`, unlike every other role here. Nothing in this job federates, and
+      # `base-action/src/parse-sdk-options.ts` deletes ACTIONS_ID_TOKEN_REQUEST_URL/_TOKEN from
+      # the environment it hands the agent anyway — so the permission bought nothing and only
+      # widened what a compromised run could reach (#665).
     steps:
       - uses: actions/checkout@v4
         with:
@@ -407,11 +408,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      # ⚠️ It DOES build, unlike the Architect. A spike is answered by measuring, and the
-      # difference between "the docs say handles persist" and "I stored one and it survived a
-      # reload" is the entire value of the role.
-      - name: Install dependencies
-        run: npm ci
+      # ⚠️ NO `npm ci`, and no build of any kind. See the tool grant below: this role holds no
+      # shell, so there is nothing for installed dependencies to be run by.
+      - id: findings-schema
+        name: Load the findings schema
+        run: |
+          # same constraints as the handoff schema: one line, and no single quote, because it is
+          # inlined into a single-quoted claude_args flag
+          body=$(jq -c . packages/claude-team/schemas/findings.json)
+          case "$body" in
+            *"'"*) echo "::error::findings.json contains a single quote; it cannot be inlined into claude_args"; exit 1 ;;
+          esac
+          echo "body=$body" >> "$GITHUB_OUTPUT"
+          echo "findings schema loaded (${#body} chars)"
       - name: Stamp the role label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -419,9 +428,9 @@ jobs:
           REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number }}
         run: "$RUNNER_TEMP/agent-bin/stamp-role-label.py"
-      - uses: anthropics/claude-code-action@v1
+      - id: research
+        uses: anthropics/claude-code-action@v1
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
           KIND: ${{ needs.delegate.outputs.kind }}
         with:
@@ -437,15 +446,46 @@ jobs:
           # something costs, what changed last year — so without them this role can only report
           # what is already known, which is the half nobody needed a run for.
           #
-          # ⚠️ The cost is that this is the one role whose input includes text the maintainer did
-          # not write. Its prompt says web content is data and never instruction, and `contents:
-          # read` above means a successful injection still cannot push. Do not widen either
-          # without re-reading that pairing — they are the mitigation, together.
+          # ⚠️ WHICH IS WHY IT HAS NO SHELL. This is the only role whose input is arbitrary
+          # third-party web content, so it is the only one where a prompt injection has an author.
+          # It shipped briefly with Bash(npm|npx|gh|git:*) and that was a live token-exfiltration
+          # path (#665): `npx <anything>` runs third-party code, and WebFetch is itself the egress.
+          #
+          # ⚠️ TAKING THE SECRET AWAY IS NOT AVAILABLE — the first fix attempted, and it does not
+          # work. The action re-injects it whatever this step declares:
+          #     src/entrypoints/run.ts        process.env.GITHUB_TOKEN = githubToken
+          #                                   process.env.GH_TOKEN     = githubToken
+          #     base-action/parse-sdk-options handed the agent as {...process.env}
+          # so GH_TOKEN *and* CLAUDE_CODE_OAUTH_TOKEN — an account credential, not a repo-scoped
+          # one — are both reachable by anything the agent can execute. What can be removed is the
+          # ability to execute. No shell, no read, and the credentials sit inert.
+          #
+          # ⚠️ Narrowing rather than removing would not have held either: `Write` plus any runner
+          # is agent-authored code, so a probe spec IS arbitrary execution. There is no `Write`
+          # here for the same reason.
+          #
+          # ⚠️ The residual, written down rather than claimed away: the action's base allowlist
+          # unions in Bash(git add|commit|rm:*) and git-push.sh and they cannot be removed from
+          # here. `contents: read` is what neuters them — a commit that cannot be pushed reaches
+          # nobody. That permission is now load-bearing for security, not just tidiness.
           claude_args: |
             --model sonnet
-            --allowedTools "Read,Edit,Write,WebSearch,WebFetch,Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(npx:*)"
+            --allowedTools "Read,WebSearch,WebFetch"
+            --json-schema '${{ steps.findings-schema.outputs.body }}'
             --max-turns 80
 
+      # ⚠️ THE ONLY WAY THE FINDINGS REACH ANYONE. The role has no shell, so it cannot run `gh`
+      # and cannot write its own results anywhere. Deterministic at both ends, the same shape as
+      # post-handoff.py: the schema forces the model to produce it, this forces delivery.
+      # ⚠️ Step env is per-step, so the token here is not the one the model step held.
+      - name: Post the findings to the spike
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          FINDINGS: ${{ steps.research.outputs.structured_output }}
+        run: "$RUNNER_TEMP/agent-bin/post-findings.py"
       # A spike has no branch, so nothing creates one — the hook is here only to say so out loud
       # rather than leave a silent gap where every other kind gets one.
       - name: Confirm the spike needs no branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,8 +180,10 @@ inspection (rule 1) — still the way to override a bad guess.
   Architect, because an Architect handed one decomposes a solution nobody has chosen — that is the
   whole reason the role exists (#659, after #284 sat open with no role that fitted it).
   ⚠️ **The only role that reads the open web**, which is most of its value on a question about
-  platform support or cost — and why it runs with `contents: read` while every other authoring
-  role gets `write`.
+  platform support or cost — and the reason it holds **no shell at all**: no `Bash`, no `Write`,
+  no `npm ci`. The host action re-injects `GH_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` into the
+  agent's environment whatever the workflow declares, so the credential cannot be removed — only
+  the ability to read it (#665). A measurement it needs becomes a separate task someone else runs.
 - `@claude/implementor` — issue or PR. Writes the code and opens the PR. Owns the
   *consumers* of the design system (`packages/app`, `packages/www`), not the system itself.
 - `@claude/designer` — issue or PR. An Implementor whose subject is `packages/design`: the
@@ -313,9 +315,8 @@ a real reply.
 
 **Budgets.** `sonnet` throughout except the Implementor, which runs `opus` — it is the only
 role whose output the maintainer must review line by line. Architect 100 turns,
-Security 40, the rest 80. Implementor, Tester and Researcher run `npm ci` as a step; nobody else
-builds. ⚠️ The Researcher builds because a spike is answered by **measuring** — the gap between
-"the docs say handles persist" and "I stored one and it survived a reload" is the role's value.
+Security 40, the rest 80. Implementor and Tester run `npm ci` as a step; nobody else builds —
+the Researcher deliberately does not, since it holds no shell to run anything with.
 
 **Allowlists union, they don't replace.** A role's `claude_args --allowedTools` is merged with
 the action's own base set, not substituted for it — `mergedAllowedTools = [...new Set([...

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -191,7 +191,7 @@ at all.)
 | role | picked up from | writes |
 |---|---|---|
 | Architect | an epic or an unshaped story | the issue, a story's branch, and its tasks |
-| Researcher | a spike | findings and a recommendation, appended to the issue |
+| Researcher | a spike | findings and a recommendation, appended to the issue by a hook — it holds no shell |
 | Implementor | a task stamped `Role: implementor` | code, outside the design system |
 | Designer | a task stamped `Role: designer` | code, inside the design system |
 | Tester | a task stamped `Role: tester`, one per story | tests |
@@ -210,10 +210,31 @@ already weighed and which constraint they called non-negotiable, and replacing i
 thing that was asked.
 
 ⚠️ **It is the only role that reads the open web, and the only one whose input the maintainer did
-not write.** That is deliberate — most spikes turn on facts a repository does not contain — and
-it is why the role is paired with `contents: read`: a successful prompt injection still cannot
-push. Its prompt states that web content is data and never instruction. Do not widen the
-permission or narrow the citation rule without re-reading that pairing; they are one mitigation.
+not write** — which is exactly why **it holds no shell**. No `Bash` of any kind, no `Write`, no
+`npm ci`, no build. It reads (`Read`/`Glob`/`Grep`), it fetches, and it returns JSON.
+
+⚠️ **Taking the secret away instead is not available, and that was the first fix attempted.**
+`claude-code-action` re-injects it whatever the workflow step declares —
+`src/entrypoints/run.ts` sets `process.env.GITHUB_TOKEN` and `GH_TOKEN`, and
+`base-action/src/parse-sdk-options.ts` hands the agent `{...process.env}` — so `GH_TOKEN` **and
+`CLAUDE_CODE_OAUTH_TOKEN`**, an account credential rather than a repo-scoped one, are readable by
+anything the agent can execute. The credential cannot be removed; the ability to read it can.
+⚠️ Narrowing rather than removing would not have held either: `Write` plus any runner is
+agent-authored code, so a probe spec *is* arbitrary execution. That is why probing was dropped
+from this role and a measurement it needs becomes someone else's task (#665).
+
+⚠️ **`WebFetch` is itself an egress channel**, so a narrower `Bash` grant was never the fix —
+exfiltration needs no shell if the agent can be induced to fetch a URL. Only the absence of a way
+to *read* the environment closes it.
+
+⚠️ **It carries no `id-token`**, unlike every other role. `parse-sdk-options.ts` deletes
+`ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN` from the agent's environment anyway, so the permission
+bought nothing and only widened what a compromised run could reach.
+
+⚠️ **The residual, written down rather than claimed away:** the action's base allowlist unions in
+`Bash(git add|commit|rm:*)` and `git-push.sh`, and a role cannot remove them. `contents: read` is
+what neuters them — a commit nobody can push reaches nobody — so that permission is load-bearing
+for security here, not housekeeping.
 
 ⚠️ **A spike that reports only what it settled is not finished.** What it could *not* determine is
 the section under the most pressure to skip and the most valuable to keep — without it the next
@@ -372,6 +393,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 | `sync-kind-label.py` | post, Architect + Researcher | applies the `epic`/`spike`/`bug`/`story` label `kind()` derives |
 | `file-sub-issues.py` | post, Architect | parents stories to their epic, tasks to their story |
 | `finish-pr.py` | post, authors | labels the PR and ensures it closes its issue |
+| `post-findings.py` | post, Researcher | renders its schema-forced findings onto the spike — the role has no shell, so this is the only way they reach anyone |
 | `post-handoff.py` | post, authors | posts the JSON handoff to the story's issue, and appends its `decisions` to one running log there |
 | `log-to-story.py` | post, Architect + authors + on merge | rewrites one comment on the story listing its tasks in trigger order |
 | `log-to-epic.py` | post, authors | rewrites one rolling work-log comment on the epic |

--- a/packages/claude-team/hooks/post-findings.py
+++ b/packages/claude-team/hooks/post-findings.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Post-hook for the Researcher. Renders its schema-forced findings onto the spike.
+
+⚠️ THIS EXISTS FOR A SECURITY REASON, not for tidiness. The Researcher is the only role whose
+input is arbitrary third-party web content, so it is the only one where a prompt injection has a
+plausible author. It therefore holds no shell at all — and without a shell it cannot run `gh`,
+so it cannot write its own findings anywhere. This hook is how they reach the issue.
+
+⚠️ REMOVING THE TOKEN FROM THE MODEL STEP DOES NOT WORK, and that was the first fix attempted.
+`claude-code-action` re-injects it regardless of what the workflow step declares:
+
+    // src/entrypoints/run.ts
+    process.env.GITHUB_TOKEN = githubToken;
+    process.env.GH_TOKEN = githubToken;
+
+and `base-action/src/parse-sdk-options.ts` hands the agent `{...process.env}`, so `GH_TOKEN`
+and `CLAUDE_CODE_OAUTH_TOKEN` are both readable by anything the agent executes. The credential
+cannot be taken away; what can be taken away is the ability to read it. No shell, no read.
+(That same file does `delete env.ACTIONS_ID_TOKEN_REQUEST_*`, so OIDC minting is already
+closed by the action itself — which is why this job does not need `id-token`.)
+
+APPENDS, never replaces. A spike keeps the maintainer's question; the findings are added below
+it. Re-running the Researcher adds another round rather than overwriting the first, because two
+passes over a question are a record, not a redraft.
+"""
+
+import json
+import os
+
+import team
+
+FINDINGS = os.environ.get("FINDINGS", "")
+ISSUE = os.environ.get("ISSUE", "")
+
+if not team.REPO:
+    team.fail("REPO is required")
+
+if not ISSUE:
+    print("Not triggered on an issue — nowhere to post findings.")
+    raise SystemExit(0)
+
+if not FINDINGS:
+    team.warn(
+        f"the Researcher produced no findings for #{ISSUE} — its step failed, or never ran. "
+        "The spike is unchanged."
+    )
+    raise SystemExit(0)
+
+try:
+    data = json.loads(FINDINGS)
+except json.JSONDecodeError:
+    team.warn(f"could not parse the Researcher output for #{ISSUE}; posting it raw.")
+    data = None
+
+if data is None:
+    body = f"### Findings\n\n```\n{FINDINGS}\n```\n"
+else:
+    lines = [f"### Findings\n", f"{data.get('answer', '').strip()}\n"]
+
+    options = data.get("options") or []
+    if options:
+        lines.append("#### Options\n")
+        for option in options:
+            lines.append(f"**{option.get('option', '').strip()}**")
+            lines.append(f"- *What decides it:* {option.get('distinguishes', '').strip()}")
+            lines.append(f"- *Costs:* {option.get('costs', '').strip()}\n")
+
+    # ⚠️ verified and inferred are rendered as DIFFERENT THINGS, deliberately. A reader will not
+    # re-check a confident claim, so collapsing the two is how an inference becomes a fact.
+    evidence = data.get("evidence") or []
+    if evidence:
+        lines.append("#### Evidence\n")
+        lines.append("| | Claim | Source | Checked |")
+        lines.append("|---|---|---|---|")
+        for item in evidence:
+            mark = "✅ read" if item.get("verified") else "⚠️ inferred"
+            lines.append(
+                f"| {mark} | {item.get('claim', '').strip()} | {item.get('source', '').strip()} "
+                f"| {item.get('checkedOn', '').strip()} |"
+            )
+        lines.append("")
+
+    unknowns = data.get("unknowns") or []
+    lines.append("#### Could not determine\n")
+    if unknowns:
+        for item in unknowns:
+            lines.append(f"**{item.get('question', '').strip()}**")
+            lines.append(f"- *Why not:* {item.get('whyNot', '').strip()}")
+            lines.append(f"- *How to settle it:* {item.get('howToSettle', '').strip()}\n")
+    else:
+        lines.append("_The Researcher reported nothing outstanding._\n")
+
+    lines.append("#### Recommendation\n")
+    lines.append(f"{data.get('recommendation', '').strip()}\n")
+    lines.append(
+        "> [!NOTE]\n"
+        "> Researched from the web and the repository, with no code executed. Any claim above "
+        f"marked *inferred* was not read at its source. Nothing is decided by this — #{ISSUE} "
+        "stays open until the maintainer chooses, and only then is there a story to shape.\n"
+    )
+    body = "\n".join(lines)
+
+if team.append_to_comment(
+    ISSUE,
+    "<!-- claude-team:findings -->",
+    body + team.run_footer(),
+    "## Research\n\nAppended below the question, which is left as it was asked. Newest last.",
+):
+    print(f"posted findings on #{ISSUE}")
+else:
+    team.warn(f"could not post findings on #{ISSUE}")

--- a/packages/claude-team/prompts/researcher.md
+++ b/packages/claude-team/prompts/researcher.md
@@ -16,38 +16,51 @@ decomposition, not code.
 
 ## What you produce
 
-⚠️ **APPEND to the issue; never rewrite the question.** The maintainer wrote what they wanted to
-know, and their framing is data — which options they already considered, which constraint they
-called non-negotiable, what they explicitly ruled out. Replacing it with your own account of the
-problem destroys the thing you were asked about. Add a clearly marked section, or a comment, and
-leave the question standing.
+**Your final message is a JSON object** matching the schema you were given: `answer`, `options`,
+`evidence`, `unknowns`, `recommendation`. A scripted hook renders it onto the issue below the
+maintainer's question, which is left exactly as they asked it.
 
-Your findings need, in this order:
+⚠️ **That JSON is the entire deliverable, and you cannot write anything anywhere else** — you
+hold no shell, so you cannot run `gh`, and nothing you leave in a file survives the run. Say it
+in the schema or it does not exist.
 
-1. **The answer, in one or two sentences.** If a reader stops there, they should still have the
-   thing they asked for.
-2. **The options, with what actually distinguishes them.** Not a feature matrix — the property
-   that would make someone pick one. Cost, support, failure mode, who it stops working for.
-3. **The evidence.** What you ran, what it printed, what you read and where. A measurement beats
-   a paragraph.
-4. **What you could not determine.** ⚠️ **The most valuable section, and the one under most
-   pressure to skip.** A spike that reports only what it settled reads as complete and is not;
-   the next person re-derives the gap without knowing it was a gap.
-5. **Your recommendation, stated as a choice** — and say what would change your mind.
+⚠️ **Never restate or rewrite the question.** Their framing is data: which options they had
+already weighed, which constraint they called non-negotiable, what they ruled out. The hook
+appends, so you are adding to their question rather than replacing it.
 
-## Measure, do not infer
+Two keys carry most of the value, and are the two under most pressure to skimp:
 
-You may write throwaway code to answer something, and you should when it is cheap. A probe that
-prints a real value settles what a paragraph of reasoning only argues.
+- **`evidence`** — every external fact needs its source and the date. ⚠️ `verified` is a real
+  distinction, not a formality: `true` means you read it at that source, `false` means it is your
+  inference from what you read. A reader will not re-check a confident claim, so an inference
+  rendered as fact is how a wrong decision gets made with full confidence. The hook prints the two
+  differently precisely so that difference survives.
+- **`unknowns`** — what you could **not** settle. A spike reporting only what it answered reads as
+  complete and is not, and the next person re-derives the gap without knowing it was one. Empty is
+  a real answer, and it is rarely the true one.
 
-- ⚠️ **Delete every probe before you finish, and confirm the working tree is clean.** A scratch
-  file left behind is one commit away from shipping. You are not here to leave code.
-- ⚠️ **Separate what you VERIFIED from what you INFERRED**, in the writing. A reader will not
-  re-check a confident claim, so an inference presented as fact is how a wrong decision gets
-  made with full confidence. "I ran it and got X; my read of why is Y" is worth more than either
-  half alone.
-- If you cannot answer something without shipping the feature, say that. "This cannot be settled
-  short of building it" is a real finding and sometimes the correct one.
+## You hold no shell, and that is deliberate
+
+You cannot run commands, install anything, start an app or write a probe. This is not an
+oversight to work around — it is the boundary that lets you read the open web at all.
+
+You are the only role whose input is arbitrary third-party content, so you are the only one where
+a prompt injection has an author. The credentials this job runs with cannot be removed — the host
+action puts them back whatever the workflow says — so what is removed instead is the ability to
+execute anything that could read them. A shell is what would turn a hostile page into running
+code, and you do not have one.
+
+When a question can only be settled by measuring:
+
+- **Say so in `unknowns`**, and put the exact thing to run in `howToSettle` — which command,
+  against what, and what each result would mean. That field is the brief for whoever runs it.
+- ⚠️ **Never guess a measurement and report it as evidence.** "I could not run this, and here is
+  precisely what would answer it" is a genuine, useful outcome. A plausible number nobody measured
+  is worse than no number, because it will be believed.
+- "This cannot be settled short of building it" is a real finding, and sometimes the right one.
+
+You *can* read the repository — `Read`, `Glob` and `Grep` are yours. Reading code is not running
+it, and much of what a spike needs is in there.
 
 ## Reading the web
 
@@ -71,7 +84,7 @@ Implementor. The maintainer chooses; the Architect shapes whatever they choose. 
 the same one every role here has, and it exists because a research run that quietly starts
 building has committed to an answer nobody approved.
 
-- No product code, no tests, no documentation.
+- No product code, no tests, no documentation — you could not write them if you tried.
 - No sub-issues, no milestones, no project edits — a scripted hook owns all of that.
 - ⚠️ **Do not close the spike.** The issue is the record of the question and its answer; closing
   it is the maintainer's, once they have decided.

--- a/packages/claude-team/schemas/findings.json
+++ b/packages/claude-team/schemas/findings.json
@@ -1,0 +1,89 @@
+{
+  "type": "object",
+  "description": "What a Researcher returns from a spike. Every key is required. This is the whole deliverable: the role holds no shell and writes no files, so a scripted hook posts this to the issue and nothing else the run produced is kept.",
+  "properties": {
+    "answer": {
+      "type": "string",
+      "description": "The answer to the question the spike asked, in one or two sentences. A reader who stops here should still have the thing they wanted. Not a summary of what you did - the answer."
+    },
+    "options": {
+      "type": "array",
+      "description": "The routes actually available, each with the property that would make someone pick it. Empty only when the question turned out to have a single answer rather than a choice.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "option": {
+            "type": "string",
+            "description": "The route, named the way a reader would refer to it."
+          },
+          "distinguishes": {
+            "type": "string",
+            "description": "What actually separates it from the others - cost, support, failure mode, who it stops working for. Not a feature list; the one property a decision turns on."
+          },
+          "costs": {
+            "type": "string",
+            "description": "What taking it gives up or requires, stated concretely. An option with no cost written down has not been examined."
+          }
+        },
+        "required": ["option", "distinguishes", "costs"],
+        "additionalProperties": false
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "description": "What each claim rests on. ⚠️ Every external fact needs a source and the date it was checked - support tables and pricing move, and an uncited claim becomes folklore the next reader cannot re-check.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "claim": {
+            "type": "string",
+            "description": "The specific thing established, stated so it can be checked rather than believed."
+          },
+          "source": {
+            "type": "string",
+            "description": "Where it came from - a URL, or a repo-relative path. Prefer a primary source (a spec, the vendor own docs, a release note) over an article describing one."
+          },
+          "checkedOn": {
+            "type": "string",
+            "description": "The date this was true, YYYY-MM-DD, as far as you could tell from the source itself."
+          },
+          "verified": {
+            "type": "boolean",
+            "description": "True when you read it directly at that source. False when it is your inference from what you read. ⚠️ A reader will not re-check a confident claim, so an inference presented as fact is how a wrong decision gets made with full confidence."
+          }
+        },
+        "required": ["claim", "source", "checkedOn", "verified"],
+        "additionalProperties": false
+      }
+    },
+    "unknowns": {
+      "type": "array",
+      "description": "What you could NOT determine. ⚠️ The most valuable key here and the one under most pressure to leave empty: a spike reporting only what it settled reads as complete and is not, and the next person re-derives the gap without knowing it was a gap. Empty is a real answer, but it is rarely the true one.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "question": {
+            "type": "string",
+            "description": "What remains open, stated as the question rather than as a topic."
+          },
+          "whyNot": {
+            "type": "string",
+            "description": "What stopped you - no source, contradictory sources, or it cannot be settled short of building the thing. That last one is a real finding and sometimes the correct one."
+          },
+          "howToSettle": {
+            "type": "string",
+            "description": "What would answer it. ⚠️ Where that is a measurement, say exactly what to run and what result would mean what: this role holds no shell, so a measurement is a separate task someone else runs, and this field is its brief."
+          }
+        },
+        "required": ["question", "whyNot", "howToSettle"],
+        "additionalProperties": false
+      }
+    },
+    "recommendation": {
+      "type": "string",
+      "description": "What you would do, stated as a choice rather than a survey - and what would change your mind. A recommendation nothing could overturn is not a recommendation."
+    }
+  },
+  "required": ["answer", "options", "evidence", "unknowns", "recommendation"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

#665 is right, and the reasoning in the comment I wrote was worse than incomplete: it argued
carefully that `contents: read` blocks a push, and never considered **code reading the step
environment**.

Reading `anthropics/claude-code-action`'s source settled three things, two of which invalidated
the fix I first proposed.

**1. Removing the token from the step does nothing.**

```js
// src/entrypoints/run.ts
process.env.GITHUB_TOKEN = githubToken;
process.env.GH_TOKEN = githubToken;
```

`base-action/src/parse-sdk-options.ts` then hands the agent `{...process.env}`. So `GH_TOKEN`
**and `CLAUDE_CODE_OAUTH_TOKEN`** are readable by anything the agent executes — and the Anthropic
credential is the worse of the two, being an account credential rather than repo-scoped. It
**cannot** be removed: it is how the agent authenticates.

**2. Narrowing `Bash` does not close it either.** `WebFetch` is itself the egress, so once a
secret is *readable*, exfiltration needs no shell. And `Write` plus any runner is agent-authored
code — a probe spec **is** arbitrary execution however tightly `npx` is scoped.

**3. The OIDC escalation in the report is already closed.** That same file does
`delete env.ACTIONS_ID_TOKEN_REQUEST_URL` / `_TOKEN` before the agent sees them, so no token can
be minted. The AWS trust-policy question is moot. `id-token` is dropped from the job anyway,
since it bought nothing.

### So the role loses the shell, not the web

| | before | after |
|---|---|---|
| tools | `Read,Edit,Write,WebSearch,WebFetch,Bash(gh\|git\|npm\|npx:*)` | **`Read,WebSearch,WebFetch`** |
| `npm ci` | yes | **no** |
| permissions | `contents:read, issues:write, id-token:write` | **`contents:read, issues:write`** |
| findings written by | the agent, via `gh` | **`post-findings.py`**, from schema-forced JSON |

The credential cannot be taken away, so what is taken away is the ability to read it. No shell,
no read, and the secrets in that environment sit inert.

Findings are now a required-shape JSON object (`answer` / `options` / `evidence` / `unknowns` /
`recommendation`) rendered onto the spike by a hook holding the token in its **own** step env.
That also makes the shape enforced rather than merely asked for — `evidence` carries a source and
a date per claim, and a `verified` flag that renders **✅ read** and **⚠️ inferred** differently,
because a reader will not re-check a confident claim.

Where a question needs measuring, the role says so in `unknowns.howToSettle` — precisely enough
that a Tester or Implementor task can be cut from it. Per your call: the Architect works from the
findings.

Closes #665

## Verification

⚠️ Workflow changes cannot run before merge, so the hook was exercised against a stubbed `gh`:

| case | result |
|---|---|
| full payload | renders answer, options, evidence table, unknowns, recommendation |
| `verified: true` vs `false` | **✅ read** vs **⚠️ inferred** — distinct in the output |
| second run on the same spike | **appends**; round 1 intact |
| `unknowns: []` | renders *"reported nothing outstanding"* rather than an empty heading |
| no issue / no findings / malformed JSON | warns or notes, exits 0, never fails the run |

Also asserted: `findings.json` parses, compacts to **one line**, and contains **no single quote**
— the inlining constraints the handoff schema already documents. My first draft had an
apostrophe; the assertion caught it.

Workflow parses; job is `contents:read, issues:write`, model step declares no `GH_TOKEN`, tools
are `Read,WebSearch,WebFetch`, and there is no `npm ci` step. `nx run-many --target=test` ✓.

## ⚠️ The residual, written down rather than claimed away

The action's base allowlist **unions in** `Bash(git add|commit|rm:*)` and `git-push.sh`, and a
role cannot remove them. `contents: read` is what neuters them — a commit nobody can push reaches
nobody — which makes that permission **load-bearing for security here**, not housekeeping. Worth
knowing before anyone "tidies" it to `write`.

Also worth stating plainly: **every other role runs agent-authored code with that same Anthropic
credential in env.** Their input is issues you shaped, so the exposure is far smaller — but my
earlier line that the Researcher carried "the same residual as the Implementor" was reassuring in
the wrong direction. Same mechanism; what differs is who can reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
