### PR TITLE
Trigger the story's next task when the previous one merges

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -1205,3 +1205,22 @@ jobs:
           REPO: ${{ github.repository }}
           BASE: ${{ github.event.pull_request.base.ref }}
         run: "$RUNNER_TEMP/agent-bin/open-story-pr.py"
+      # ⚠️ AFTER close-merged-work.py, and that ordering is load-bearing: until it has run, the
+      # task this PR just finished is still open, so it would be selected as its own successor.
+      #
+      # ⚠️ TRIGGER_TOKEN must be a PAT, not GITHUB_TOKEN. GitHub will not start a workflow run
+      # from an event it created, and `delegate`'s guard excludes `github-actions[bot]` besides —
+      # so labelling with the default token would leave `@claude` sitting on an issue having
+      # triggered nothing, and firing it would then need a remove-and-re-add. The hook warns and
+      # skips when it is unset, which leaves every task triggered by hand exactly as before.
+      #
+      # ⚠️ Safe in this job on the same argument as PROJECTS_TOKEN above: there is no model step
+      # here, and step env is per-step. Never move it to job level.
+      - name: Trigger the story's next task
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRIGGER_TOKEN: ${{ secrets.TRIGGER_TOKEN }}
+          REPO: ${{ github.repository }}
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: "$RUNNER_TEMP/agent-bin/trigger-next-task.py"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,12 @@ fires for PRs too, and without the guard a PR comment started a role written for
 The router cannot pick it on a PR (rule 2 sends every PR to the Implementor).
 
 ⚠️ Every run is started by hand — a label or a comment — and the delegator picks the role from
-there. No role chains off another. **Tester and Writer briefly chained off the Implementor via
+there. No role chains off another. ⚠️ **A task does chain off a MERGE**, since #677:
+`trigger-next-task.py` labels the story's next task when the previous one's PR merges, so a story
+runs from one decision per task rather than one click per task. Nothing starts because a *role*
+finished — it starts because the maintainer merged, which was already the gate. ⚠️ It needs
+`TRIGGER_TOKEN`, a PAT that can write labels: a label applied with `GITHUB_TOKEN` starts no run at
+all, so without the secret the hook warns and every task is triggered by hand as before. **Tester and Writer briefly chained off the Implementor via
 `needs:` and it was reverted** — the job graph left them queued behind every run, and a role
 that skips after waiting reports as cancelled, so the history filled with cancelled jobs. If
 it is ever retried, the constraint that shaped it still holds: a comment cannot chain the

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -264,8 +264,10 @@ the boundary can be checked rather than negotiated. A task spanning both is two 
 only the Architect can cut it in two.
 
 ⚠️ **The Tester and Writer are tasks the Architect cuts** — the Writer ahead of the authoring
-tasks, the Tester after them. No role chains off another; nothing runs that a maintainer did
-not trigger.
+tasks, the Tester after them. ⚠️ **No role chains off another — but a task now chains off a
+MERGE.** Merging a task's PR labels the story's next task, so the whole story runs from one
+decision per task instead of one click per task. The distinction that matters: nothing starts
+because a *role* finished; it starts because the maintainer *merged*, which was already the gate.
 
 ⚠️ **A test derived from the implementation is worthless, and looks exactly like coverage.**
 It asserts what the code does, so it passes by construction and cannot fail for the only
@@ -438,6 +440,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 | `log-to-epic.py` | post, authors | rewrites one rolling work-log comment on the epic |
 | `open-story-pr.py` | **on merge** | opens the story's PR once a task has landed on its branch |
 | `close-merged-work.py` | on merge | closes the PR's issues and files them on the board |
+| `trigger-next-task.py` | on merge | labels the story's next task so it starts — needs a PAT, and says so loudly when it has none |
 
 ⚠️ These were prompt instructions until a model skipped them. A scripted step costs no
 turns and cannot be forgotten.
@@ -468,6 +471,25 @@ turns and cannot be forgotten.
   puts them in *step* env. Step env is per-step, so a scripted step can hold a token the
   model step beside it cannot read. Secret masking covers logs only — not an API payload a
   model could write.
+
+- ⚠️ **`trigger-next-task.py` needs a PAT and cannot be made to work without one.** GitHub will
+  not start a workflow run from an event created with `GITHUB_TOKEN`, and the router's `if:`
+  excludes `github-actions[bot]` besides. Labelling with the default token is **worse than doing
+  nothing**: the front-door label ends up sitting on an issue having triggered nothing, and firing
+  it then needs a remove-and-re-add. So an absent token warns and skips, leaving every task
+  triggered by hand exactly as before.
+- ⚠️ **This is NOT the chaining that was reverted.** That was `needs:` between jobs — followers
+  queued behind every run, and a skipped follower reports as cancelled, so the history filled with
+  them. This is a fresh run from a `labeled` event: no job graph, nothing queued, nothing to
+  cancel. The old revert does not argue against it.
+- ⚠️ **The chain cannot run away, and that is a property of where it is hooked.** It advances only
+  when a PR merges, and no hook merges anything — so there is exactly one human gate per task, the
+  same one that already existed. It is automation of a click, not of a decision.
+- ⚠️ **It must run AFTER `close-merged-work.py`.** Until that has closed the task this PR
+  finished, that task is still open — so it would be selected as its own successor and relabelled
+  in a loop.
+- ⚠️ **Re-applying a label GitHub already has fires no `labeled` event.** A hook that "succeeds" by
+  re-adding a present label has triggered nothing, so this one checks first and says so.
 
 ⚠️ **A scripted hook fed by model-written input is still model-driven.** Derive a hook's
 input from something the model must produce for another reason, or from state it cannot

--- a/packages/claude-team/hooks/log-to-story.py
+++ b/packages/claude-team/hooks/log-to-story.py
@@ -30,43 +30,16 @@ if not STORY:
     print("No story in scope — nothing to order.")
     raise SystemExit(0)
 
-tasks = team.sub_issues(STORY)
-if not tasks:
+if not team.sub_issues(STORY):
     print(f"#{STORY} has no tasks — nothing to order.")
     raise SystemExit(0)
 
 
-def phase(role: str) -> int:
-    """The writer first, then the authors, then the tester.
-
-    ⚠️ The writer used to sort LAST. It moved because it owns the product specification, and a
-    specification is only worth anything if it says what the code SHOULD do — which it cannot,
-    if it was written by reading the code that already exists. Running first is what makes
-    "from intent, not from the diff" true by construction rather than by instruction.
-
-    An unstamped task sorts with the authors — routing defaults it to an author too, so the two
-    stay consistent.
-    """
-    return {"writer": 1, "tester": 3}.get(role, 2)
-
-
-rows = []
-for task in tasks:
-    role = team.role_stamp(team.issue_body(task["number"]))
-    rows.append(
-        {
-            "phase": phase(role),
-            "number": task["number"],
-            "state": task.get("state", ""),
-            "role": role or "—",
-            "title": task.get("title", ""),
-        }
-    )
-rows.sort(key=lambda r: (r["phase"], r["number"]))
-
-# Ready/waiting falls out of the same order rather than being tracked separately: a task is
-# ready when everything before it is closed. So the first open task IS the one to trigger.
-nxt = next((r for r in rows if r["state"] == "open"), None)
+# ⚠️ SHARED WITH trigger-next-task.py via team.ordered_tasks/next_open_task. This used to
+# compute the order here; a second hook now acts on the answer, and two derivations of "which
+# task is next" would mean a status comment and an automatic trigger disagreeing.
+rows = team.ordered_tasks(STORY)
+nxt = team.next_open_task(rows)
 
 lines = [MARKER, "## Tasks, in trigger order", ""]
 if nxt:

--- a/packages/claude-team/hooks/team.py
+++ b/packages/claude-team/hooks/team.py
@@ -222,6 +222,58 @@ def story_from_branch(branch: str) -> str:
     return found.group(1) if found else ""
 
 
+# ── a story's tasks, in the order they should be triggered ──────────────────────────────
+
+
+def task_phase(role: str) -> int:
+    """The writer first, then the authors, then the tester.
+
+    ⚠️ The writer used to sort LAST. It moved because it owns the product specification, and a
+    specification is only worth anything if it says what the code SHOULD do — which it cannot, if
+    it was written by reading the code that already exists. Running first makes "from intent, not
+    from the diff" true by construction rather than by instruction.
+
+    An unstamped task sorts with the authors — routing defaults it to an author too, so the two
+    stay consistent.
+    """
+    return {"writer": 1, "tester": 3}.get(role, 2)
+
+
+def ordered_tasks(story: str | int) -> list[dict]:
+    """A story's tasks in trigger order, each with its `phase`, `role`, `number` and `state`.
+
+    ⚠️ SHARED ON PURPOSE. Two hooks deriving "which task is next" separately is the drift this
+    module exists to prevent — one would be fixed and the other would not, and the two answers
+    are a status comment and an automatic trigger, so a disagreement between them is a task
+    started out of order while the board says otherwise.
+
+    Order comes from two things the Architect must produce for other reasons: the `Role:` stamp,
+    and the number it created them in. A third stamp naming an order would be a third line it
+    could skip.
+    """
+    rows = []
+    for task in sub_issues(story):
+        role = role_stamp(issue_body(task["number"]))
+        rows.append({
+            "phase": task_phase(role),
+            "number": task["number"],
+            "state": task.get("state", ""),
+            "role": role or "—",
+            "title": task.get("title", ""),
+        })
+    rows.sort(key=lambda r: (r["phase"], r["number"]))
+    return rows
+
+
+def next_open_task(rows: list[dict]) -> dict | None:
+    """The task to trigger: the first open one.
+
+    Ready/waiting falls out of the order rather than being tracked separately — a task is ready
+    once everything before it is closed.
+    """
+    return next((r for r in rows if r["state"] == "open"), None)
+
+
 # ── one marked comment, rewritten in place ──────────────────────────────────────────────
 
 

--- a/packages/claude-team/hooks/trigger-next-task.py
+++ b/packages/claude-team/hooks/trigger-next-task.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Runs on a merged task PR. Labels the story's next task so it starts.
+
+A story's tasks are linear and their order is already derived, so triggering each one by hand
+is a click carrying no decision. The maintainer's decision is the MERGE; this makes the merge
+the trigger.
+
+⚠️ THE CHAIN CANNOT RUN AWAY, and that is a property of where it is hooked rather than a guard
+bolted on. It advances only when a PR merges, and nothing here merges anything — so there is
+exactly one human gate per task, the same one that already existed.
+
+⚠️ THIS NEEDS A PAT, and the reason is the whole difficulty. GitHub refuses to start a workflow
+run from an event created with `GITHUB_TOKEN`, and `delegate`'s own `if:` excludes
+`github-actions[bot]` besides. Labelling with the default token would be WORSE than doing
+nothing: the label would sit on the issue having triggered nothing, and firing it would then
+need a remove-and-re-add. So an absent token skips loudly rather than labelling uselessly.
+
+⚠️ NOT THE CHAINING THAT WAS REVERTED. That was `needs:` between jobs — followers queued behind
+every run and a skipped follower reports as cancelled, so the history filled with them. This is
+a fresh run from a `labeled` event: no job graph, nothing queued, nothing to cancel.
+
+⚠️ ORDER IT AFTER `close-merged-work.py`. That hook closes the task this PR just finished, and
+until it has, that task is still open — so it would be picked as its own successor and relabelled
+forever.
+"""
+
+import os
+
+import team
+
+BASE = os.environ.get("BASE", "")
+LABEL = os.environ.get("TRIGGER_LABEL", "@claude")
+TOKEN = os.environ.get("TRIGGER_TOKEN", "")
+
+if not team.REPO:
+    team.fail("REPO is required")
+
+# A task PR's base is its story's branch, `<story#>-<summary>`. A story PR's base is the default
+# branch, which has no leading number — so a merging story resolves to nothing and this no-ops,
+# which is right: a story merging is the end of the chain, not a link in it.
+STORY = team.story_from_branch(BASE)
+if not STORY:
+    print(f"base {BASE or '(none)'} names no story — nothing to chain.")
+    raise SystemExit(0)
+
+rows = team.ordered_tasks(STORY)
+if not rows:
+    print(f"#{STORY} has no tasks — nothing to chain.")
+    raise SystemExit(0)
+
+nxt = team.next_open_task(rows)
+if not nxt:
+    print(f"every task on #{STORY} is closed — the story is ready to review.")
+    raise SystemExit(0)
+
+number = nxt["number"]
+
+# ⚠️ Re-applying a label GitHub already has fires NO `labeled` event, so a second run would
+# silently trigger nothing. Say so rather than reporting a chain that did not happen.
+labels = {(l.get("name") or "") for l in team.issue(number, "labels").get("labels", [])}
+if LABEL in labels:
+    print(f"#{number} already carries {LABEL} — leaving it; re-applying would trigger nothing.")
+    raise SystemExit(0)
+
+if not TOKEN:
+    team.warn(
+        f"TRIGGER_TOKEN is not set, so #{number} was NOT triggered — trigger it by hand. "
+        f"A label applied with GITHUB_TOKEN starts no run (GitHub will not start a workflow from "
+        f"an event it created), so this hook does nothing at all without a PAT that can write "
+        f"labels. Set one and the chain runs; leave it and every task is triggered by hand, "
+        f"exactly as before."
+    )
+    raise SystemExit(0)
+
+# the PAT only for the write that has to look like a person; everything above read with the
+# default token
+os.environ["GH_TOKEN"] = TOKEN
+
+if team.gh("issue", "edit", str(number), "--repo", team.REPO, "--add-label", LABEL) is None:
+    team.warn(
+        f"could not add {LABEL} to #{number} — trigger it by hand. Does TRIGGER_TOKEN carry "
+        f"`repo` scope, and does the label exist?"
+    )
+    raise SystemExit(0)
+
+print(f"#{STORY} -> triggered #{number} ({nxt['role']}) with {LABEL}")


### PR DESCRIPTION
## Summary

A story's tasks are linear and their order is already derived, so triggering each by hand is a
click that carries no decision. **The decision is the merge** — this makes the merge the trigger.
Chains everything in order: writer → authors → tester.

`trigger-next-task.py` runs in `merge_housekeeping`, resolves the story from the PR's base branch,
and labels the first open task.

The ordering moves into `team.ordered_tasks` / `next_open_task`, shared with `log-to-story.py`.
That is not tidying: one hook *names* the next task in a status comment and the other *acts* on
it, so two derivations would mean a task started out of order while the board said otherwise.

Closes #677

## ⚠️ It needs a secret you have to create

`TRIGGER_TOKEN` — a PAT that can write labels.

GitHub will not start a workflow run from an event created with `GITHUB_TOKEN`, and `delegate`'s
guard excludes `github-actions[bot]` besides. Labelling with the default token would be **worse
than doing nothing**: `@claude` would sit on the issue having triggered nothing, and firing it
would then need a remove-and-re-add.

**Without the secret this changes nothing** — the hook warns and skips, and every task is
triggered by hand exactly as today. So this is safe to merge before you decide about the token.

Two notes on scoping it:
- A classic PAT with `repo`, or a fine-grained one with **Issues: write** on this repo.
- ⚠️ It lives in *step* env on a **scripted** step, in a job with **no model step** — the same
  argument that makes `PROJECTS_TOKEN` safe there. Never move it to job level.

## Two things worth knowing before you judge it

⚠️ **This is not the chaining that was reverted.** `CLAUDE.md` records that chaining "was tried
and reverted", but that was `needs:` between *jobs*: followers queued behind every run, and a
skipped follower reports as cancelled, so the history filled with them. This is a fresh run from a
`labeled` event — no job graph, nothing queued, nothing to cancel. The old revert does not argue
against it.

⚠️ **The chain cannot run away**, and that falls out of where it is hooked rather than a guard
bolted on: it advances only when a PR merges, and no hook merges anything. **One human gate per
task — the same one that already existed.** It automates a click, not a decision.

## Verification

Exercised against a stubbed `gh`:

| case | result |
|---|---|
| task PR merged, next task open, token present | `#603 -> triggered #702 (implementor) with @claude` |
| same, `TRIGGER_TOKEN` unset | warns, labels nothing, exits 0 |
| **story** PR merged into `mainline` | `base mainline names no story — nothing to chain` |
| next task already carries `@claude` | skips — ⚠️ re-applying fires no `labeled` event, so "success" there would be a chain that did not happen |
| every task closed | `the story is ready to review` |

Also: `log-to-story.py` still names **#702** after the refactor, so the comment and the trigger
agree by construction.

`nx run-many --target=test` ✓ (6 projects, 0 errors — claude-team is Python). Workflow parses;
`merge_housekeeping` still has no model step.

⚠️ **Cannot be proven before merge** — `pull_request` events run the workflow from the PR's base
branch. The real check is the first task merge after this lands.

## Ordering that is load-bearing

The step runs **after** `close-merged-work.py`. Until that has closed the task this PR finished,
that task is still open — so it would be selected as its own successor and relabelled in a loop.

## Docs

`CLAUDE.md` and `packages/claude-team/CLAUDE.md` both stated "no role chains off another" and
"nothing runs that a maintainer did not trigger". Both are now partly false and are corrected
rather than left to drift — the precise distinction being that nothing starts because a *role*
finished; it starts because you merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
