### PR TITLE
Pass the Researcher its own token, so it can authenticate at all

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -396,6 +396,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # ⚠️ THE ONLY CHECKOUT HERE THAT SETS THIS, and it closes a hole the "no shell" rule
+          # does not. `actions/checkout` defaults to `persist-credentials: true`, which leaves the
+          # token in `.git/config` as an `http.<host>.extraheader` — so an agent with nothing but
+          # `Read` can recover a live credential from a FILE, no command execution required, and
+          # then post it anywhere with WebFetch. Removing Bash was necessary and, on its own, not
+          # sufficient (#669).
+          #
+          # Safe to disable here because nothing in this job uses git after checkout: the model
+          # only reads, and the hooks authenticate through `gh` with a token from their own step
+          # env. ⚠️ Do NOT copy this to the authoring jobs — they push, and it would break them.
+          persist-credentials: false
       - id: prompt
         uses: ./.github/actions/load-prompt
         with:

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -388,10 +388,10 @@ jobs:
       # nothing and has no branch to cut.
       contents: read
       issues: write
-      # ⚠️ NO `id-token`, unlike every other role here. Nothing in this job federates, and
-      # `base-action/src/parse-sdk-options.ts` deletes ACTIONS_ID_TOKEN_REQUEST_URL/_TOKEN from
-      # the environment it hands the agent anyway — so the permission bought nothing and only
-      # widened what a compromised run could reach (#665).
+      # ⚠️ NO `id-token`, unlike every other role here — which is only possible because this job
+      # passes `github_token` below. The action needs OIDC to mint its own App token; removing
+      # the permission without supplying a token broke the role outright (#668). Supplying one
+      # skips that path, and is also what makes the two lines above bound the agent at all.
     steps:
       - uses: actions/checkout@v4
         with:
@@ -435,6 +435,27 @@ jobs:
           KIND: ${{ needs.delegate.outputs.kind }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # ⚠️ THE ONE ROLE THAT PASSES ITS OWN TOKEN, and it does two jobs at once.
+          #
+          # 1. It is what lets this job run without `id-token: write`. Left unset,
+          #    `setupGitHubToken()` mints an OIDC token and exchanges it for a GitHub App token —
+          #    so dropping the permission broke the role outright ("Could not fetch an OIDC
+          #    token"), the first run after #665 (#668). Set, `OVERRIDE_GITHUB_TOKEN` short-
+          #    circuits that path before OIDC is ever reached.
+          #
+          # 2. ⚠️ It is what makes the `permissions:` block above actually govern the agent. That
+          #    block scopes `secrets.GITHUB_TOKEN`; it does NOT scope the App token the exchange
+          #    mints, whose grants come from the service (`DEFAULT_PERMISSIONS` there is
+          #    `contents: write`). And `run.ts` puts whichever token it ended up with into
+          #    `process.env.GH_TOKEN`. So without this input, `contents: read` constrains the
+          #    hooks and not the model — which is the opposite of what it is there for, since the
+          #    hooks are the trusted half.
+          #
+          # ⚠️ Every other role still takes the App-token path, so their `permissions:` blocks do
+          # not bound what their agent holds either. That is a much smaller problem — their input
+          # is issues the maintainer shaped — but it is not zero, and it is not what those blocks
+          # look like they say.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # the exact handle — see the Architect's job for why a bare "@claude" kills the run
           trigger_phrase: "@claude/researcher"
           branch_prefix: ""
@@ -466,8 +487,10 @@ jobs:
           #
           # ⚠️ The residual, written down rather than claimed away: the action's base allowlist
           # unions in Bash(git add|commit|rm:*) and git-push.sh and they cannot be removed from
-          # here. `contents: read` is what neuters them — a commit that cannot be pushed reaches
-          # nobody. That permission is now load-bearing for security, not just tidiness.
+          # here. Two things neuter them, and the second is the one that actually holds: there is
+          # no `Write`, so the agent cannot author a file worth committing; and `contents: read`
+          # bounds the token — but ONLY because `github_token` is passed below. Stated without
+          # that caveat once already, and it was wrong about which token it described.
           claude_args: |
             --model sonnet
             --allowedTools "Read,WebSearch,WebFetch"

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -227,14 +227,26 @@ from this role and a measurement it needs becomes someone else's task (#665).
 exfiltration needs no shell if the agent can be induced to fetch a URL. Only the absence of a way
 to *read* the environment closes it.
 
-⚠️ **It carries no `id-token`**, unlike every other role. `parse-sdk-options.ts` deletes
-`ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN` from the agent's environment anyway, so the permission
-bought nothing and only widened what a compromised run could reach.
+⚠️ **It carries no `id-token` and passes its own `github_token`, and those two are one change.**
+Removing the permission alone broke the role outright — `setupGitHubToken()` mints an OIDC token
+and exchanges it for a GitHub App token, so with no OIDC and no supplied token the action cannot
+authenticate at all (#668). Passing `github_token` short-circuits that path before OIDC is
+reached.
+
+⚠️ **And it is what makes a `permissions:` block mean anything to the agent.** That block scopes
+`secrets.GITHUB_TOKEN`. It does **not** scope the App token the exchange mints — those grants come
+from the service — and `run.ts` puts whichever token it obtained into `process.env.GH_TOKEN`. So
+without the input, a job's `permissions:` bounds its *hooks* and not its *model*, which is exactly
+backwards: the hooks are the trusted half. ⚠️ **Every other role still takes the App-token path**,
+so their blocks do not bound their agents either. Smaller problem — their input is maintainer-
+shaped issues — but not zero, and not what those blocks look like they say.
 
 ⚠️ **The residual, written down rather than claimed away:** the action's base allowlist unions in
-`Bash(git add|commit|rm:*)` and `git-push.sh`, and a role cannot remove them. `contents: read` is
-what neuters them — a commit nobody can push reaches nobody — so that permission is load-bearing
-for security here, not housekeeping.
+`Bash(git add|commit|rm:*)` and `git-push.sh`, and a role cannot remove them. Two things neuter
+them, and the order matters: there is no `Write`, so the agent cannot author a file worth
+committing; and `contents: read` bounds the token — **but only because `github_token` is passed**.
+That second half was stated without its caveat once, and it was wrong about which token it
+described.
 
 ⚠️ **A spike that reports only what it settled is not finished.** What it could *not* determine is
 the section under the most pressure to skip and the most valuable to keep — without it the next

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -223,6 +223,13 @@ anything the agent can execute. The credential cannot be removed; the ability to
 agent-authored code, so a probe spec *is* arbitrary execution. That is why probing was dropped
 from this role and a measurement it needs becomes someone else's task (#665).
 
+⚠️ **A credential can reach the agent through a FILE, not only through the environment**, and
+removing the shell does nothing about that. `actions/checkout` defaults to
+`persist-credentials: true`, which writes the token into `.git/config` as an
+`http.<host>.extraheader` — so a role holding nothing but `Read` can recover it and post it
+anywhere it can fetch. A web-reading role's checkout therefore needs `persist-credentials: false`.
+⚠️ Only the reading role's: an authoring job pushes, and disabling it there breaks the push.
+
 ⚠️ **`WebFetch` is itself an egress channel**, so a narrower `Bash` grant was never the fix —
 exfiltration needs no shell if the agent can be induced to fetch a URL. Only the absence of a way
 to *read* the environment closes it.


### PR DESCRIPTION
## Summary

The first real Researcher run (#284, run `31228774092`) failed at the model step:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
  at getOidcToken (src/github/token.ts:58:34)
  at async setupGitHubToken (src/github/token.ts:168:27)
  at async run (src/entrypoints/run.ts:174:27)
```

**My error, in #667.** I dropped `id-token: write` on the grounds that
`base-action/src/parse-sdk-options.ts` deletes `ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN` from the
environment handed to the agent, so the permission "bought nothing". Both halves are true; I
conflated two different consumers:

- the **agent** cannot mint an OIDC token — those vars are scrubbed;
- the **action itself** can and must — `setupGitHubToken()` mints one and exchanges it for a
  GitHub App token, before the agent starts.

So I removed something load-bearing for authentication, to buy a property the action already
provided.

## And a second thing it exposed

`setupGitHubToken()` returns an **App token**, and `run.ts:187` puts it into
`process.env.GH_TOKEN`. A job's `permissions:` block scopes `secrets.GITHUB_TOKEN` — **not** that
App token, whose grants come from the exchange service (`DEFAULT_PERMISSIONS` there is
`contents: write`).

⚠️ So my claim in #667 that "`contents: read` is load-bearing — a commit nobody can push reaches
nobody" was **about the wrong token**. It bounded the hooks, not the model. Backwards, since the
hooks are the trusted half.

## Fix

Pass `github_token: ${{ secrets.GITHUB_TOKEN }}`, which sets `OVERRIDE_GITHUB_TOKEN` and returns
before OIDC is reached (`token.ts:setupGitHubToken`). One input does both jobs:

1. the role authenticates again, with `id-token` still off;
2. the `permissions:` block now genuinely bounds what the agent holds.

## Out of scope, but recorded

⚠️ **Every other role still takes the App-token path**, so `permissions:` does not bound their
agents either. Much smaller — their input is issues the maintainer shaped, not the open web — but
not zero, and not what those blocks look like they say. Worth its own decision; not folded in here.

## Acceptance criteria

- [ ] A Researcher run on #284 reaches the model and posts findings.
- [ ] `id-token` stays off.
- [ ] The docs say which token `permissions:` actually bounds.

## Verification

⚠️ This cannot be proven before merge — `issues` events run the workflow from the default branch,
which is how the original break reached you rather than me. What I can show:

- the workflow parses; researcher is `contents:read, issues:write`, `github_token` passed, tools
  still `Read,WebSearch,WebFetch`, no `npm ci`;
- `token.ts:setupGitHubToken()` returns `OVERRIDE_GITHUB_TOKEN` before any OIDC call, and
  `action.yml:298` maps the `github_token` input to it;
- `nx run-many --target=test` ✓.

**The real check is the next run on #284.** The failed run did no harm — `post-findings.py` saw no
findings, warned, and left the spike untouched, which is the degradation path working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)