### PR TITLE
Give @claude a bounded remit to repair process state

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -552,16 +552,32 @@ jobs:
           # `.git/config` as an http extraheader, recoverable by anything holding `Read`. This role
           # never pushes, so there is nothing to lose by dropping it.
           persist-credentials: false
+      - name: Stash the agent hooks
+        run: |
+          mkdir -p "$RUNNER_TEMP/agent-bin"
+          cp packages/claude-team/hooks/*.py "$RUNNER_TEMP/agent-bin/"
+          chmod +x "$RUNNER_TEMP/agent-bin"/*.py
       - id: prompt
         uses: ./.github/actions/load-prompt
         with:
           role: claude
+      - id: repairs-schema
+        name: Load the repairs schema
+        run: |
+          # same constraints as every other inlined schema: one line, and no single quote
+          body=$(jq -c . packages/claude-team/schemas/repairs.json)
+          case "$body" in
+            *"'"*) echo "::error::repairs.json contains a single quote; it cannot be inlined into claude_args"; exit 1 ;;
+          esac
+          echo "body=$body" >> "$GITHUB_OUTPUT"
+          echo "repairs schema loaded (${#body} chars)"
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       # ⚠️ No role-label stamp. The stamp records "this role has been here" on work; a
       # conversation is not work, and there is no `@claude/claude` label for it to write.
-      - uses: anthropics/claude-code-action@v1
+      - id: custodian
+        uses: anthropics/claude-code-action@v1
         env:
           ISSUE: ${{ !github.event.issue.pull_request && github.event.issue.number || '' }}
           STORY: ${{ needs.delegate.outputs.story }}
@@ -577,14 +593,50 @@ jobs:
           # extract as `/architect do X`. It cannot happen here: rule 1b only routes to this job
           # when no role handle matched, so the text after `@claude` is prose.
           trigger_phrase: "@claude"
+          # ⚠️ Load-bearing for the ANSWER, not just for progress. Tag mode gives this role its
+          # tracking comment, and with `--json-schema` below the final message is JSON — so the
+          # comment is the only place a human ever reads a reply. Dropping track_progress here
+          # would leave every question answered into a machine-readable void.
           track_progress: true
           prompt: ${{ steps.prompt.outputs.body }}
-          # Reads and answers. No Edit/Write: this role produces no content, and repairs are a
-          # separate bounded remit that does not exist yet.
+          # ⚠️ THIS LIST IS WHAT MAKES "NEVER TOUCHES CONTENT" TRUE (#799). The remit is process
+          # state only, and the acceptance criterion was that it be enforced by what the role can
+          # *reach* rather than by its prompt — so every verb here is read-only and the repairs go
+          # through `apply-repairs.py`, whose repertoire is a fixed enum.
+          #
+          # ⚠️ `Bash(gh:*)` was the old grant and had to go: `gh issue edit --body` rewrites an
+          # issue, which is content. Allowlisted by SUBCOMMAND now, the same way Security is, and
+          # for the same reason — a family grant cannot express "read but do not write".
+          #
+          # ⚠️ `gh api` is deliberately absent: it reaches every endpoint the token has, including
+          # every mutation. Relationships stay readable without it because `gh issue view` exposes
+          # `parent`, `subIssues` and `subIssuesSummary` — checked before narrowing this, since
+          # Security already taught us that too narrow starves a role *silently* (#494).
+          #
+          # ⚠️ The residual, written down rather than claimed away: the action's base allowlist
+          # unions in `Bash(git add|commit|rm:*)` and `git-push.sh` and cannot be removed. There is
+          # no `Write`/`Edit` here, so there is nothing to author worth committing, and
+          # `contents: read` bounds the token — which holds only because `github_token` is passed.
           claude_args: |
             --model sonnet
-            --allowedTools "Read,Glob,Grep,Bash(gh:*),Bash(git:*)"
+            --allowedTools "Read,Glob,Grep,Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh label list:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git status:*),Bash(git ls-remote:*),Bash(git rev-parse:*)"
+            --json-schema '${{ steps.repairs-schema.outputs.body }}'
             --max-turns 40
+
+      # ⚠️ THE MODEL PROPOSES, THIS DISPOSES. Deterministic at both ends, the same shape as
+      # post-handoff/post-findings: the schema forces the report, this forces delivery — and here
+      # it also forces the *bound*, since the hook's enum is the whole of what can change.
+      # ⚠️ Step env is per-step, so PROJECTS_TOKEN here is not readable by the model step above.
+      - name: Apply the process repairs
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+          REPO: ${{ github.repository }}
+          PROJECT_OWNER: "@me"
+          PROJECT_NUMBER: "4"
+          REPAIRS: ${{ steps.custodian.outputs.structured_output }}
+        run: "$RUNNER_TEMP/agent-bin/apply-repairs.py"
 
   # ── Researcher: answers a spike before anything is shaped ──────────────────────
   # ⚠️ ITS OWN JOB, not a step in `authors`. The authoring job's whole tail — finish-pr.py,

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -252,7 +252,7 @@ at all.)
 
 | role | picked up from | writes |
 |---|---|---|
-| `@claude` | its name in a **comment**, with no role handle; **and** a route the script had to guess | an answer, or a role name. No code, no branch, no PR — it is who you talk to |
+| `@claude` | its name in a **comment**, with no role handle; **and** a route the script had to guess | an answer, a role name, and repairs to process state. No code, no branch, no PR — it is who you talk to |
 | Architect | an epic or an unshaped story | the issue, a story's branch, and its tasks |
 | Researcher | a spike | findings and a recommendation, appended to the issue by a hook — it holds no shell |
 | Implementor | a task stamped `Role: implementor` | code, outside the design system |
@@ -261,7 +261,52 @@ at all.)
 | Writer | a task stamped `Role: writer`, one per story, run **first** | the product specification, then documentation |
 | Security | every merge, plus its handle on a PR | issues it files |
 
-⚠️ **The root role has two jobs and two prompts.** `claude.md` is the conversation — someone asked
+### The custodian's repair remit
+
+The root role is the only one that may put **process state** right — the breakage no role owns,
+which is exactly why it accumulates: an issue off the board, a child never parented, a missing
+classification label.
+
+⚠️ **It names repairs; a hook applies them.** The model returns JSON, `apply-repairs.py` acts on it,
+and the hook's repertoire is a fixed enum — `board-item`, `sub-issue-link`, `classification-label`.
+That is what makes "never touches content" a fact about what *exists* rather than a promise in a
+prompt, which was the acceptance criterion: enforced by what the role can **reach**.
+
+⚠️ **Its tools are allowlisted by SUBCOMMAND**, the same way Security's are and for the same reason:
+`Bash(gh:*)` includes `gh issue edit --body`, which rewrites an issue, and a family grant cannot
+express "read but do not write". ⚠️ `gh api` is deliberately absent — it reaches every endpoint the
+token has. Relationships survive that narrowing because `gh issue view` exposes `parent`,
+`subIssues` and `subIssuesSummary`; **that was checked before narrowing**, because Security already
+taught this package that too narrow starves a role *silently*.
+
+⚠️ **Creating a missing branch is NOT in the repertoire, though it is the case that motivated the
+role.** Writing a ref needs `contents: write`, and the action's base allowlist unions in
+`Bash(git rm:*)` and `git-push.sh` which no role can remove — so `contents: write` would let a run
+delete files and push them, and the no-content claim would rest on holding no `Write` tool rather
+than on the token. `contents: read` is load-bearing. The branch case is prevented upstream anyway.
+
+⚠️ **Fix AND report, never fix quietly**, and this is the rule most likely to be eroded by a
+well-meaning change. Every repair appends to one log comment on its target carrying *what was
+wrong* and *why*. The value of this system has come from breakage being visible: a 404 nobody hid
+is what produced the rule that prevents it, and a custodian that had silently created the branch
+would have left a working run and a rule still wrong, with nobody knowing to fix it.
+
+⚠️ **A repeat escalates instead of repairing.** Reaching for the same `kind` on the same target
+twice means the cause was never fixed, so the hook withholds the repair, files an issue, and leaves
+the instance broken **on purpose**. A custodian quietly repairing the same thing weekly has become
+a suppressor of the signal that would have fixed it properly. The check reads the log comment —
+state on the issue, not a memory of the last run.
+
+⚠️ **`unrepairable` is the other half and carries the weight.** Anything outside the enum, anything
+needing content changed, and anything whose real fix is upstream in a rule goes there with what
+would fix it. Keeping it separate from `repairs` is the point: a custodian that quietly fixed
+everything would erase the evidence that the rule is wrong.
+
+⚠️ **The answer still goes in the tracking comment.** With `--json-schema` the final message is
+JSON, so `track_progress: true` stops being cosmetic and becomes the only place a human reads a
+reply — a run that answers into the JSON and leaves the comment empty has answered nobody.
+
+⚠️ **The root role has three jobs and two prompts.** `claude.md` is the conversation — someone asked
 it something. `route.md` is the interception — nobody asked it anything, and its whole output is a
 role name plus the reason, returned as JSON to a shell step. Splitting them is not tidiness: a
 conversational prompt handed a routing decision answers in prose, and a routing prompt handed a
@@ -521,6 +566,7 @@ forgotten by a model that ran out of turns or simply skipped it.
 | `sync-kind-label.py` | post, Architect + Researcher | applies the `epic`/`spike`/`bug`/`story` label `kind()` derives |
 | `file-sub-issues.py` | post, Architect | parents stories to their epic, tasks to their story |
 | `finish-pr.py` | post, authors | labels the PR, and ensures it closes its issue — or, when the author reported work `remaining`, that it does not |
+| `apply-repairs.py` | post, the root role | applies the process repairs it named, records each with what was wrong and why, and files an issue rather than repairing the same thing twice |
 | `post-findings.py` | post, Researcher | renders its schema-forced findings onto the spike — the role has no shell, so this is the only way they reach anyone |
 | `post-handoff.py` | post, authors | posts the JSON handoff to the story's issue, and appends its `decisions` to one running log there |
 | `log-to-story.py` | post, Architect + authors + on merge | rewrites one comment on the story listing its tasks in trigger order |

--- a/packages/claude-team/hooks/apply-repairs.py
+++ b/packages/claude-team/hooks/apply-repairs.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Applies the root role's process repairs, records every one, and escalates a repeat.
+
+⚠️ THE MODEL PROPOSES, THIS DISPOSES, and that split is what makes "never touches content"
+checkable rather than promised. The role holds no mutating verb at all — its whole repertoire is
+the enum below, and a repair it cannot name here is one it cannot make. So "no code, no spec, no
+rewritten issue body" is enforced by what exists, not by a paragraph asking nicely.
+
+⚠️ FIX AND REPORT, NEVER FIX QUIETLY. Every repair appends to one log comment on its target. The
+value of this system has come from breakage being *visible*: #744's 404 is what produced #777, and
+a custodian that had silently created the branch would have left a working run and a rule still
+wrong, with nobody knowing to fix it.
+
+⚠️ WHICH IS WHY A REPEAT ESCALATES. Reaching for the same repair on the same target twice means the
+cause was never fixed and this is now papering over it — so the second attempt files an issue
+instead of repairing, and says what it would have done. A custodian quietly repairing the same
+thing weekly has become a suppressor of exactly the signal that would have fixed it properly.
+
+⚠️ THE REPEAT CHECK READS THE LOG, not a memory of the last run. State on the issue is the only
+thing that survives a run, and deriving from it is the rule this package keeps relearning.
+
+⚠️ CREATING A MISSING BRANCH IS DELIBERATELY *NOT* IN THE REPERTOIRE, though it is the case that
+motivated the role. Writing a ref needs `contents: write`, and the host action's base allowlist
+unions in `Bash(git rm:*)` plus `git-push.sh` — which no role can remove. With `contents: read`
+those are inert; with `contents: write` a run could delete files and push them, and the whole claim
+that this role cannot touch content would rest on it holding no `Write` tool rather than on the
+token. The branch case is already prevented upstream anyway, so the trade is a bad one. It goes in
+`unrepairable`, where a human acts on it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import team
+
+REPAIRS = os.environ.get("REPAIRS", "")
+OWNER = os.environ.get("PROJECT_OWNER", "")
+PROJECT = os.environ.get("PROJECT_NUMBER", "")
+
+MARKER = "<!-- claude-team:custodian-log -->"
+CLASSIFICATION = {"epic", "spike", "bug", "story"}
+
+if not team.REPO:
+    team.fail("REPO is required")
+
+if not REPAIRS.strip():
+    print("no repair report from the run — nothing to apply.")
+    raise SystemExit(0)
+
+try:
+    report = json.loads(REPAIRS)
+except json.JSONDecodeError:
+    team.warn("the repair report was not valid JSON — nothing applied.")
+    raise SystemExit(0)
+
+repairs = report.get("repairs") or []
+unrepairable = report.get("unrepairable") or []
+
+
+def already_repaired(target: str, kind: str) -> bool:
+    """True when this exact repair is already recorded on the target.
+
+    ⚠️ Matches on kind AND target, not on the prose. Two runs describing the same breakage in
+    different words are still the same repair, and the whole point of escalation is to catch the
+    second one.
+    """
+    comments = team.gh_json("api", f"repos/{team.REPO}/issues/{target}/comments", "--paginate")
+    if not isinstance(comments, list):
+        return False
+    return any(
+        MARKER in (c.get("body") or "") and f"`{kind}`" in (c.get("body") or "")
+        for c in comments
+    )
+
+
+def apply(repair: dict) -> str | None:
+    """Perform one repair. Returns a description of what changed, or None if nothing did."""
+    kind = repair.get("kind")
+    target = repair.get("target") or ""
+
+    if not target.isdigit():
+        team.warn(f"repair {kind} has a non-numeric target {target!r} — skipped.")
+        return None
+
+    if kind == "board-item":
+        if not (OWNER and PROJECT):
+            team.warn("no project configured — cannot place a board item.")
+            return None
+        url = f"https://github.com/{team.REPO}/issues/{target}"
+        done = team.gh("project", "item-add", PROJECT, "--owner", OWNER, "--url", url)
+        return f"added #{target} to project {PROJECT}" if done is not None else None
+
+    if kind == "sub-issue-link":
+        parent = repair.get("parent") or ""
+        if not parent.isdigit():
+            team.warn(f"sub-issue-link for #{target} has no numeric parent — skipped.")
+            return None
+        child = team.gh_json("api", f"repos/{team.REPO}/issues/{target}")
+        if not isinstance(child, dict) or "id" not in child:
+            return None
+        done = team.gh(
+            "api", "--method", "POST", f"repos/{team.REPO}/issues/{parent}/sub_issues",
+            "-F", f"sub_issue_id={child['id']}",
+        )
+        return f"parented #{target} under #{parent}" if done is not None else None
+
+    if kind == "classification-label":
+        label = (repair.get("label") or "").lower()
+        # ⚠️ The enum in the schema is not the guard — this is. A schema constrains a well-behaved
+        # model; this constrains the output, and a routing label applied by accident would start
+        # work nobody asked for.
+        if label not in CLASSIFICATION:
+            team.warn(f"refusing to apply {label!r} — only {sorted(CLASSIFICATION)} are allowed here.")
+            return None
+        done = team.gh("issue", "edit", target, "--repo", team.REPO, "--add-label", label)
+        return f"labelled #{target} `{label}`" if done is not None else None
+
+    return None
+
+
+def escalate(repair: dict) -> None:
+    """File an issue rather than repairing the same thing twice."""
+    kind, target = repair.get("kind"), repair.get("target")
+    team.gh(
+        "issue", "create", "--repo", team.REPO,
+        "--title", f"Recurring process repair: {kind} on #{target}",
+        "--body",
+        f"The custodian has now reached for a `{kind}` repair on #{target} more than once, so the "
+        "cause was never fixed and repairing it again would just hide it.\n\n"
+        f"**What is wrong:** {repair.get('wrong')}\n\n"
+        f"**Why it happens:** {repair.get('why')}\n\n"
+        f"⚠️ **This issue exists because the repair was withheld.** #{target} is still in the "
+        "broken state — fix the cause, then put the instance right by hand." + team.run_footer(),
+    )
+
+
+applied, withheld = [], []
+
+for repair in repairs:
+    kind, target = repair.get("kind"), repair.get("target") or ""
+    if kind == "report" or not target.isdigit():
+        continue
+
+    if already_repaired(target, kind):
+        escalate(repair)
+        withheld.append(f"`{kind}` on #{target} — already repaired once; filed an issue instead")
+        continue
+
+    changed = apply(repair)
+    if changed:
+        team.append_to_comment(
+            target, MARKER,
+            f"**`{kind}`** — {changed}.\n\n_What was wrong:_ {repair.get('wrong')}\n\n"
+            f"_Why:_ {repair.get('why')}{team.run_link()}",
+            "🔧 **Custodian repairs.** Process state put right by a run, each with what was wrong "
+            "and why. Nothing here changed any content.",
+        )
+        applied.append(f"{kind} on #{target}: {changed}")
+
+for line in applied:
+    print(f"repaired — {line}")
+for line in withheld:
+    print(f"withheld — {line}")
+for item in unrepairable:
+    print(f"reported only — {item.get('what')} (would fix: {item.get('wouldFix')})")
+
+if not (applied or withheld):
+    print("no repairs applied.")

--- a/packages/claude-team/prompts/claude.md
+++ b/packages/claude-team/prompts/claude.md
@@ -32,9 +32,39 @@ each could have been caught by someone whose job it was to look.
 - ⚠️ **You start no other role.** The maintainer triggers work. If the answer is "an Implementor
   should do this", say so — do not try to make it happen. A run that quietly starts work nobody
   approved is the failure the whole role model is built to avoid.
-- ⚠️ **You do not repair anything yet.** Reporting a problem you found is right; fixing it is a
-  separate, bounded remit that does not exist until it is defined. Until then, if you find
-  something broken, **say what is broken and what would fix it** — precisely enough to act on.
+- ⚠️ **You do not repair content.** Process state is yours; what the project *says* is not. No
+  code, no tests, no specification, no rewritten issue body — not even to correct something plainly
+  wrong. Those have owners. This is the same boundary every role here has, and it is drawn where it
+  can be checked by looking rather than argued about.
+
+## Repairing process state
+
+You are the only role that may put process state right: a missing branch, an issue off the board,
+a child never parented, a classification label absent. Nobody else owns these, which is why they
+accumulate.
+
+⚠️ **You do not perform repairs — you name them.** Your run returns JSON matching the schema, and a
+scripted hook applies it. That is deliberate: the repertoire in the schema is the *whole* of what
+you can change, so "never touches content" is a fact about what exists rather than a promise you
+are keeping. A repair you cannot express there is one you cannot make — put it in `unrepairable`
+and say what would fix it.
+
+⚠️ **`repairs: []` is the normal answer.** Most questions need no repair. Inventing one to look
+useful is worse than none: every entry writes a permanent record on someone's issue.
+
+⚠️ **Fix AND report, never fix quietly.** Every repair appends to a log on its target saying what
+was wrong and why. The `why` is the half that matters — the record exists so the *cause* gets
+fixed, not so the symptom keeps getting swept up. This system's value has come from breakage being
+visible: a 404 nobody hid is what produced the rule that prevents it.
+
+⚠️ **Repairing the same thing twice is a failure, not a service.** The hook withholds a repeat and
+files an issue instead, leaving the instance broken on purpose. Do not work around that — if you
+find yourself wanting to, the finding is that the cause is still there, and that belongs in
+`unrepairable`.
+
+⚠️ **Your answer goes in the tracking comment, not in the JSON.** The JSON is the machine-readable
+tail a hook consumes; nobody reads it. A run that puts its answer there and leaves the comment
+empty has answered nobody. Write the reply as you work, exactly as you would with no schema at all.
 
 ## How to answer well
 

--- a/packages/claude-team/schemas/repairs.json
+++ b/packages/claude-team/schemas/repairs.json
@@ -1,0 +1,63 @@
+{
+  "type": "object",
+  "description": "What the root role returns from a run: the process repairs it wants applied, and what it found but will not touch. ⚠️ THIS IS NOT THE ANSWER TO THE PERSON. The answer goes in the tracking comment, written while the run works; this is the machine-readable tail a hook acts on. A run that puts its answer here and nothing in the comment has answered nobody.",
+  "properties": {
+    "repairs": {
+      "type": "array",
+      "description": "Process state to put right. ⚠️ EMPTY IS THE COMMON CASE and a real answer - most questions need no repair, and inventing one to look useful is worse than none. Every entry is applied by a scripted hook from a fixed repertoire, so a repair that is not expressible here is not a repair you can make: report it instead.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["board-item", "sub-issue-link", "classification-label"],
+            "description": "board-item: put an issue or PR on the project board. sub-issue-link: parent a child to the issue that owns it. classification-label: apply the epic/spike/bug/story label that says what an issue IS - never a routing label, which is the maintainer decision. ⚠️ Three kinds is the whole repertoire, on purpose: anything else, including a missing branch, goes in `unrepairable` where a human acts on it."
+          },
+          "target": {
+            "type": "string",
+            "description": "The issue or PR number this concerns, digits only. For sub-issue-link it is the CHILD."
+          },
+          "parent": {
+            "type": "string",
+            "description": "For sub-issue-link only: the parent issue number, digits only. Ignored for every other kind."
+          },
+          "label": {
+            "type": "string",
+            "description": "For classification-label only: one of epic, spike, bug, story. ⚠️ The hook rejects anything else, so a routing label cannot be applied through here even if asked for."
+          },
+          "wrong": {
+            "type": "string",
+            "description": "What is actually wrong, stated so a reader can check it rather than take it on trust. Name what you looked at."
+          },
+          "why": {
+            "type": "string",
+            "description": "Why it happened, where you can tell. ⚠️ This is the half that makes a repair worth more than a fix: the record exists so the underlying cause gets fixed, not so the symptom keeps getting swept up."
+          }
+        },
+        "required": ["kind", "target", "wrong", "why"],
+        "additionalProperties": false
+      }
+    },
+    "unrepairable": {
+      "type": "array",
+      "description": "Process problems you found and deliberately did not fix - because no repair kind covers them, because fixing would need content changed, or because the right fix is upstream in a rule rather than in this instance. ⚠️ Keeping this separate from `repairs` is the point: a custodian that quietly fixed everything would erase the evidence that the rule is wrong.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "what": {
+            "type": "string",
+            "description": "The problem, stated concretely and with what you read to find it."
+          },
+          "wouldFix": {
+            "type": "string",
+            "description": "What would actually fix it - usually a change to a hook, a permission or a prompt, named precisely enough to act on."
+          }
+        },
+        "required": ["what", "wouldFix"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["repairs", "unrepairable"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

The root role could explain breakage and not touch it — `claude.md` said so outright: *"You do not
repair anything yet."* It now has the bounded custodial remit this story defines: put **process
state** right, and make every repair visible.

Closes #799 — the last open story under #796.

## How "never touches content" is enforced

The acceptance criterion was *enforced by what the role can reach, not only by its prompt*. Three
things do that, and none of them is a paragraph asking nicely:

- **The model names repairs; it does not perform them.** It returns JSON, and `apply-repairs.py`
  acts on it. The hook's repertoire is a fixed enum — `board-item`, `sub-issue-link`,
  `classification-label` — so a repair that cannot be named there cannot be made.
- **Tools are allowlisted by SUBCOMMAND**, the way Security's are. `Bash(gh:*)` had to go: it
  includes `gh issue edit --body`, which rewrites an issue. ⚠️ `gh api` is out entirely — it
  reaches every endpoint the token has, including every mutation.
- **`contents: read` stays.** See below.

⚠️ **Narrowing cost nothing, and I checked that before narrowing rather than after.** Security
already taught this package that too narrow starves a role *silently* (#494), and my first concern
was that dropping `gh api` would blind the custodian to issue relationships. It does not:
`gh issue view --json parent,subIssues,subIssuesSummary` exists and returns them. Verified against
this repo before I cut the grant.

⚠️ **The hook rejects a routing label even though the schema already constrains it.** A schema
constrains a well-behaved model; the hook constrains the output. `@claude/implementor` smuggled
into the `label` field is refused with a warning — tested below. Applying a routing label would
start work nobody asked for, which is the one failure this whole role model exists to prevent.

## What I deliberately left out, and why

**Creating a missing branch is not in the repertoire** — despite being the case (#744) that
motivated the role. Writing a ref needs `contents: write`, and the action's base allowlist unions
in `Bash(git rm:*)` and `git-push.sh`, which no role can remove. With `contents: read` those are
inert; with `contents: write` a run could delete files and push them, and the entire no-content
claim would rest on the role holding no `Write` tool rather than on the token. #777 already
prevents the original case, so the trade is a bad one. It goes to `unrepairable`.

## Fix and report, never fix quietly

Every repair appends to one log comment on its target carrying **what was wrong** and **why** — the
`why` being the half that makes the record worth more than the fix, since it exists so the *cause*
gets fixed rather than the symptom swept up.

⚠️ **A repeat escalates.** The same `kind` on the same target twice means the cause was never
fixed, so the hook withholds the repair, files an issue, and **leaves the instance broken on
purpose**. The check reads the log comment — state on the issue, not a memory of the last run.

`unrepairable` carries the other half: anything outside the enum, anything needing content changed,
and anything whose real fix is upstream in a rule, each with what would fix it.

## One consequence worth knowing

⚠️ `--json-schema` makes the final message JSON, so **`track_progress: true` stops being cosmetic**
— the tracking comment becomes the only place a human reads a reply. The prompt says this
explicitly, because a run that answers into the JSON and leaves the comment empty has answered
nobody.

## Verification

`nx run-many --target=test` (lint, 6 projects, 0 errors) ✓ · `tsc --noEmit` ✓ · `nx build app` ✓ ·
workflow parses, `repairs.json` is valid single-quote-free JSON ✓

`apply-repairs.py` exercised against a stubbed `gh`:

| input | result |
|---|---|
| `board-item` + an `unrepairable` entry | repaired; the finding reported, not acted on |
| `sub-issue-link` | parented #736 under #735 |
| `classification-label: story` | applied |
| ⚠️ `classification-label: @claude/implementor` | **refused** — `only ['bug','epic','spike','story']` |
| ⚠️ unknown kind (`rewrite-body`, schema bypassed) | ignored |
| ⚠️ non-numeric target (`../../etc`) | ignored |
| `repairs: []` | nothing applied |
| malformed JSON | warned, nothing applied |
| **same kind + target, second time** | **withheld; issue filed; 0 project calls** |
| different kind, same target, after a prior repair | applied — escalation is per kind, not per issue |

The record it writes was inspected in full, not just asserted to exist.

⚠️ **None of this can run before merge** — `issues`/`issue_comment` always run the workflow from
the default branch. First real exercise is an `@claude` comment after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
