### PR TITLE
Let merge_housekeeping actually open the story PR

### DIFF
--- a/.github/workflows/claude-roles.yaml
+++ b/.github/workflows/claude-roles.yaml
@@ -1465,7 +1465,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      # ⚠️ WRITE, because `open-story-pr.py` calls `gh pr create`. It was `read`, so that call
+      # 403'd every time — the hook has **never once** succeeded, and every story PR in this repo
+      # was opened by hand. The docs described it as the mechanism regardless, which is how a
+      # story branch sat unmerged long enough to lose its work (#735/#815).
+      # ⚠️ Nothing else in this job needs it: `close-merged-work.py` only *reads* PRs and closes
+      # issues, and the board writes go through PROJECTS_TOKEN on their own step.
+      pull-requests: write
       issues: write
     steps:
       - uses: actions/checkout@v4

--- a/packages/claude-team/CLAUDE.md
+++ b/packages/claude-team/CLAUDE.md
@@ -653,6 +653,18 @@ turns and cannot be forgotten.
   close with nothing to signal it. ⚠️ **Unless the author reported `remaining`** — then the hook
   withholds the keyword rather than adding it. A forgotten keyword and a deliberately omitted one
   were indistinguishable, and the deliberate one lost.
+- ⚠️ **`open-story-pr.py` calls `gh pr create`, so its job needs `pull-requests: write`** — and
+  until that was noticed it had `read`, so the call 403'd **every time since the hook existed**.
+  It had never once succeeded: every story PR in the consuming repo was opened by hand, while this
+  file described the hook as the mechanism. A story branch then sat unmerged with nobody looking
+  and its work was lost.
+  ⚠️ **It warned rather than failing, which is what made it survive.** A `::warning::` fails no
+  step, so the job stayed green and the gap was invisible from outside — the same shape as the
+  `defaulted` output nobody read. It now **fails the step**: every benign case returns earlier, so
+  reaching the create call and not creating anything is always a real problem.
+  ⚠️ The general lesson, since this is the third instance: **a hook that is the sole mechanism for
+  something must fail loudly when it cannot do it.** Best-effort is right for bookkeeping that a
+  human would notice missing; it is wrong for the only thing that opens a PR.
 - ⚠️ **A job that can be triggered on a PR needs `pull-requests: write`, not `issues: write`, to
   say anything at all.** Commenting on a PR goes through the `/issues/{n}/comments` endpoint — so
   the API reads as if `issues` covers it — but the permission GitHub checks is `pull-requests`.

--- a/packages/claude-team/hooks/open-story-pr.py
+++ b/packages/claude-team/hooks/open-story-pr.py
@@ -76,4 +76,13 @@ if team.gh(
 ) is not None:
     print(f"opened the story PR for {BASE}")
 else:
-    team.warn(f"could not open the story PR for {BASE} — open it by hand.")
+    # ⚠️ FAILS THE STEP, and that is the whole lesson of this hook's history. It warned instead,
+    # for as long as it existed, while `pull-requests: read` made the create 403 every single
+    # time — so it never once worked, the job stayed green, and the docs went on describing it as
+    # the mechanism. A story branch then sat unmerged with nobody looking, and its work was lost
+    # (#735/#815).
+    #
+    # ⚠️ Reaching this line means a PR genuinely should exist: every benign case — merged into the
+    # default branch, an unresolvable story, a PR already open, a branch not ahead — returned
+    # earlier. So there is no legitimate reason to be here and quiet.
+    team.fail(f"could not open the story PR for {BASE} — open it by hand.")


### PR DESCRIPTION
## Summary

`open-story-pr.py` calls `gh pr create`, and `merge_housekeeping` carried `pull-requests: read`.
That call has **403'd every time since the hook existed** — it has never once succeeded.

Closes #861

## The evidence, since "never worked" is a strong claim

Every story PR in this repo — **#740, #766, #788, #806** — was opened by **matt-whitaker**, by
hand. There is no successful instance from the hook, while `packages/claude-team/CLAUDE.md` states
as settled fact that "the story's PR opens on the first task merge, from the merge hook".

## Why it survived, and what it cost

It **warned** instead of failing:

```
##[warning]could not open the story PR for 735-bug-add-rows-on-brewing — open it by hand.
```

A `::warning::` fails no step, so the job stayed green and the gap was invisible from outside —
the same shape as the `defaulted` output nobody read (#797).

⚠️ **This is what lost #735.** Its fix merged to the story branch as `dd8c2f4`, no story PR ever
opened, the branch sat 16 commits behind, and the issue closed COMPLETED anyway. Recovered by hand
as #815 — but only because the symptom was noticed weeks later.

## What changed

- `pull-requests: read` → **`write`**. ⚠️ Nothing else in the job needs it: `close-merged-work.py`
  only *reads* PRs and closes issues, and the board writes go through `PROJECTS_TOKEN` on their own
  step. Checked rather than assumed.
- **The failure now fails the step.** Reaching the create call means a PR genuinely should exist —
  every benign case returns earlier.
- `CLAUDE.md` gains the incident and the general rule it implies: **a hook that is the sole
  mechanism for something must fail loudly when it cannot do it.** Best-effort is right for
  bookkeeping a human would notice missing; it is wrong for the only thing that opens a PR.

## Verification

`nx run-many --target=test` (lint, 6 projects, 0 errors) ✓ · workflow parses; the job is now
`{contents: read, pull-requests: write, issues: write}` ✓ · hook compiles ✓

Every path exercised against a stubbed `gh`, because making a fall-through fatal is only safe if
the benign cases really do return first:

| case | exit | says |
|---|---|---|
| merged into the default branch | 0 | not a story branch, nothing to open |
| base has no issue-number prefix | 0 | cannot resolve its story (warning) |
| a story PR is already open | 0 | PR #857 already open |
| branch not ahead of the default | 0 | nothing to open a PR for |
| ahead, create succeeds | 0 | opened the story PR |
| **ahead, create fails — the 403** | **1** | `::error::could not open the story PR` |

⚠️ **Not testable before merge** — `pull_request` events run the workflow from the PR's base
branch. First real exercise is the next task PR merging into a story branch; it should open that
story's PR automatically. **#857** (the #808 story PR) already exists, so its remaining task merges
will exercise the already-open path rather than creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
