### PR TITLE
Give @claude a root role, so naming it starts a conversation

### DIFF
--- a/.github/agent-prompts/claude.md
+++ b/.github/agent-prompts/claude.md
@@ -1,0 +1,33 @@
+BrewDocs is an offline-first homebrewing PWA — an npm-workspaces monorepo,
+`packages/{app,core,design,kb,www,e2e,spec,claude-team}`, default branch `mainline`.
+
+Where to look, in the order that usually answers fastest:
+
+- **How the role system works** — [`packages/claude-team/CLAUDE.md`](packages/claude-team/CLAUDE.md).
+  The hierarchy, routing, the hooks and the trap each was written around. Most "why did it do
+  that?" questions are answered there, with the incident that caused the rule.
+- **This repo's application of it** — the root [`CLAUDE.md`](CLAUDE.md): the roles, their budgets,
+  the labels, the deploy branches.
+- **What the product promises** — `packages/spec/product/*.md`, by behaviour id.
+- **Why a specific run did something** — `gh run view <id> --log`. ⚠️ Diagnose a suspicious run by
+  its `num_turns`, never by its comment: a dead run reports success and leaves the action's
+  hardcoded placeholder, which reads exactly like a real reply.
+
+Facts that answer a lot of questions:
+
+- **The `@claude` label routes; a comment naming `@claude` reaches you.** Re-adding the label is
+  the deliberate "run again" gesture — `labeled` fires on every add.
+- **Routing is `packages/claude-team/hooks/delegate.py`**, a script, never a model. Its precedence
+  list is at the top of the file and is usually the whole answer to "why did this go there?"
+- ⚠️ **A `Branch:` line names the STORY's branch** — on the story and on every one of its tasks.
+  Anything deriving a story from a branch reads that prefix.
+- ⚠️ **`packages/claude-team` is portable** and must never name this repo, its branches or its
+  packages. Repo-specific rules live in `.github/agent-prompts/` overlays instead. If someone asks
+  for a change that would put a BrewDocs path in the package, that is the thing to point out.
+
+⚠️ **Never apply a `@claude/<role>` label or the `@claude` label to anything.** They are the
+maintainer's routing decision and a record of what has run; applying one starts work nobody asked
+for. Recommend, and stop.
+
+Write no code comments if you ever propose a change — this repo's default is none, and the *why*
+belongs in a `CLAUDE.md` where it is discoverable and maintained.

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -368,6 +368,63 @@ jobs:
           # the tasks it just cut, or an epic's stories
           INCLUDE_SUB_ISSUES: "true"
         run: "$RUNNER_TEMP/agent-bin/set-issue-status.py"
+  # ── @claude: the root role, reached by naming it in a comment ──────────────────
+  # ⚠️ ROUTED, NOT LABELLED. There is no `@claude/claude` handle and no label of its own — the
+  # router sends here (rule 1b) when a comment names `@claude` and no role handle matched. The
+  # `@claude` LABEL still routes to a working role exactly as before; the split is that the label
+  # does the work and a comment talks about it.
+  claude:
+    needs: delegate
+    if: |
+      always() && needs.delegate.result != 'skipped'
+      && contains(needs.delegate.outputs.roles, 'claude')
+    runs-on: ubuntu-latest
+    permissions:
+      # reads to answer, writes only its own reply. No branch, no PR, no code.
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # ⚠️ Same reasoning as the Researcher: `persist-credentials: true` leaves the token in
+          # `.git/config` as an http extraheader, recoverable by anything holding `Read`. This role
+          # never pushes, so there is nothing to lose by dropping it.
+          persist-credentials: false
+      - id: prompt
+        uses: ./.github/actions/load-prompt
+        with:
+          role: claude
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      # ⚠️ No role-label stamp. The stamp records "this role has been here" on work; a
+      # conversation is not work, and there is no `@claude/claude` label for it to write.
+      - uses: anthropics/claude-code-action@v1
+        env:
+          ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
+          STORY: ${{ needs.delegate.outputs.story }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # ⚠️ Supplied for the two reasons #668 established: it short-circuits `setupGitHubToken`
+          # before OIDC, so this job needs no `id-token`; and it makes the `permissions:` block
+          # above actually bound the agent, which the App token from the exchange does not.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # ⚠️ The bare handle is correct HERE and nowhere else. The action extracts everything
+          # after the phrase as "the user request" and the CLI scans it for a slash command — which
+          # is why a bare `@claude` breaks the *role* jobs, where `@claude/architect do X` would
+          # extract as `/architect do X`. It cannot happen here: rule 1b only routes to this job
+          # when no role handle matched, so the text after `@claude` is prose.
+          trigger_phrase: "@claude"
+          track_progress: true
+          prompt: ${{ steps.prompt.outputs.body }}
+          # Reads and answers. No Edit/Write: this role produces no content, and repairs are a
+          # separate bounded remit that does not exist yet.
+          claude_args: |
+            --model sonnet
+            --allowedTools "Read,Glob,Grep,Bash(gh:*),Bash(git:*)"
+            --max-turns 40
+
   # ── Researcher: answers a spike before anything is shaped ──────────────────────
   # ⚠️ ITS OWN JOB, not a step in `authors`. The authoring job's whole tail — finish-pr.py,
   # post-handoff.py, the PR label — assumes a run that produced a PR. A Researcher produces a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,8 @@ Guidance for human contributors **and** for the `@claude` GitHub integration.
 
 ### The Claude GitHub roles
 
-Seven roles, one workflow (`.github/workflows/claude-roles.yaml`), so a comment makes one run
-with the unselected roles skipping inside it rather than six skipped runs cluttering the
+Eight roles, one workflow (`.github/workflows/claude-roles.yaml`), so a comment makes one run
+with the unselected roles skipping inside it rather than seven skipped runs cluttering the
 history.
 
 **Each role's prompt is a file** — `.github/agent-prompts/<role>.md`. Editing a role means
@@ -172,6 +172,11 @@ and `delegate.py` reads the issue's state to pick the role. A bare `@claude` in 
 the same. A `@claude/<role>` handle in a comment names the role outright and skips the
 inspection (rule 1) — still the way to override a bad guess.
 
+- `@claude` **(no handle)** — the root role, reached by naming it in a **comment**. It answers:
+  explains why a run did what it did, says which role owns something, and points at what would fix
+  a process problem. It writes no code, cuts no branch and starts no role. ⚠️ **The label still
+  routes** — the split is that the label does the work and a comment talks about it, which also
+  means a bare `@claude` on a PR now answers instead of running an Implementor (#798).
 - `@claude/architect` — epic or story. Shapes the issue, cuts a story's branch, and creates
   its tasks — each stamped with the role that should pick it up.
 - `@claude/researcher` — a **spike**: an issue titled `Spike:` or labelled `spike`, whose answer

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -168,6 +168,22 @@ the issue's state to pick the role. The same label named in a comment does the s
 `@claude/<role>` handle in a comment names the role outright and skips the inspection — the
 way to override a bad guess.
 
+⚠️ **The label does the work; a comment talks about it.** That split is the whole ergonomics of
+the root role. The `@claude` **label** routes to a working role exactly as it always has. A comment
+naming `@claude` with **no** role handle now reaches the root role instead of falling through to
+rules 2-4 — so "@claude what happened here?" answers rather than starting an Implementor.
+
+⚠️ **An unknown handle lands there too.** `@claude/nonsense` matches no role, so rule 1b catches it
+and the root role can say there is no such role — where rule 3 would previously have shaped the
+issue as a story instead.
+
+⚠️ **This changes PR follow-ups.** A bare `@claude` on a PR used to run an Implementor; it now
+answers. `@claude/implementor` is the way to ask for the work, and it is unchanged.
+
+⚠️ **`trigger_phrase` is the bare `@claude` for that job, and only that job.** The usual warning —
+that a bare phrase makes `@claude/architect do X` extract as the slash command `/architect do X` and
+kills the run — cannot bite here, because rule 1b only routes to it when no role handle matched.
+
 ⚠️ **A handle skips the role decision, not the context.** It still resolves the story — from
 the PR's head branch on a PR, from the issue's **Branch** line on an issue. It did neither on
 an issue once, so a handled role started with no story and paid turns rediscovering what the
@@ -190,6 +206,7 @@ at all.)
 
 | role | picked up from | writes |
 |---|---|---|
+| `@claude` | its name in a **comment**, with no role handle | an answer. No code, no branch, no PR — it is who you talk to |
 | Architect | an epic or an unshaped story | the issue, a story's branch, and its tasks |
 | Researcher | a spike | findings and a recommendation, appended to the issue by a hook — it holds no shell |
 | Implementor | a task stamped `Role: implementor` | code, outside the design system |

--- a/packages/claude-team/hooks/delegate.py
+++ b/packages/claude-team/hooks/delegate.py
@@ -11,6 +11,7 @@ the task as a `Role:` line, which rule 4 reads.
 
 Precedence:
   1. a @claude/<role> handle in the comment wins outright
+  1b. a bare @claude in a COMMENT -> the root role, which answers rather than routes
   2. a PR            -> resolve its story, default to implementor
   3. no Branch line  -> researcher for a spike, otherwise architect, told what it is
   4. a Branch line   -> the role stamped on the task
@@ -152,6 +153,34 @@ for role in ("architect", "researcher", "implementor", "tester", "writer", "desi
                     REASON += f"; #{NUMBER} belongs to story #{STORY}"
         emit()
         raise SystemExit(0)
+
+# ---- 1b. a bare `@claude` in a COMMENT is a conversation, not a route
+#
+# ⚠️ COMMENT ONLY. The `@claude` **label** still routes exactly as it always has — that is the
+# front door and nothing here touches it. The split is worth stating plainly because it is the
+# whole ergonomics of the change: **the label does the work, a comment talks about it.**
+#
+# Reaching here means rule 1 found no `@claude/<role>` handle, so the trigger named `@claude`
+# and nothing more. Previously that fell through to rules 2-4 and started whichever role the
+# state implied — so typing "@claude what happened here?" ran an Implementor. Nothing is lost by
+# ending it: `@claude/<role>` still names a role outright, and re-adding the label is the
+# documented "run again" gesture.
+#
+# ⚠️ An unknown handle lands here too (`@claude/nonsense` matches no role), and that is the right
+# home for it — the root role can say there is no such role, where rule 3 would have silently
+# shaped the issue as a story instead.
+if COMMENT_BODY and "@claude" in COMMENT_BODY:
+    ROLES = "claude"
+    REASON = "@claude named in a comment with no role handle — answering rather than routing"
+    # the same context a handle gets: being conversational is no reason to arrive uninformed
+    if NUMBER:
+        if IS_PR:
+            STORY = resolve_pr_story()
+        else:
+            STORY_BRANCH = team.branch_line(team.issue_body(NUMBER))
+            STORY = team.story_from_branch(STORY_BRANCH)
+    emit()
+    raise SystemExit(0)
 
 # ---- 2. triggered on a PR: resolve its story, default to implementor
 if IS_PR:

--- a/packages/claude-team/prompts/claude.md
+++ b/packages/claude-team/prompts/claude.md
@@ -1,0 +1,49 @@
+You are **`@claude`** — the root role. Someone named you in a comment and wants an answer, not a
+run.
+
+Every other role here is triggered to *produce* something: code, tests, a specification, a shaped
+issue. You are the one they talk to.
+
+## Why you exist
+
+The other roles are specialists with narrow remits, and that is deliberate — a boundary that can be
+checked beats one that has to be negotiated. The cost is that nobody owns the space *between* them:
+why a run did what it did, which role a piece of work belongs to, what a label means, why an issue
+routed somewhere surprising.
+
+⚠️ **That gap is not theoretical.** Process failures accumulate there — an issue that skipped the
+step which would have created its branch, an Architect re-run that filed a second set of stories
+over the first, a PR that never linked its issue. Each was caught by a human reading carefully, and
+each could have been caught by someone whose job it was to look.
+
+## What you do
+
+- **Answer the question asked.** Directly, and in the first sentence where you can.
+- **Explain how the system behaved**, and why. You can read the repository, the issues, the PRs and
+  the workflow runs; use them rather than describing how it is supposed to work.
+- **Say which role owns something** when the answer is "not you, and not me".
+- **Say when you do not know.** A confident wrong answer about routing costs someone a run.
+
+## What you do not do
+
+- ⚠️ **You write no product content** — no code, no tests, no documentation, no specification.
+  Those have owners. Name the owner and stop. This is the same boundary every role here has, drawn
+  the same checkable way.
+- ⚠️ **You start no other role.** The maintainer triggers work. If the answer is "an Implementor
+  should do this", say so — do not try to make it happen. A run that quietly starts work nobody
+  approved is the failure the whole role model is built to avoid.
+- ⚠️ **You do not repair anything yet.** Reporting a problem you found is right; fixing it is a
+  separate, bounded remit that does not exist until it is defined. Until then, if you find
+  something broken, **say what is broken and what would fix it** — precisely enough to act on.
+
+## How to answer well
+
+- **Read before asserting.** You have the repository and `gh`. A claim you can check, check —
+  especially about a specific run, issue or file. This system's recurring failure is a confident
+  claim about behaviour that nobody verified.
+- **Distinguish what you read from what you inferred.** A reader will not re-check a confident
+  sentence, so an inference stated as fact is how a wrong decision gets made with full confidence.
+- ⚠️ **A comment is not evidence of what happened.** Runs, diffs and issue state are. Where they
+  disagree with a comment — including one written by another role — trust the state and say so.
+- Be brief. You are in a conversation, not writing a report. If the answer is one sentence, it is
+  one sentence.


### PR DESCRIPTION
## Summary

Naming `@claude` in a comment reached a **router**, not something that could answer — so
*"@claude what happened here?"* started whichever role the issue state implied.

`delegate.py` gains **rule 1b**: a comment naming `@claude` with no role handle routes to the root
role. The `@claude` **label** still routes to a working role exactly as before.

> **The label does the work; a comment talks about it.**

An unknown handle lands there too — `@claude/nonsense` matches no role, so the root role can say
there is no such role, where rule 3 would previously have shaped the issue as a story instead.

Part of #796. Closes #798

## ⚠️ One behaviour change to know about

**A bare `@claude` on a PR used to run an Implementor follow-up. It now answers.**
`@claude/implementor` is how you ask for the work, and it is unchanged. The root role still
resolves story context the way a handle does — being conversational is no reason to arrive
uninformed (measured: `roles=claude | story=651`).

## What it can and cannot do

- **Reads and answers.** `Read,Glob,Grep,Bash(gh:*),Bash(git:*)`.
- ⚠️ **No `Edit`/`Write`.** It produces no content, and repairs are a separate bounded remit that
  does not exist yet (#799). Its prompt says to report what is broken and what would fix it —
  precisely enough to act on — and stop.
- ⚠️ **No role-label stamp.** A stamp records that a role *worked* something; a conversation is not
  work, and there is no `@claude/claude` label for it to write.
- ⚠️ **It starts no other role**, and its overlay forbids applying `@claude`/`@claude/<role>`
  labels — those are your routing decision.

## The two traps it sits on, and why neither bites

**`trigger_phrase` is the bare `@claude`** — normally fatal. `CLAUDE.md` records that a bare phrase
makes `@claude/architect do X` extract as the slash command `/architect do X`, which killed every
comment-triggered role between #485 and #488. It cannot happen here: **rule 1b only routes to this
job when no role handle matched**, so the text after the phrase is always prose.

**Token and checkout follow #668/#669.** `github_token` is supplied, so the job needs no
`id-token` *and* its `permissions:` block actually bounds the agent — which the App token from the
exchange does not. `persist-credentials: false`, since it never pushes and a token left in
`.git/config` is readable by anything holding `Read`.

## Verification

⚠️ Workflow changes cannot run before merge. Routing exercised against a stubbed `gh`:

| trigger | routes to |
|---|---|
| comment: `@claude why did this…` | **`claude`** |
| comment: `@claude/nonsense …` | **`claude`** |
| comment: `@claude/architect` / `/researcher` / `/tester` | architect / researcher / tester — unchanged |
| **label** on a stamped task | `designer` — unchanged |
| **label** on an unshaped issue | `architect` — unchanged |
| **label** on a PR | `implementor` — unchanged |
| comment `@claude` on a **PR** | `claude`, with `story=651` resolved |

Prompt composes from all four files (260 lines); no bare `PROMPT_EOF`. Workflow parses; job is
`contents: read, issues: write`. `nx run-many --target=test` ✓.

## Scope

This is **half** of #798 as written. The other half — the custodian **intercepting** a `defaulted`
route and supplying the role — needs a model step inside the `delegate` job plus an
outputs-resolution step, and it depends on this prompt existing. It follows in its own PR, along
with suppressing #797's guess notice when the custodian answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
