### PR TITLE
Ask @claude which role to run when the router has to guess

### DIFF
--- a/.github/agent-prompts/route.md
+++ b/.github/agent-prompts/route.md
@@ -1,0 +1,19 @@
+## Routing in BrewDocs
+
+The Implementor/Designer split is a package boundary here, so it is checkable rather than a
+judgement. Read which package the issue names:
+
+| the issue touches | role |
+|---|---|
+| `packages/design/**` | `designer` |
+| `packages/app/**`, `packages/www/**`, `packages/core/**`, `packages/kb/**` | `implementor` |
+| `packages/e2e/**` | `tester` |
+| `packages/spec/**`, any `CLAUDE.md`, `.claude/skills/**` | `writer` |
+
+⚠️ **A task naming `packages/design` *and* a consumer is still `designer`.** The Designer repairs
+the consumers its own change breaks — that is deliberate (#701), not a boundary violation, and
+splitting it would make every primitive rename two tasks and a stall. It is only two tasks when
+the consumer half needs a *different value* rather than the same value spelled differently.
+
+⚠️ **`packages/claude-team/**` and `.github/workflows/**` are not an author's.** A change to the
+role system itself is the maintainer's, driven from a local session. Answer `undecided` and say so.

--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -172,16 +172,30 @@ jobs:
       issues: write
       pull-requests: read
     outputs:
-      roles: ${{ steps.route.outputs.roles }}
+      # ⚠️ FROM `resolve`, NOT `route`. Where the script had to fall back to a default, the root
+      # role is asked inside this job and `resolve` settles which of the two answers wins. Reading
+      # `route` here would run the guess and quietly discard the answer.
+      roles: ${{ steps.resolve.outputs.roles }}
+      # ⚠️ THE REST STILL COME FROM `route`, and that split is deliberate. The interception decides
+      # a ROLE; the story, its branch and the issue kind are read from state and are not in doubt —
+      # a model has no business restating them, and letting it would put two sources on one fact.
       story: ${{ steps.route.outputs.story }}
       # the branch NAME, not the number — passed to the host action as `base_branch` so an
       # author's task branch is cut off the story's branch instead of the default one
       story_branch: ${{ steps.route.outputs.story_branch }}
       kind: ${{ steps.route.outputs.kind }}
-      defaulted: ${{ steps.route.outputs.defaulted }}
-      reason: ${{ steps.route.outputs.reason }}
+      # ⚠️ `defaulted` and `reason` are NOT job outputs. They were, for as long as they existed,
+      # with nothing in any job reading either — which is the exact defect #797 fixed one level
+      # down, reproduced one level up. Both are live *step* outputs feeding `resolve` and
+      # `report-route.py` inside this job; a job-level declaration only invites a reader to assume
+      # something gates on them.
     steps:
       - uses: actions/checkout@v4
+        with:
+          # ⚠️ The custodian step below reads issue bodies, which anyone can file. Same reasoning
+          # as the Researcher: `persist-credentials: true` leaves the token in `.git/config` as an
+          # http extraheader, recoverable by anything holding `Read`. Nothing in this job pushes.
+          persist-credentials: false
       - name: Stash the agent hooks
         run: |
           mkdir -p "$RUNNER_TEMP/agent-bin"
@@ -212,6 +226,153 @@ jobs:
           # only PR path in is a comment or review.
           IS_PR: ${{ (github.event.issue.pull_request || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review') && 'true' || 'false' }}
         run: "$RUNNER_TEMP/agent-bin/delegate.py"
+
+      # ── The interception ──────────────────────────────────────────────────────────
+      # Where `delegate.py` had to guess, ask the root role before running the guess.
+      #
+      # ⚠️ A STEP IN THIS JOB, and each of the three alternatives is ruled out by something this
+      # repo has already paid for:
+      #   - a new workflow run — an event created with `GITHUB_TOKEN` starts nothing, by design.
+      #   - a job the roles `needs:` — a job needing a SKIPPED job reports cancelled, which is
+      #     exactly the noise #430 reverted; this would skip on every non-defaulted run.
+      #   - a job that `needs: delegate` — too late. The role jobs gate on this job's outputs, so
+      #     by the time it could speak they have already started on the guess.
+      # A job cannot gate on a step inside itself; it CAN gate on an output that step produced.
+      #
+      # ⚠️ THIS DOES NOT MAKE ROUTING A MODEL DECISION. Rules 1-4 are readable state and stay
+      # scripted. This runs only where the state that should have decided is absent — the choice
+      # is not "script or model", it is "read the issue or guess".
+      - id: route-schema
+        name: Load the routing schema
+        if: steps.route.outputs.defaulted == 'true'
+        run: |
+          # same constraints as the handoff and findings schemas: one line, and no single quote,
+          # because it is inlined into a single-quoted claude_args flag
+          body=$(jq -c . packages/claude-team/schemas/route.json)
+          case "$body" in
+            *"'"*) echo "::error::route.json contains a single quote; it cannot be inlined into claude_args"; exit 1 ;;
+          esac
+          echo "body=$body" >> "$GITHUB_OUTPUT"
+          echo "routing schema loaded (${#body} chars)"
+      - id: route-prompt
+        if: steps.route.outputs.defaulted == 'true'
+        uses: ./.github/actions/load-prompt
+        with:
+          role: route
+      - id: custodian
+        name: Ask the root role which role this is
+        if: steps.route.outputs.defaulted == 'true'
+        # ⚠️ A FAILED INTERCEPTION MUST NOT MEAN NOTHING RUNS. The script's default is the floor:
+        # `resolve` falls back to it whenever this step produces no usable answer, and this keeps
+        # the job green so it gets there. Degrading to the old behaviour is the correct failure.
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        env:
+          ISSUE: ${{ github.event.issue.number }}
+          STORY: ${{ steps.route.outputs.story }}
+          # what the script fell back to and why — the model is correcting a specific guess, not
+          # routing from scratch, and saying which one saves it rediscovering the gap
+          ROUTE_DEFAULT: ${{ steps.route.outputs.roles }}
+          ROUTE_REASON: ${{ steps.route.outputs.reason }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # ⚠️ Required, not optional — the same pairing #668 established. It short-circuits
+          # `setupGitHubToken` before OIDC, which is why this job needs no `id-token`; and it is
+          # what makes this job's `permissions:` block bound the agent at all, since the App token
+          # the exchange would otherwise mint is scoped by the service and not by that block.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # ⚠️ NO `track_progress`, and that is the one place this job differs from every other
+          # model step here. With a prompt supplied and no track_progress the action picks AGENT
+          # mode (`src/modes/detector.ts`), which means: our prompt is authoritative rather than
+          # wrapped in the tag-mode framing that tells a model its instructions are the triggering
+          # comment — and there is no triggering comment on a label event anyway — and no tracking
+          # comment is created. The usual objection to agent mode is that losing the tracking
+          # comment loses the maintainer's window into the run; it does not apply to a routing
+          # decision, whose durable record is the comment `report-route.py` writes below. Two
+          # comments for one sub-second decision would be the worse outcome.
+          # ⚠️ `structured_output` is unaffected — `src/entrypoints/run.ts` sets it after the run,
+          # in either mode. Checked in source rather than assumed.
+          prompt: ${{ steps.route-prompt.outputs.body }}
+          # Reads the issue and answers. No Write/Edit: it must not "helpfully" add the missing
+          # `Role:` stamp — a route that rewrote its own input would leave nothing to notice.
+          claude_args: |
+            --model sonnet
+            --allowedTools "Read,Glob,Grep,Bash(gh:*)"
+            --json-schema '${{ steps.route-schema.outputs.body }}'
+            --max-turns 15
+
+      - id: resolve
+        name: Settle the route
+        # ⚠️ `always()`, because the step above may have failed and this is what falls back.
+        if: always()
+        env:
+          SCRIPT_ROLES: ${{ steps.route.outputs.roles }}
+          SCRIPT_REASON: ${{ steps.route.outputs.reason }}
+          SCRIPT_REMEDY: ${{ steps.route.outputs.remedy }}
+          # empty when the step was skipped, failed, or returned nothing
+          CUSTODIAN: ${{ steps.custodian.outputs.structured_output }}
+        run: |
+          # ⚠️ Reads one field, and CANNOT fail the step. Empty input, unparseable input and a
+          # missing key all come back as the empty string, which is what makes the fallback below
+          # the automatic behaviour rather than something that has to be reached.
+          # ⚠️ jq is captured BEFORE the pipeline rather than inside it. `|| true` at the end of a
+          # pipe guards the last command, not jq — correct today only because the default `run:`
+          # shell is `bash -e` with no `pipefail`, which is not a thing to depend on.
+          # ⚠️ AND IT TRIMS. $GITHUB_OUTPUT is line-oriented so newlines have to go, but a bare
+          # `tr` turns jq's trailing newline into a trailing SPACE — measured: an empty `why` came
+          # back as " ", passed `[ -n ]`, and produced a resolution notice with no reason in it.
+          field() {
+            local raw
+            raw=$(printf '%s' "$CUSTODIAN" | jq -r "$1 // \"\"" 2>/dev/null) || raw=""
+            printf '%s' "$raw" | tr '\n\t' '  ' | sed -e 's/  */ /g' -e 's/^ //' -e 's/ *$//'
+          }
+          role=$(field .role)
+          why=$(field .why)
+          remedy=$(field .remedy)
+
+          # ⚠️ THE ALLOWLIST IS THE SAFETY, not the schema. An enum constrains a well-behaved
+          # model; this constrains the output. `undecided` — the honest answer, and the one the
+          # prompt asks for over a coin flip — falls through here to the script's default, which
+          # is exactly right: it keeps the guess AND the notice that announces it.
+          case "$role" in
+            architect|researcher|implementor|designer|tester|writer) ;;
+            *) role="" ;;
+          esac
+
+          if [ -n "$role" ] && [ -n "$why" ]; then
+            {
+              echo "roles=$role"
+              echo "reason=$why"
+              echo "remedy=${remedy:-$SCRIPT_REMEDY}"
+              echo "resolved_by=custodian"
+            } >> "$GITHUB_OUTPUT"
+            echo "resolved by the custodian: $role — $why"
+          else
+            {
+              echo "roles=$SCRIPT_ROLES"
+              echo "reason=$SCRIPT_REASON"
+              echo "remedy=$SCRIPT_REMEDY"
+              echo "resolved_by=script"
+            } >> "$GITHUB_OUTPUT"
+            echo "resolved by the script: $SCRIPT_ROLES — $SCRIPT_REASON"
+          fi
+
+      # ⚠️ AFTER `resolve`, never inside `delegate.py`, and that ordering is the fix. Announcing a
+      # default at the moment the script picks it announces it before the root role has been
+      # asked — so an intercepted run posted "I guessed" and then ran something else. The notice
+      # has to describe the decision that actually took effect (#798).
+      - name: Say how this run routed
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          DEFAULTED: ${{ steps.route.outputs.defaulted }}
+          ROLES: ${{ steps.resolve.outputs.roles }}
+          REASON: ${{ steps.resolve.outputs.reason }}
+          REMEDY: ${{ steps.resolve.outputs.remedy }}
+          RESOLVED_BY: ${{ steps.resolve.outputs.resolved_by }}
+        run: "$RUNNER_TEMP/agent-bin/report-route.py"
 
   # ── Architect ────────────────────────────────────────────────────────────────
   # Shapes work so the others can act on it. On an epic it defines the goal and cuts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,10 @@ inspection (rule 1) — still the way to override a bad guess.
   a process problem. It writes no code, cuts no branch and starts no role. ⚠️ **The label still
   routes** — the split is that the label does the work and a comment talks about it, which also
   means a bare `@claude` on a PR now answers instead of running an Implementor (#798).
+  ⚠️ **It is also reached without being named**, as a step inside `delegate` whenever the router
+  had to guess: it reads the issue, returns a role, and the script's default becomes the fallback
+  rather than the decision. Its second prompt is `route.md`; the mechanics and the three job shapes
+  that do *not* work are in `packages/claude-team/CLAUDE.md`.
 - `@claude/architect` — epic or story. Shapes the issue, cuts a story's branch, and creates
   its tasks — each stamped with the role that should pick it up.
 - `@claude/researcher` — a **spike**: an issue titled `Spike:` or labelled `spike`, whose answer

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -194,6 +194,52 @@ state-based rules, which would re-judge the role and could pick a different one.
 needs judgement — which author owns a task — is answered once by the Architect and written
 into the task as a `Role:` line.
 
+### When the script has to guess
+
+⚠️ **A `defaulted` route means "ask", not "run".** Rules 1-4 decide from state, and where the
+state that should decide is missing they fall back to a default rather than stall. That default is
+now a **floor**: the router job puts the question to the root role first, and runs the fallback
+only if it cannot answer. The choice this adds is not "script or model" — it is "read the issue or
+guess", and guessing was the incumbent.
+
+⚠️ **It is a STEP in the router job, and each alternative is ruled out by something already paid
+for here:**
+
+| shape | why not |
+|---|---|
+| a new workflow run | an event created with the workflow token starts no run, by design |
+| a job the roles `needs:` | a job needing a **skipped** job reports cancelled — the #430 revert, verbatim |
+| a job that `needs:` the router | too late; role jobs gate on the router's outputs and have already started |
+
+A job cannot gate on a step inside itself. It *can* gate on an output that step produced, which is
+what makes the step form work where the job form does not.
+
+⚠️ **The step's answer is filtered by an allowlist, not trusted because it matched a schema.** A
+shell step accepts a known role and discards anything else, so a malformed answer, a failed step, a
+skipped step and `undecided` all arrive as the same thing: the script's default, with its notice
+intact. **A failed interception must never mean nothing runs** — degrading to the old behaviour is
+the correct failure, and the step carries `continue-on-error` so the job reaches the fallback.
+
+⚠️ **`undecided` has to be a real answer, or the schema manufactures a guess.** An enum of roles
+alone leaves no way to say "the issue does not tell me", so a model obliged to pick one produces
+exactly the confident-wrong route this is meant to remove — and worse than the script's, because
+answering suppresses the guess notice that would have flagged it.
+
+⚠️ **It decides the ROLE and nothing else.** The story, its branch and the issue kind stay on the
+script's outputs. They are read from state and are not in doubt; letting a model restate them puts
+two sources on one fact.
+
+⚠️ **Announcing a default belongs AFTER the decision, not inside `delegate.py`.** It was inside,
+and that was one step too early: the script announced its guess before anything had been asked, so
+an intercepted run posted "I guessed" and then ran something else — a notice describing a decision
+that never took effect, which is worse than none because it is a false record of *why* the run did
+what it did. `report-route.py` runs after resolution and says whichever actually happened.
+
+⚠️ **Deciding correctly does not repair the issue.** The missing stamp is still missing and the
+next trigger takes the same detour, so the remedy is carried on **both** outcomes. Only the
+sentence changes: a guess "keeps guessing the same way", an interception "costs a run before any
+of the work starts".
+
 ⚠️ **The role stamp is a record, not a route.** Roles stamp `@claude/<role>` as they start,
 so the labels read as "these agents have been here". Nothing routes off them.
 
@@ -206,7 +252,7 @@ at all.)
 
 | role | picked up from | writes |
 |---|---|---|
-| `@claude` | its name in a **comment**, with no role handle | an answer. No code, no branch, no PR — it is who you talk to |
+| `@claude` | its name in a **comment**, with no role handle; **and** a route the script had to guess | an answer, or a role name. No code, no branch, no PR — it is who you talk to |
 | Architect | an epic or an unshaped story | the issue, a story's branch, and its tasks |
 | Researcher | a spike | findings and a recommendation, appended to the issue by a hook — it holds no shell |
 | Implementor | a task stamped `Role: implementor` | code, outside the design system |
@@ -214,6 +260,20 @@ at all.)
 | Tester | a task stamped `Role: tester`, one per story | tests |
 | Writer | a task stamped `Role: writer`, one per story, run **first** | the product specification, then documentation |
 | Security | every merge, plus its handle on a PR | issues it files |
+
+⚠️ **The root role has two jobs and two prompts.** `claude.md` is the conversation — someone asked
+it something. `route.md` is the interception — nobody asked it anything, and its whole output is a
+role name plus the reason, returned as JSON to a shell step. Splitting them is not tidiness: a
+conversational prompt handed a routing decision answers in prose, and a routing prompt handed a
+question answers with an enum. Same persona, same bounds, different contract.
+
+⚠️ **`route.md` is loaded by a STEP, so it runs in agent mode**, and that is the one place here
+where losing the tag-mode tracking comment is the *better* outcome — the durable record is the
+comment `report-route.py` writes, and a tracking comment beside it would be two comments for one
+sub-second decision. It is also why the prompt is authoritative rather than wrapped in the
+framing that tells a model its instructions are the triggering comment; there is no comment on a
+label event to be confused by. ⚠️ `structured_output` is set after the run in either mode, so the
+schema still binds — checked in the action's source, not assumed.
 
 ⚠️ **The Researcher answers; it does not shape.** It appends findings to the spike and stops —
 it creates no story, cuts no branch and starts no author. The maintainer decides, and only then
@@ -454,6 +514,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 |---|---|---|
 | `acknowledge.py` | the router job, first | reacts 👀 so the trigger is visibly received |
 | `delegate.py` | the router job | picks the role from issue state — routing is scripted, not judged |
+| `report-route.py` | the router job, last | says on the issue that this run did not route from state alone — whether the script guessed or the root role was asked |
 | `stamp-role-label.py` | pre, every role | stamps `@claude/<role>` on the triggering issue or PR |
 | `set-issue-status.py` | pre, authors + post, Architect | puts an issue **on** the board and sets its Status; column and flags are inputs |
 | `ensure-story-branch.py` | post, Architect + Researcher; **pre, authors** | creates the story's branch if it is missing; an epic and a spike have none, and it says so rather than warning |
@@ -477,14 +538,21 @@ turns and cannot be forgotten.
   react to an unrelated comment. Empty falls back to the issue or PR itself.
 - ⚠️ **`delegate.py` defaults a missing `Role:` stamp and says so.** Wrong is recoverable,
   silent is not — a run that quietly does nothing is indistinguishable from a broken workflow.
-  ⚠️ **"Says so" now means on the issue, not only in the log.** `DEFAULTED` was emitted to
+  ⚠️ **"Says so" means on the issue, not only in the log.** `DEFAULTED` was emitted to
   `$GITHUB_OUTPUT` and declared as a job output with **nothing reading it** — a required channel
   with no consumer, the same shape that shipped dead for the #475/#476 handoff, for `decisions` on
-  the PR path, and for `docsCandidates`. It now upserts one comment naming the guess **and its
-  remedy**: the two default paths are a missing `Role:` stamp and a PR whose story cannot be
-  resolved, and each is a one-line fix, so a warning without it would be noise. Upserted rather
-  than appended — a re-run guessing the same way twice is one fact, unlike the decisions log where
-  each round is its own record.
+  the PR path, and for `docsCandidates`. One comment names the route **and its remedy**: the two
+  default paths are a missing `Role:` stamp and a PR whose story cannot be resolved, and each is a
+  one-line fix, so a warning without it would be noise. Upserted rather than appended — a re-run
+  resolving the same way twice is one fact, unlike the decisions log where each round is its own
+  record.
+  ⚠️ **`report-route.py` writes it, not `delegate.py`, because the announcement has to follow the
+  interception** — see *When the script has to guess*. Both outcomes share the comment's marker, so
+  a later interception **replaces** an earlier guess rather than stacking under it.
+  ⚠️ **The same defect one level up: `defaulted` and `reason` were job outputs nobody read.** The
+  fix for the router's dead channel reproduced it at the job boundary. They are step outputs now,
+  consumed inside the router job; a job-level declaration only invites a reader to assume something
+  gates on them.
 - ⚠️ **The log hooks rewrite ONE comment each, never one per run.** An epic with ten tasks
   across three roles would otherwise bury itself in thirty comments. They are also derived
   entirely from GitHub state — no model writes any part of them, which is the only reason

--- a/packages/claude-team/hooks/delegate.py
+++ b/packages/claude-team/hooks/delegate.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
-"""Decides which role handles an event, from issue state. Emits `roles`, `story`, `defaulted`
-and `reason` to $GITHUB_OUTPUT; every role job gates on `roles`.
+"""Decides which role handles an event, from issue state. Emits `roles`, `story`, `defaulted`,
+`reason` and `remedy` to $GITHUB_OUTPUT; every role job gates on `roles`.
+
+⚠️ `defaulted` MEANS "ASK SOMEONE ELSE", not "run this". Where it is true the workflow puts the
+route to the root role before any role job starts, and only falls back to what this script chose
+if that cannot answer. So a default here is a floor, not the decision — which is why nothing in
+this file announces one any more; see `emit`.
 
 THIS IS A SCRIPT ON PURPOSE. Routing was going to be a model step emitting JSON, and that is
 the pattern this repo has been bitten by most — a model asked to produce data a consumer
@@ -37,41 +42,23 @@ ROLES = STORY = STORY_BRANCH = REASON = KIND = REMEDY = ""
 DEFAULTED = False
 
 
-def report_guess() -> None:
-    """Say, where the maintainer looks, that this run routed on a guess.
-
-    ⚠️ `DEFAULTED` was emitted to `$GITHUB_OUTPUT` and declared as a job output for a long time
-    with NOTHING READING IT — so "default rather than stall, but say so" said so only in a log
-    nobody opens. A required channel with no consumer is the shape that shipped dead three times
-    here already (#797).
-
-    ⚠️ UPSERTED, not appended. A re-run that guesses the same way twice is one fact, not two —
-    unlike the decisions log, where each round is a separate record worth keeping.
-
-    ⚠️ Carries the REMEDY, not just the guess. A warning the reader cannot act on is noise, and
-    the whole point is that the stamp or the branch name is a one-line fix.
-    """
-    if not (DEFAULTED and NUMBER):
-        return
-    team.upsert_comment(
-        NUMBER,
-        "<!-- claude-team:routing-guess -->",
-        "<!-- claude-team:routing-guess -->\n"
-        f"🔔 **I guessed the role for this one.** Routed to `{ROLES}` because {REASON}.\n\n"
-        f"{REMEDY}\n\n"
-        "Until then this keeps guessing the same way, which is recoverable but not right."
-        + team.run_footer(),
-    )
-
-
 def emit() -> None:
-    report_guess()
+    """Write the route to `$GITHUB_OUTPUT`. This does NOT announce a default.
+
+    ⚠️ IT USED TO, AND THAT WAS ONE STEP TOO EARLY. Announcing here means announcing before the
+    root role has been asked, so an intercepted route posted "I guessed" and then ran something
+    else — the notice describing a decision that never took effect. `report-route.py` runs after
+    the interception instead, and says whichever of the two actually happened.
+
+    `remedy` rides along for it: the fix for a default outlives the run that hit it, and the hook
+    is where it gets said.
+    """
     out = os.environ.get("GITHUB_OUTPUT")
     if out:
         with open(out, "a", encoding="utf-8") as handle:
             handle.write(
                 f"roles={ROLES}\nstory={STORY}\nstory_branch={STORY_BRANCH}\nkind={KIND}\n"
-                f"defaulted={str(DEFAULTED).lower()}\nreason={REASON}\n"
+                f"defaulted={str(DEFAULTED).lower()}\nreason={REASON}\nremedy={REMEDY}\n"
             )
     print(
         f"roles={ROLES} story={STORY or 'none'} branch={STORY_BRANCH or 'none'} "

--- a/packages/claude-team/hooks/report-route.py
+++ b/packages/claude-team/hooks/report-route.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Says, where the maintainer looks, that this run did not route from state alone.
+
+⚠️ THIS EXISTS BECAUSE `defaulted` WAS A CHANNEL WITH NO READER. It was emitted to
+`$GITHUB_OUTPUT` and declared as a job output for a long time with nothing consuming it — so
+"default rather than stall, but say so" said so only in a log nobody opens. That is the same shape
+that shipped dead for the #475/#476 handoff, for `decisions` on the PR path, and for
+`docsCandidates` (#797).
+
+⚠️ IT RUNS AFTER THE INTERCEPTION, not inside `delegate.py`, and the ordering is the whole point.
+The script announcing its own default announces it before the root role has been asked — so an
+intercepted route posted "I guessed" and then ran something else entirely. A notice describing a
+decision that did not take effect is worse than none: it is a false record of why the run did what
+it did (#798).
+
+⚠️ ONE COMMENT, UPSERTED, and the two outcomes share its marker deliberately. A re-run that
+resolves the same way twice is one fact, not two — unlike the decisions log, where each round is
+its own record. Sharing the marker is also what makes a later interception *replace* an earlier
+guess rather than sit under it.
+
+⚠️ THE REMEDY SURVIVES BOTH OUTCOMES. Deciding correctly does not repair the issue: the stamp is
+still missing and the next trigger lands in the same fallback. A notice the reader cannot act on
+is noise, and this one is only ever raised where the fix is a single line.
+"""
+
+import os
+
+import team
+
+NUMBER = os.environ.get("NUMBER", "")
+DEFAULTED = os.environ.get("DEFAULTED", "") == "true"
+ROLES = os.environ.get("ROLES", "")
+REASON = os.environ.get("REASON", "")
+REMEDY = os.environ.get("REMEDY", "")
+RESOLVED_BY = os.environ.get("RESOLVED_BY", "script")
+
+MARKER = "<!-- claude-team:routing-guess -->"
+
+if not team.REPO:
+    team.fail("REPO is required")
+
+if not (DEFAULTED and NUMBER and ROLES):
+    raise SystemExit(0)
+
+if RESOLVED_BY == "custodian":
+    body = (
+        f"🔔 **The router could not settle this one, so I read the issue and picked a role.** "
+        f"Running `{ROLES}` — {REASON}.\n\n"
+        f"{REMEDY}\n\n"
+        "Until then every trigger on this issue takes the same detour, which works but costs a "
+        "run before any of the work starts."
+    )
+else:
+    body = (
+        f"🔔 **I guessed the role for this one.** Routed to `{ROLES}` because {REASON}.\n\n"
+        f"{REMEDY}\n\n"
+        "Until then this keeps guessing the same way, which is recoverable but not right."
+    )
+
+team.upsert_comment(NUMBER, MARKER, f"{MARKER}\n{body}" + team.run_footer())

--- a/packages/claude-team/prompts/route.md
+++ b/packages/claude-team/prompts/route.md
@@ -1,0 +1,75 @@
+You are **`@claude`** — the same root role, doing its other job.
+
+Usually you are named in a comment and you answer. This run is different: nobody asked you
+anything. `delegate.py` reached a fallback — it could not settle the role from state alone, so it
+picked a default and stopped short of running it. You are being asked which role should actually
+run, before any of them starts.
+
+## Why this is a model step and not more script
+
+Routing is a script, and that is not being softened here. Rules 1 through 4 are readable state and
+stay scripted, because a model deciding what a script already knows is how a run gets a wrong
+answer confidently.
+
+⚠️ **You are only reached where the script has already failed.** Every path to you is a
+`defaulted` route — the state that should have decided is missing. The alternative is not "the
+script decides correctly", it is "the script guesses". You are being asked to read the thing the
+script cannot: what the issue actually describes.
+
+## What you have
+
+- `$ISSUE` — the issue that triggered this run. Start with `gh issue view "$ISSUE"`.
+- `$ROUTE_DEFAULT` and `$ROUTE_REASON` — the role the script fell back to, and why it had to.
+  ⚠️ You are correcting a specific guess, not routing from scratch. Read the reason first: it
+  names the state that was missing, which is usually the whole question.
+- `$STORY` — the story this belongs to, where one could be resolved. Often empty here, and that
+  emptiness is itself a signal.
+
+## The two ways you get here
+
+- **A task with no `Role:` stamp.** The Architect writes it; an issue filed by hand has none. The
+  body still says what the work is, and that is what you read.
+- **A story that was triggered instead of one of its tasks.** It has sub-issues and no stamp of its
+  own. Nothing should run on it directly.
+
+## How to decide
+
+Read the issue. Then pick the role whose remit covers the work it describes:
+
+- **implementor** — code outside the design system.
+- **designer** — code inside the design system. ⚠️ The split is the *package a change touches*, not
+  a judgement about how design-ish it is. Check which package the issue names.
+- **tester** — the functional-test suite.
+- **writer** — the product specification, or documentation.
+- **architect** — the issue is not shaped: no branch, no tasks, nothing an author could pick up.
+- **researcher** — the issue asks a question nobody has answered yet.
+
+⚠️ **`undecided` is a real answer and often the right one.** Two cases especially:
+
+- The issue does not tell you. A story with sub-issues and no stamp is one of these — the answer
+  is not a role, it is "trigger a task instead", and that belongs in your `remedy`.
+- You would be choosing between two roles on a coin flip.
+
+Prefer it to a confident guess. The script default is already recoverable and *announces itself*;
+answering suppresses that notice, so a wrong answer is worse than no answer — it removes the
+warning that would have caught it.
+
+## What you return
+
+JSON matching the schema, and nothing else. This run writes no comment, opens nothing and
+changes nothing — a scripted step reads your answer and another posts the record.
+
+- **`why`** replaces the guess notice the maintainer would otherwise have seen, so it has to stand
+  alone. Name what you read, not what you concluded: *"the body names `packages/design/src/button`
+  and only that"* beats *"this is a design change"*.
+- **`remedy`** is the line that would make the next run scripted. ⚠️ **Deciding does not repair
+  anything.** The stamp is still missing, and the next trigger lands here again — say what to add.
+
+## Bounds
+
+- ⚠️ **You do not do the work.** Not a line of it, not "while I am here". You name a role.
+- ⚠️ **You do not start the role either** — the workflow does that with your answer.
+- ⚠️ **You do not edit the issue** to add the stamp you wish it had. That is the maintainer's, and
+  a route that quietly rewrote its own input would leave nothing to notice.
+- Spend few turns. This is one decision from one issue; a long investigation here delays every
+  role behind it.

--- a/packages/claude-team/schemas/route.json
+++ b/packages/claude-team/schemas/route.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "description": "The role that should handle an event the router could not settle from state alone. Returned by the root role when delegate.py has fallen back to a default. It is read by a shell step that accepts a known role and ignores anything else, so an answer outside the enum costs nothing but is also worth nothing.",
+  "properties": {
+    "role": {
+      "type": "string",
+      "enum": ["architect", "researcher", "implementor", "designer", "tester", "writer", "undecided"],
+      "description": "The role to run. Pick undecided when the issue does not tell you - it is a real answer, and the script default runs instead with its guess notice intact. ⚠️ Prefer undecided to a coin flip: the script default is already recoverable, and a confident wrong role is worse because the notice that would have flagged it is suppressed."
+    },
+    "why": {
+      "type": "string",
+      "description": "What in the issue decided it, in one sentence, naming the thing you read rather than the conclusion. The maintainer sees this instead of the guess notice, so it has to stand on its own."
+    },
+    "remedy": {
+      "type": "string",
+      "description": "The one-line change to the issue that would let the script route it next time without asking - usually the Role: stamp it is missing, or which task to trigger instead. ⚠️ Deciding correctly does not repair the issue: the next run reaches the same fallback, so the fix still has to be said out loud."
+    }
+  },
+  "required": ["role", "why", "remedy"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

The interception half of #798. #801 gave `@claude` a root role that *answers*; this makes it
*decide* — when `delegate.py` has to guess a role, it is asked before the guess runs.

Closes #798

**A `defaulted` route now means "ask", not "run".** Rules 1–4 stay scripted — this only fires
where the state that should have decided is missing, so the choice it adds is not "script or
model", it is "read the issue or guess", and guessing was the incumbent.

**It is a step inside `delegate`, and the three obvious job shapes are each ruled out by
something this repo has already paid for:**

| shape | why not |
|---|---|
| a new workflow run | an event created with `GITHUB_TOKEN` starts no run, by design |
| a job the roles `needs:` | a job needing a **skipped** job reports cancelled — the #430 revert, verbatim |
| a job that `needs: delegate` | too late; the role jobs gate on this job's outputs and have already started |

A job cannot gate on a step inside itself; it *can* gate on an output that step produced.

**The answer is filtered, not trusted.** A shell step accepts a known role and discards anything
else, so a failed step, a skipped step, malformed JSON and `undecided` all resolve identically —
the script's default, with its notice intact. The model step carries `continue-on-error` so the
job reaches that fallback. `undecided` is in the schema deliberately: an enum of roles alone
leaves no way to say "the issue does not tell me", and a model obliged to pick one manufactures
exactly the confident-wrong route this removes.

**The notice moved, and that is the fix rather than a side effect.** `delegate.py` announced its
own default — one step too early, before anything had been asked, so an intercepted run would
have posted "I guessed" and then run something else. `report-route.py` runs after resolution and
says whichever happened. Both outcomes share the comment marker (an interception *replaces* an
earlier guess) and both carry the remedy, because deciding correctly does not add the missing
`Role:` stamp — the next trigger takes the same detour.

Two things found while building it, both fixed here:

- **`defaulted` and `reason` were job outputs nothing read.** #797 fixed exactly that defect one
  level down; it was reproduced at the job boundary. They are step outputs now.
- **`tr '\n' ' '` turned jq's trailing newline into a trailing space**, so an empty `why` passed
  `[ -n ]` and produced a resolution notice with no reason in it. Measured, then trimmed.

Two things checked in `anthropics/claude-code-action` source rather than assumed:

- `src/modes/detector.ts` — with a prompt supplied and no `track_progress`, an `issues` event
  picks **agent** mode. That is wanted here: the prompt is authoritative rather than wrapped in
  the framing that says the model's instructions are the triggering comment (there is no comment
  on a label event), and no tracking comment is created. The usual objection — losing the
  maintainer's window into the run — does not apply, because the durable record is the comment
  `report-route.py` writes; a tracking comment beside it would be two comments for one
  sub-second decision.
- `src/entrypoints/run.ts:310` — `structured_output` is set after the run in **either** mode, so
  the schema still binds.

## Verification

`nx run-many --target=test` (lint, 6 projects) ✓ · `tsc --noEmit` ✓ · `nx build app` ✓

No app code changed, so there is no screen to check. The moving parts were exercised directly
instead — the workflow's own `resolve` block was extracted from the YAML and run, rather than a
copy of it:

**`delegate.py`**, against a stubbed `gh`:

| issue state | route | `defaulted` | comment written |
|---|---|---|---|
| `Branch:` + `Role: designer` | `designer` | false | 0 |
| `Branch:`, no `Role:` | `implementor` | **true** | **0** — the notice moved |
| `Branch:`, no `Role:`, 2 sub-issues | `implementor` | **true** | **0**, and the "trigger a task instead" remedy |

**The `resolve` step**, extracted from `claude-roles.yaml` (`jq` shimmed — this machine has none):

| custodian returned | roles | resolved_by |
|---|---|---|
| `{"role":"designer",…}` | `designer` | custodian |
| `{"role":"undecided",…}` | `implementor` | script |
| *(step skipped — empty)* | `implementor` | script |
| `not json at all` | `implementor` | script |
| `{"role":"maintainer",…}` | `implementor` | script |
| `{"role":"tester","why":""}` | `implementor` | script |
| `{"role":"designer; rm -rf /",…}` | `implementor` | script |
| `{"role":"writer","why":"a\nb"}` | `writer` | custodian, reason flattened |
| `{"role":"writer"}` *(no remedy)* | `writer` | custodian, script's remedy |

**`report-route.py`** — silent when not defaulted; the #797 wording when the script guessed; the
new wording when the custodian answered; same marker on both.

⚠️ **None of this can be tested before merge** — `issues` and `issue_comment` always run the
workflow from the default branch, so this branch's version never fires. The first real exercise
is a `@claude` label on an issue with no `Role:` stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
