### PR TITLE
Let @claude answer on a PR

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -541,9 +541,20 @@ jobs:
       && contains(needs.delegate.outputs.roles, 'claude')
     runs-on: ubuntu-latest
     permissions:
-      # reads to answer, writes only its own reply. No branch, no PR, no code.
+      # reads to answer, writes only its own reply. No branch, no code.
       contents: read
       issues: write
+      # ⚠️ REQUIRED TO ANSWER ON A PR, and its absence is not a degraded run — it is a dead one.
+      # Commenting on a PR goes through the `/issues/{n}/comments` endpoint, but the permission
+      # GitHub checks is `pull-requests`, not `issues`. Without this the action cannot create its
+      # tracking comment, and since that comment IS how a tag-mode run reports, it aborts at setup
+      # before the model is ever called: "Resource not accessible by integration".
+      # ⚠️ This role reaches PRs by design — rule 1b routes a bare `@claude` on a PR here rather
+      # than to an Implementor — so the PR path is the normal case, not an edge.
+      # ⚠️ It does NOT widen what the role may change. Commenting on and labelling a PR is process
+      # state; `contents: read` is what still bounds it away from content, and that is the load-
+      # bearing half (it neuters the `git rm`/`git-push.sh` the action's base allowlist unions in).
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -653,6 +653,15 @@ turns and cannot be forgotten.
   close with nothing to signal it. ⚠️ **Unless the author reported `remaining`** — then the hook
   withholds the keyword rather than adding it. A forgotten keyword and a deliberately omitted one
   were indistinguishable, and the deliberate one lost.
+- ⚠️ **A job that can be triggered on a PR needs `pull-requests: write`, not `issues: write`, to
+  say anything at all.** Commenting on a PR goes through the `/issues/{n}/comments` endpoint — so
+  the API reads as if `issues` covers it — but the permission GitHub checks is `pull-requests`.
+  Without it the host action cannot create its tracking comment, and because that comment *is* how
+  a tag-mode run reports, the run **aborts at setup before the model is called**: `Resource not
+  accessible by integration`. ⚠️ Diagnose it by the step that failed, not by `num_turns` — there is
+  no result payload at all, which is a different fingerprint from the dead run that reports success.
+  ⚠️ The trap is that the job works perfectly on issues, so the gap stays invisible until the first
+  PR trigger, however long that takes.
 - ⚠️ **Keep long-lived credentials out of any job a model step shares** unless the workflow
   puts them in *step* env. Step env is per-step, so a scripted step can hold a token the
   model step beside it cannot read. Secret masking covers logs only — not an API payload a


### PR DESCRIPTION
## Summary

`@claude` on a **PR** was dying at setup, before the model was ever called:

```
##[error]Action failed with error: Resource not accessible by integration
          - https://docs.github.com/rest/issues/comments#create-an-issue-comment
```

The `claude` job had `issues: write` but not `pull-requests: write`. Commenting on a PR goes
through the `/issues/{n}/comments` endpoint — so the API reads as though `issues` covers it — but
the permission GitHub checks is **`pull-requests`**. Without it the action cannot create its
tracking comment, and because that comment *is* how a tag-mode run reports, the run aborts during
setup.

Closes #859

## Why it went unnoticed

⚠️ **The job works perfectly on issues.** The gap is invisible until the first PR trigger, and this
was it — [run 31565333504](https://github.com/matt-whitaker/brewdocs.beer/actions/runs/31565333504/job/94016735365),
a comment on PR #857, failed at step 7 about four seconds in.

The role reaches PRs **by design** — rule 1b routes a bare `@claude` on a PR here rather than to an
Implementor — so the PR path is the normal case, not an edge, and it has been dead since the role
was introduced.

⚠️ **What this was not**, since three recent changes were plausible suspects: not the
`--json-schema`, not `apply-repairs.py` (that step *succeeded*, on `if: always()`), not the
narrowed tool allowlist. The run died before any of them. `permission_denials_count` is not the
fingerprint either — there is no result payload at all, which distinguishes this from the dead run
that reports success.

## The fix

One line, plus the reasoning next to it. ⚠️ **`contents: read` stays** — it is the load-bearing
half, neutering the `Bash(git rm:*)` and `git-push.sh` that union in from the action's base
allowlist and cannot be removed. Commenting on and labelling a PR is process state, squarely inside
this role's remit, so nothing about what it may change is widened.

`packages/claude-team/CLAUDE.md` gains the asymmetry and its fingerprint, since it is the kind of
thing that gets rediscovered.

## ⚠️ Follow-up found, deliberately not fixed here

`architect` and `researcher` have the same missing permission **and** are reachable from a PR,
which contradicts their own documented intent — but the right fix is different, so it is not folded
in.

Both gate on:

```
contains(needs.delegate.outputs.roles, 'X')
  || (!github.event.issue.pull_request && contains(github.event.comment.body, '@claude/X'))
```

The PR guard is on the **handle arm only**. `delegate.py` rule 1 matches `@claude/<role>` in a
comment body **without checking `IS_PR`**, so a `@claude/architect` on a PR sets `roles=architect`
and the *first* arm matches — guard bypassed. The run then fails exactly as this one did.

⚠️ The root `CLAUDE.md` explains that guard by saying *"the router cannot pick it on a PR (rule 2
sends every PR to the Implementor)"* — that is **wrong**: rule 1 short-circuits before rule 2 and
does pick it. So the stated reason the guard is sufficient does not hold.

The fix there is to make the guard cover the whole condition rather than to add the permission,
because a spike is never a PR and an epic is never a PR — but that changes *when a role runs*, and
workflow changes cannot be tested before merge, so it wants your call rather than my judgement.

## Verification

`nx run-many --target=test` (lint, 6 projects, 0 errors) ✓ · workflow parses; `claude` job is now
`{contents: read, issues: write, pull-requests: write}` with its 7 steps unchanged ✓

⚠️ **Not testable before merge** — `issue_comment` always runs the workflow from the default
branch. Confirm by commenting `@claude` on any open PR once this lands; it should create its
tracking comment and answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
