### PR TITLE
Let the Designer repair the consumers its own change breaks

### DIFF
--- a/.github/agent-prompts/designer.md
+++ b/.github/agent-prompts/designer.md
@@ -2,6 +2,16 @@ Your package is **`packages/design`** — the React UI primitives that emit Tail
 class strings. `packages/app` and `packages/www` are the *consumers*, and belong to the
 Implementor.
 
+⚠️ **You may still edit a consumer to repair a break your own change caused** — a renamed prop at
+its call sites in `packages/app`, a signature the app now passes wrongly. `tsc --noEmit` and
+`npm run build -w packages/app` are both in your gate, and a breaking primitive change cannot pass
+them otherwise. Keep it mechanical, keep it minimal, and list every file in `decisions`.
+
+⚠️ **Owning the repair is not owning the file.** Those packages are still the Implementor's: do not
+add behaviour, refactor what you are passing through, or fix an unrelated thing you notice on the
+way. If the app needs a *different value* rather than the same value spelled differently, that is a
+decision you do not get to make — report it.
+
 Read [`packages/design/CLAUDE.md`](packages/design/CLAUDE.md) before you touch anything, and
 [`DESIGN.md`](packages/design/DESIGN.md) for the long-form system (color, typography,
 spacing, radii, components).
@@ -17,7 +27,9 @@ tsconfig.
 
 ⚠️ **Tailwind v4 does not scan symlinked workspace deps.** `app/src/styles.css` and www's
 each carry a load-bearing `@source "../../design/src";`. If styling vanishes wholesale, that
-is why — but those files are the Implementor's, so report it rather than editing them.
+is why — ⚠️ but that is a **pre-existing config gap, not something your change broke**, so it
+stays reported rather than edited. It is the clearest example of the line: you repair your own
+breakage, never someone else's.
 
 ⚠️ **Don't check tailwind/daisyui behaviour by reading `node_modules` at the repo root** —
 daisyui is nested per-consumer and the root has no copy. The built CSS in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,9 +189,12 @@ inspection (rule 1) — still the way to override a bad guess.
 - `@claude/designer` — issue or PR. An Implementor whose subject is `packages/design`: the
   primitives, their props and class strings, the stories and the tokens.
   ⚠️ The split is by **package**, not by judgement, so it can be checked rather than
-  negotiated. A task that changes a primitive *and* its call sites is two tasks — the
-  Architect cuts it in two, and the Designer's prompt says to report and stop rather than
-  reach across. Implementor and Designer never both run for one task.
+  negotiated. ⚠️ **The Designer does repair the consumers its own change breaks** (#701) — a
+  breaking primitive change cannot pass `tsc`/`vite build` otherwise, and it was previously told
+  both to stop at the boundary and to hand over a green gate. The licence is mechanical only:
+  repair what your change broke, never what was already broken. A consumer needing a *different
+  value*, rather than the same value spelled differently, is behavioural and still the
+  Implementor's. Implementor and Designer never both run for one task.
 - `@claude/tester` — issue or PR. Owns `packages/e2e`.
 - `@claude/writer` — issue or PR. Owns every `CLAUDE.md` and `.claude/skills/`.
 - `@claude/security` — PR. Runs **automatically on every merge** to `mainline`, and the

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -260,8 +260,19 @@ the section under the most pressure to skip and the most valuable to keep — wi
 person re-derives the gap without knowing it was one.
 
 ⚠️ **Implementor and Designer split on the package a change touches, not on judgement**, so
-the boundary can be checked rather than negotiated. A task spanning both is two tasks, and
-only the Architect can cut it in two.
+the boundary can be checked rather than negotiated.
+
+⚠️ **But the Designer repairs the consumers its own change breaks**, and that is not a hole in the
+boundary — it is what makes the boundary survivable. A primitive is an API, so changing one can
+stop its consumers compiling, and the same role is told to hand over a green gate. Those were
+contradictory instructions and a run had to disobey one of them silently. The licence is bounded
+by a checkable line: **repair what your change broke, never what was already broken**, and keep it
+mechanical. A consumer needing a *different value* rather than the same value spelled differently
+is a behavioural decision, still the Implementor's, and still a stop-and-report.
+
+⚠️ **A task spanning both is two tasks only when the consumer half is behavioural.** Splitting a
+change whose consumer side is purely keeping the build green makes every primitive rename two
+tasks and a stall.
 
 ⚠️ **The Tester and Writer are tasks the Architect cuts** — the Writer ahead of the authoring
 tasks, the Tester after them. No role chains off another; nothing runs that a maintainer did

--- a/packages/claude-team/prompts/architect.md
+++ b/packages/claude-team/prompts/architect.md
@@ -162,11 +162,19 @@ changes fall inside the design-system package is `designer`; everything else is
 `implementor`. Read the paths rather than reasoning about which side a change "really"
 belongs to — the boundary is drawn to be checkable.
 
-**A task that changes a primitive *and* its call sites is two tasks**, and you are the only
-one who can split it: cut the design-package change as a `designer` task and the consumer
-updates as an `implementor` task, and say in the consumer task that it depends on the other.
-Neither role will reach across on its own — both are told to report and stop — so a task
-left spanning both simply stalls.
+**A task that changes a primitive *and* asks for new consumer BEHAVIOUR is two tasks**, and you
+are the only one who can split it: cut the design-package change as a `designer` task and the
+consumer work as an `implementor` task, and say in the consumer task that it depends on the other.
+
+⚠️ **Do not split a change whose consumer half is only keeping the build green.** The Designer
+repairs the call sites its own change breaks — a renamed prop, a changed signature — because a
+breaking primitive change cannot pass a typecheck or a build otherwise. Splitting that makes every
+primitive rename two tasks and a hand-off for work one role can finish.
+
+The question to ask is **mechanical or behavioural**: the same value spelled differently is the
+Designer's to fix; a *different* value, or a screen that should now do something else, is the
+Implementor's. When it is genuinely both, split it — a task left spanning a behavioural boundary
+stalls, because neither role will decide the other's half.
 
 ## Sizing is about exploration cost, not just reviewability
 

--- a/packages/claude-team/prompts/designer.md
+++ b/packages/claude-team/prompts/designer.md
@@ -25,11 +25,27 @@ checked rather than negotiated: if the file is inside the design package it is y
 it is outside it is not. Do not reason about which side a change "really" belongs to — read
 the path.
 
-⚠️ **When a task spans both sides, say so and stop.** A change to a primitive *and* its call
-sites is two tasks, and the Architect cuts it into two. Do not fix the primitive and then
-follow it out into the consumers, and do not reshape a consumer to avoid touching the
-primitive. Report what you found, name the two halves, and leave it — a Designer quietly
-editing consumer code is exactly the drift the package boundary exists to prevent.
+⚠️ **Repair what your change breaks. Never fix what was already broken, and never improve
+anything while you are there.** That is the whole licence, and it is a checkable line rather
+than a judgement.
+
+A primitive is an API, so changing one can stop its consumers compiling — and you are also told
+to hand over a green gate. Those were once contradictory instructions, and a run had to disobey
+one of them silently. So: when your own change breaks a consumer, make the **minimum mechanical
+change** that restores the build. A renamed prop at its call sites. A changed signature. A moved
+type import.
+
+⚠️ **Mechanical is the licence; behavioural is not.** If keeping the gate green needs a decision
+about how a consumer should *behave* — which value to pass now that the old one is gone, what a
+screen should do differently — stop. That is the Implementor's, and guessing it is the drift the
+package boundary exists to prevent. Report it, name what you would need decided, and leave it.
+
+⚠️ **Do not reshape a consumer to avoid touching the primitive.** The fix belongs in the design
+package; the consumer edit only follows it.
+
+⚠️ **Record every consumer file you touched in `decisions`**, with why. That is the note for
+whoever picks this up next: it lands on the story, where it outlives your run — and without it,
+the next reader finds edits outside your package with no account of who made them or why.
 
 - ⚠️ **You write no tests.** The Tester owns them. Report `testingNotes` instead.
 - ⚠️ **You change no documentation.** The Writer owns it. Report `docsCandidates` instead —
@@ -57,15 +73,23 @@ editing consumer code is exactly the drift the package boundary exists to preven
   you believe is affected but did not touch — that list is what the Implementor picks up.
   Keep it a scannable status doc. A **🔔 Maintainer** section, if you have one, goes below.
 
-## The handoff to the Tester and the Writer
+## The handoff to the roles that follow you
 
-Your **final message is a JSON object** matching the schema you were given: `testingNotes`
-for the Tester, `docsCandidates` for the Writer. They are handed it directly as context —
-neither goes looking for a section in a comment.
+Your **final message is a JSON object** matching the schema you were given: `remaining` for
+whether the task is finished at all, `decisions` for the record, `testingNotes` for the Tester,
+`docsCandidates` for the Writer. They are handed it directly as context — none goes looking for
+a section in a comment.
 
-- **Both keys are required.** `[]` is a real answer, and the right one when there is
+- **Every key is required.** `[]` is a real answer, and the right one when there is
   genuinely nothing: it says "I considered this and there is nothing here", which a later
   role can act on. A missing key says nothing at all.
+- ⚠️ **`decisions` is where a consumer edit gets accounted for**, and where anything you settled
+  that the task did not already say goes — above all something the maintainer changed in review.
+  A PR comment does not survive its thread; the issue does. State the rule now in force, not the
+  conversation.
+- ⚠️ **`remaining` is the only way to say you did not finish**, and leaving the closing keyword
+  out of the PR body is not one — a hook puts it back. Non-empty means the task stays open and
+  this list is what the next run is handed. `[]` means finished; most runs finish.
 - ⚠️ **Do not pad either list.** An entry that restates the diff costs another role a turn
   to read and reject, and trains them to skim the ones that matter.
 - `why` is the field that decides an entry. For a testing note it is the silent failure


### PR DESCRIPTION
## Summary

The Designer was given two instructions it could not both obey. From its own prompt:

> ⚠️ **When a task spans both sides, say so and stop.** … Do not fix the primitive and then follow
> it out into the consumers

and twenty lines later:

> Before you finish: **Make the repo's gate green. Never hand over a red gate.**

The gate is `npm test --ws`, `tsc --noEmit`, `npm run build -w packages/app`. Rename a prop on a
primitive with call sites in `packages/app` and `tsc` fails — so those are the same instruction
pointing opposite ways. Whichever a run picked it disobeyed the other, and **both failure modes are
silent**: a red gate handed over, or consumer edits nobody sanctioned.

Closes #701

## The rule

**Repair what your change broke. Never fix what was already broken, and never improve anything
while you are there.**

That is deliberately a *checkable* line rather than a judgement, matching how the package boundary
itself is drawn. Mechanical only — a renamed prop at its call sites, a changed signature, a moved
type import.

⚠️ **Mechanical is the licence; behavioural is not.** A consumer needing a **different value**,
rather than the same value spelled differently, is a decision the Designer does not get to make.
Stop and report — that is still the Implementor's.

The clearest illustration is one already in the overlay and now labelled as such: the tailwind
`@source` line in `app/src/styles.css` is a **pre-existing config gap, not something a design
change broke**, so it stays reported rather than edited.

## The note for whoever comes next

Every consumer file touched goes in **`decisions`**, which `post-handoff.py` lands on the story
where it outlives the run. Without it, the next reader finds edits outside the Designer's package
with no account of who made them or why.

⚠️ **That exposed a second gap.** The `designer` step carries `--json-schema` and
`post-handoff.py` reads `steps.designer.outputs.structured_output` — so the role was **already
required** to emit `remaining` and `decisions` (#666, #655) while its prompt described only
`testingNotes` and `docsCandidates`. It was being forced to produce two keys nobody had told it the
purpose of. Both are now explained.

## The Architect's split rule is refined, not dropped

**Split when the consumer half is behavioural; do not split one that is only keeping the build
green.** Otherwise every primitive rename becomes two tasks and a hand-off for work one role can
finish. The question is *mechanical or behavioural*, and the prompt now says so in those words.

## Files

| file | change |
|---|---|
| `packages/claude-team/prompts/designer.md` | the bounded rule; handoff section brought up to the real schema |
| `.github/agent-prompts/designer.md` | names the consumer packages; keeps the `@source` carve-out as the example of the line |
| `packages/claude-team/prompts/architect.md` | mechanical-vs-behavioural split |
| `packages/claude-team/CLAUDE.md`, `CLAUDE.md` | both stated the old rule flatly; corrected rather than left to drift |

## Verification

- `nx run-many --target=test` (eslint) ✓ — 6 projects, 0 errors.
- ⚠️ **`tsc --noEmit` and `nx build app` not run, and not applicable** — prompts and markdown only,
  no TypeScript touched. Saying so rather than listing them as passed.
- Both prompts still **compose**: designer 324 lines, architect 395, across all four files.
- Neither new file contains a bare `PROMPT_EOF` line — the heredoc-truncation trap `load-prompt`
  documents.

⚠️ **Cannot be proven before merge.** `issues`/`issue_comment` always run the workflow from the
default branch, so the check is the first Designer run after this lands — specifically whether it
edits a consumer *and* lists it in `decisions`, rather than doing one without the other.

## Out of scope

- The Implementor's prompt — already covers `remaining` and `decisions`.
- The package boundary itself. `packages/design` is still the Designer's and the consumers are
  still the Implementor's; this says who **repairs a break**, not who owns the file.
- Widening the Designer's tools — it already holds `Edit`/`Write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
