### PR TITLE
Ensure the story's branch exists before an authoring run

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -716,6 +716,30 @@ jobs:
       - if: contains(steps.roles.outputs.list, 'tester')
         run: npx playwright install --with-deps chromium
 
+      # ⚠️ THE STORY BRANCH MUST EXIST BEFORE ANY MODEL STEP, and until #777 nothing guaranteed
+      # it on this path. `setupBranch` resolves the base branch first of all —
+      #     const sourceBranchRef = await octokits.rest.git.getRef({ ref: `heads/${sourceBranch}` })
+      # — so a `base_branch` naming a missing ref is a 404 and the job dies in ~3s, before the
+      # model is ever called.
+      #
+      # ⚠️ It went missing because the hook that creates it was wired POST-ARCHITECT ONLY, while
+      # `delegate.py` rule 4 routes straight to the stamped role whenever a `Branch:` line is
+      # present. An issue filed with both routing lines already written — which is what a good
+      # agent-filed bug looks like — therefore skips the Architect and never gets a branch (#744).
+      #
+      # Idempotent by construction: the hook only ever handles the absent case and never touches
+      # an existing branch, so this is a guarantee rather than a second creation path.
+      #
+      # ⚠️ KIND is deliberately unset here. `delegate.py` only emits it on the Architect path, and
+      # the hook skips epics and spikes by that value — neither of which ever reaches an author.
+      - name: Ensure the story's branch exists
+        if: steps.roles.outputs.list != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+        run: "$RUNNER_TEMP/agent-bin/ensure-story-branch.py"
+
       # ⚠️ ANY role that ran, not the three that build. This shared the `npm ci` gate, which
       # is correct there — the Writer compiles nothing — and wrong here: a Writer's task is as
       # much in progress as any other, so it sat in its original column for the whole run and

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -439,7 +439,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 | `delegate.py` | the router job | picks the role from issue state — routing is scripted, not judged |
 | `stamp-role-label.py` | pre, every role | stamps `@claude/<role>` on the triggering issue or PR |
 | `set-issue-status.py` | pre, authors + post, Architect | puts an issue **on** the board and sets its Status; column and flags are inputs |
-| `ensure-story-branch.py` | post, Architect + Researcher | creates the story's branch if it is missing; an epic and a spike have none, and it says so rather than warning |
+| `ensure-story-branch.py` | post, Architect + Researcher; **pre, authors** | creates the story's branch if it is missing; an epic and a spike have none, and it says so rather than warning |
 | `sync-kind-label.py` | post, Architect + Researcher | applies the `epic`/`spike`/`bug`/`story` label `kind()` derives |
 | `file-sub-issues.py` | post, Architect | parents stories to their epic, tasks to their story |
 | `finish-pr.py` | post, authors | labels the PR, and ensures it closes its issue — or, when the author reported work `remaining`, that it does not |
@@ -468,6 +468,15 @@ turns and cannot be forgotten.
   line plus an `epic #N` reference, and adopted a meta-issue that quoted the convention as an
   example. Checking the author is a bot is what makes it sound — with the accepted cost that a
   hand-written sub-issue is never auto-parented.
+- ⚠️ **`ensure-story-branch.py` runs on the AUTHORS path too, and that is not redundancy.**
+  `delegate.py` rule 4 routes straight to the stamped role whenever a `Branch:` line is present, so
+  an issue filed with both routing lines already written — **which is what a good agent-filed bug
+  looks like** — never reaches the Architect, and so never reached the hook that creates its branch.
+  `setupBranch` resolves the base branch before anything else, so the authoring job then 404s and
+  dies in ~3s, before the model is called (#744, #777).
+  ⚠️ The deeper fault was treating the `Branch:` **line** as proof of the **branch** — a
+  model-written block standing in for state, which is the anti-pattern this file already names.
+  Running the idempotent hook once more is the cheap fix; it only ever handles the absent case.
 - ⚠️ **A role labels only what it opens.** The stamp hook marks the triggering issue or PR;
   `finish-pr.py` labels the PR that run created. Nothing labels someone else's work.
 - ⚠️ **`Closes #<issue>` is both a prompt instruction and a hook.** The model writing it puts

--- a/packages/claude-team/hooks/ensure-story-branch.py
+++ b/packages/claude-team/hooks/ensure-story-branch.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
-"""Post-hook for the Architect. Guarantees the story's branch exists on the remote.
+"""Guarantees the story's branch exists on the remote.
+
+⚠️ RUNS IN TWO PLACES, and both are load-bearing: POST on the Architect, and PRE on the authors.
+The Architect half is the original (see the ordering note below). The authors half exists because
+`delegate.py` rule 4 routes straight to the stamped role whenever a `Branch:` line is present — so
+an issue filed with both routing lines already written never reaches the Architect, and until #777
+never got a branch either. `setupBranch` resolves the base branch before anything else
+(`getRef({ref: heads/${sourceBranch}})`), so a missing one is a 404 that kills the job in ~3s,
+before the model is called at all (#744).
+
+⚠️ Idempotence is what makes running it twice safe, and it is not incidental — see the final note:
+absent is the only case this handles.
 
 WHY A HOOK AT ALL. Cutting the branch was the Architect's job and it silently failed about half
 the time, because the host action and our prompt give contradictory instructions and the model
@@ -26,6 +37,15 @@ looks at. Running after the model means the action has already generated its nam
 ⚠️ NEVER TOUCHES AN EXISTING BRANCH. Absent is the only case this handles. A branch that
 exists may carry an author's commits, and resetting it to the default branch would discard
 them — the failure this hook exists to prevent, inflicted by the fix for it.
+
+⚠️ ONE RESIDUAL, ON THE AUTHORS PATH ONLY, and it predates this hook running there. `setupBranch`
+generates the task branch as `{{entityNumber}}-{{description}}`, where `description` is the first
+five words of the title kebab-cased, and falls back to `claude/<entity>-<n>-<timestamp>` if that
+name already exists. For a STORY that can never collide — the story branch carries the story
+number and the task branch the task number. For a BUG, story and task are the same issue, so both
+begin `<issue#>-` and a collision is possible if the Branch line happens to equal those first five
+words. It degrades into the stranded-branch case `finish-pr.py` already reports, and dodging it
+would mean reimplementing the action's own naming rule here — a worse trap than the collision.
 """
 
 import os


### PR DESCRIPTION
## Summary

#744 died in **2.7s** with a 404 and never reached the model:

```
GET /repos/…/git/ref/heads%2F744-empty-scalar-blur-throws — 404
Error in branch setup: HttpError: Not Found
```

Structural, not a one-off. `delegate.py` **rule 4** routes straight to the stamped role whenever a
`Branch:` line is present, so an issue filed with **both** routing lines already written skips the
Architect — and `ensure-story-branch.py` was wired **post-Architect only**. The branch was never
created, and `setupBranch` resolves the base branch before anything else:

```js
const sourceBranchRef = await octokits.rest.git.getRef({ ref: `heads/${sourceBranch}` });
```

⚠️ **Pre-stamping the routing lines is what a good agent-filed bug looks like** — #744 came from
the Tester. So the better the filer behaves, the more reliably this broke.

⚠️ The underlying fault: **the `Branch:` line was treated as proof the branch exists.** A
model-written block standing in for state — the anti-pattern `packages/claude-team/CLAUDE.md`
already names in its own words.

Closes #777

## The fix

Run the existing `ensure-story-branch.py` as a **pre** step on the `authors` job. It is idempotent
by construction — *"absent is the only case this handles"* — so this is a guarantee, not a second
creation path.

## The collision I flagged: read the source, and it does not fire

I said on #777 not to assume this was safe. It isn't, by reasoning — it is safe by what
`setupBranch` actually does, in this order:

1. `getRef(heads/${sourceBranch})` ← **the 404 that killed #744**
2. generate `newBranch` from `{{entityNumber}}-{{description}}`
3. `git ls-remote` that generated name → if it exists, fall back to `claude/<entity>-<n>-<timestamp>`

Creating the **base** fixes (1) and never touches (3). And `branch-template.ts`'s
`extractDescription` takes the **first five words of the title**, kebab-cased — for #744 that is
`744-bug-clearing-a-scalar-input`, not `744-empty-scalar-blur-throws`.

⚠️ **A residual remains, and it predates this change.** For a **bug**, story and task are the same
issue, so both names begin `<issue#>-` and could collide if the Branch line happened to equal those
first five words. It degrades into the stranded-branch case `finish-pr.py` already reports.
Dodging it would mean reimplementing the action's naming rule inside our hook — a worse trap than
the collision. Documented in the hook instead.

## Verification

⚠️ Workflow changes cannot run before merge, so the hook was exercised against a stubbed `gh`:

| case | result |
|---|---|
| Branch line present, branch **missing** (the #744 case, `KIND` empty as on the authors path) | **created** at `mainline@abc1234` |
| branch already exists | *"leaving it alone"* — **nothing created** |
| no Branch line | warns, creates nothing |
| `KIND=epic` | skips |
| PR trigger (`ISSUE` blank) | *"no story branch to ensure"*, creates nothing |

Also asserted structurally: the new step sits at index **11**, the first model step at **14** — the
branch is guaranteed before any model runs. Workflow parses. `nx run-many --target=test` ✓
(6 projects, 0 errors — claude-team is Python).

⚠️ **The real check is the next authoring run on a pre-stamped issue.** #744's branch was created
by hand as an unblock, so it will not exercise this; the next agent-filed bug will.

## Out of scope

- #744's own fix — unblocked and independent.
- Rule 4's routing decision. Reading the `Role:` stamp is right; only the unchecked branch
  assumption was at fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
