### PR TITLE
Say on the issue when the router routed on a guess

### DIFF
--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -460,6 +460,14 @@ turns and cannot be forgotten.
   react to an unrelated comment. Empty falls back to the issue or PR itself.
 - ⚠️ **`delegate.py` defaults a missing `Role:` stamp and says so.** Wrong is recoverable,
   silent is not — a run that quietly does nothing is indistinguishable from a broken workflow.
+  ⚠️ **"Says so" now means on the issue, not only in the log.** `DEFAULTED` was emitted to
+  `$GITHUB_OUTPUT` and declared as a job output with **nothing reading it** — a required channel
+  with no consumer, the same shape that shipped dead for the #475/#476 handoff, for `decisions` on
+  the PR path, and for `docsCandidates`. It now upserts one comment naming the guess **and its
+  remedy**: the two default paths are a missing `Role:` stamp and a PR whose story cannot be
+  resolved, and each is a one-line fix, so a warning without it would be noise. Upserted rather
+  than appended — a re-run guessing the same way twice is one fact, unlike the decisions log where
+  each round is its own record.
 - ⚠️ **The log hooks rewrite ONE comment each, never one per run.** An epic with ten tasks
   across three roles would otherwise bury itself in thirty comments. They are also derived
   entirely from GitHub state — no model writes any part of them, which is the only reason

--- a/packages/claude-team/hooks/delegate.py
+++ b/packages/claude-team/hooks/delegate.py
@@ -32,11 +32,39 @@ IS_PR = os.environ.get("IS_PR", "false") == "true"
 if not team.REPO:
     team.fail("REPO is required")
 
-ROLES = STORY = STORY_BRANCH = REASON = KIND = ""
+ROLES = STORY = STORY_BRANCH = REASON = KIND = REMEDY = ""
 DEFAULTED = False
 
 
+def report_guess() -> None:
+    """Say, where the maintainer looks, that this run routed on a guess.
+
+    ⚠️ `DEFAULTED` was emitted to `$GITHUB_OUTPUT` and declared as a job output for a long time
+    with NOTHING READING IT — so "default rather than stall, but say so" said so only in a log
+    nobody opens. A required channel with no consumer is the shape that shipped dead three times
+    here already (#797).
+
+    ⚠️ UPSERTED, not appended. A re-run that guesses the same way twice is one fact, not two —
+    unlike the decisions log, where each round is a separate record worth keeping.
+
+    ⚠️ Carries the REMEDY, not just the guess. A warning the reader cannot act on is noise, and
+    the whole point is that the stamp or the branch name is a one-line fix.
+    """
+    if not (DEFAULTED and NUMBER):
+        return
+    team.upsert_comment(
+        NUMBER,
+        "<!-- claude-team:routing-guess -->",
+        "<!-- claude-team:routing-guess -->\n"
+        f"🔔 **I guessed the role for this one.** Routed to `{ROLES}` because {REASON}.\n\n"
+        f"{REMEDY}\n\n"
+        "Until then this keeps guessing the same way, which is recoverable but not right."
+        + team.run_footer(),
+    )
+
+
 def emit() -> None:
+    report_guess()
     out = os.environ.get("GITHUB_OUTPUT")
     if out:
         with open(out, "a", encoding="utf-8") as handle:
@@ -136,6 +164,11 @@ if IS_PR:
     else:
         DEFAULTED = True
         REASON = f"PR #{NUMBER} resolves to no story; defaulting to implementor"
+        REMEDY = (
+            "**To fix it:** name the head branch `<story#>-<summary>` so the story can be read "
+            "off it, or add `Closes #<issue>` to the PR body. The branch name is the primary "
+            "route — a closing reference is only the fallback."
+        )
     emit()
     raise SystemExit(0)
 
@@ -201,6 +234,14 @@ else:
     # recoverable, nothing running is not — but say so.
     ROLES = "implementor"
     DEFAULTED = True
+    REMEDY = (
+        f"**To fix it:** trigger one of #{NUMBER}'s tasks instead — a story is worked through "
+        "them, not directly."
+        if kids
+        else "**To fix it:** add `**Role: implementor|designer|tester|writer**` on its own line "
+             "in the body. The Architect normally writes it; an issue filed by hand will not "
+             "have one."
+    )
     REASON = (
         f"#{NUMBER} is a story with {kids} task(s) and no Role: stamp; defaulting to "
         "implementor — you probably meant to trigger one of its tasks"


### PR DESCRIPTION
## Summary

`delegate.py` sets `DEFAULTED = True` in exactly two places, and both carry the same comment in the
source — *"Default rather than stall … but say so."*

- `delegate.py:137` — a PR that resolves to no story
- `delegate.py:203` — a branched issue with no `Role:` stamp

It was emitted to `$GITHUB_OUTPUT` and declared as a job output at `claude-roles.yaml:181`, and
**nothing read it.** So "say so" meant a line in a log nobody opens — a required channel with no
consumer, the shape that already shipped dead for the #475/#476 handoff, for `decisions` on the PR
path, and for `docsCandidates`.

Closes #797

## What it does now

Upserts one comment on the triggering issue or PR naming the guess **and its remedy**:

> 🔔 **I guessed the role for this one.** Routed to `implementor` because #900 carries no Role: stamp.
>
> **To fix it:** add `**Role: implementor|designer|tester|writer**` on its own line in the body. The Architect normally writes it; an issue filed by hand will not have one.

⚠️ **The remedy is the point, not the warning.** Both default paths are a one-line fix — a stamp, or
a branch named `<story#>-<summary>` — so a notice without one would be noise the reader cannot act
on.

⚠️ **Upserted, not appended.** A re-run guessing the same way twice is one fact. That is the
opposite of the decisions log, deliberately: there each round is a record worth keeping, here it is
a current state.

## Why it lives in `delegate.py`

`DEFAULTED`, `REASON` and the comment machinery are already there, and the job already holds
`issues: write` for `unroutable()` — which established the same pattern with the same reasoning:
*"A silent no-op is indistinguishable from the workflow being broken."* A second hook would have
had to re-read the outputs and re-derive which default fired.

## Verification

⚠️ Workflow-adjacent, so it cannot run before merge. Exercised against a stubbed `gh` across every
routing outcome:

| case | `roles` / `defaulted` | comment |
|---|---|---|
| branched issue, no `Role:` stamp, no tasks | `implementor` / `true` | remedy = add the stamp |
| same, but it **has** tasks | `implementor` / `true` | remedy = trigger one of its tasks instead |
| PR resolving to no story | `implementor` / `true` | remedy = name the branch, or `Closes #N` |
| **confident route** (stamped `designer`) | `designer` / `false` | ⚠️ **nothing written at all** |
| two defaulted runs, same issue | — | **one** comment, reflecting the later run |

`nx run-many --target=test` ✓ (6 projects, 0 errors — claude-team is Python).

## One thing I did not do

A stale notice survives after the maintainer fixes the stamp — the next *confident* run leaves it
alone rather than clearing it. Clearing would mean listing comments on every routing decision, and
`delegate` is the hot path that runs on every trigger. The comment carries its run link, so it is
at least dated. Worth revisiting only if it proves confusing in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
